### PR TITLE
not use env (yargs does not really support it)

### DIFF
--- a/packages/nwd-api-server/src/programs/server.ts
+++ b/packages/nwd-api-server/src/programs/server.ts
@@ -13,12 +13,11 @@ export function configureServerProgram(argv: yargs.Argv) {
         .option("port", {
           description: "port for the server to listen to",
           type: "number",
-          default: process.env.PORT,
+          demandOption: true,
         })
         .option("pg-uri", {
           description: "connection string for postgres",
           type: "string",
-          default: process.env.PGURI,
           demandOption: true,
         }),
     (argv) => main(argv),


### PR DESCRIPTION
Pass all configuration parameters as command line arguments.

yargs does not really support the use of environment variables. So let's not do that. We might make this work after all if it we have spare time.