### PR TITLE
deploy on released event

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,6 @@
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [released]
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Publish new version on released event. This event is triggered when a new release is made in github.

Note that this event triggers only on a release, and not a prerelease!

A better solution for releasing is necessary now because gh actions tries (and fails) to release now from forks also. This causes an error and that is not a good thing!

