### PR TITLE
chore: changed postcss config from js to cjs

### DIFF
--- a/apps/nwd-web/postcss.config.cjs
+++ b/apps/nwd-web/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};


### PR DESCRIPTION
On windows the `--tubro` flag caused some issues when the config files are normal js (module) files.
![image](https://github.com/buchungapp/nationaal-watersportdiploma/assets/44841260/ea02c091-806e-4b4a-bf26-75fd19d315bb)
