### PR TITLE
Fix/articles not loading

### DIFF
--- a/apps/web/src/lib/articles.ts
+++ b/apps/web/src/lib/articles.ts
@@ -42,12 +42,8 @@ export async function getAllArticles() {
   const articleFilenames = await glob("*/page.mdx", {
     cwd: path.join(workingPath, contentPath),
   });
-  console.log("path", path.join(workingPath, contentPath));
-
-  console.log("articleFilenames", articleFilenames);
 
   const articles = await Promise.all(articleFilenames.map(importArticle));
-  console.log("articles", articles);
 
   return articles.sort((a, z) => +new Date(z.date) - +new Date(a.date));
 }


### PR DESCRIPTION
The working dir for dynamic pages works differently than for static pages. This required the `getAllArticles` function to prefix the `process.cwd()` to the path `./src/app/actueel/(article)`