### PR TITLE
fixed layout height not being full screen

### DIFF
--- a/apps/web/src/app/(dashboard)/[location]/layout.tsx
+++ b/apps/web/src/app/(dashboard)/[location]/layout.tsx
@@ -43,8 +43,8 @@ export default function Layout({
         </div>
       </div>
 
-      <main className="py-2.5 min-h-full flex flex-col lg:pl-72 pr-2.5">
-        <div className="px-4 sm:px-8 shadow flex-1 ring-1 ring-gray-200 rounded min-h-full lg:px-12 bg-white">
+      <main className="py-2.5 h-screen flex flex-col lg:pl-72 pr-2.5">
+        <div className="px-4 sm:px-8 shadow flex-1 ring-1 ring-gray-200 rounded min-h-full lg:px-12 bg-white overflow-y-auto">
           {children}
         </div>
       </main>


### PR DESCRIPTION
Fixes the dashboard layout not being full screen

![image](https://github.com/buchungapp/nationaal-watersportdiploma/assets/44841260/636e7a10-6849-482f-9409-73eb9b7da854)
