### PR TITLE
fix overflow issue on mobile safari

### DIFF
--- a/apps/web/src/app/(diploma)/diploma/[id]/_components/template.tsx
+++ b/apps/web/src/app/(diploma)/diploma/[id]/_components/template.tsx
@@ -96,7 +96,7 @@ export default async function CertificateTemplate({
           <div className="bg-white h-1 w-full" />
         </div>
       </header>
-      <section className="grid aspect-[2/1] relative flex-1 grid-cols-1 lg:grid-cols-2 px-4 sm:px-8 lg:px-16 py-6 gap-16 lg:py-12">
+      <section className="grid aspect-[2/1] w-full relative flex-1 grid-cols-1 lg:grid-cols-2 px-4 sm:px-8 lg:px-16 py-6 gap-16 lg:py-12">
         <div className="absolute inset-0 overflow-hidden">
           <div className="relative h-full w-full">
             <Image

--- a/apps/web/src/app/(diploma)/diploma/[id]/page.tsx
+++ b/apps/web/src/app/(diploma)/diploma/[id]/page.tsx
@@ -36,6 +36,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title: `Bekijk het NWD diploma van ${certificate.student.firstName}!`,
     description: `${certificate.student.firstName} heeft een nieuwe diploma behaald voor ${certificate.program.title} bij ${certificate.location.name}!`,
+    openGraph: {
+      title: `Bekijk het NWD diploma van ${certificate.student.firstName}!`,
+      description: `${certificate.student.firstName} heeft een nieuwe diploma behaald voor ${certificate.program.title} bij ${certificate.location.name}!`,
+    },
     robots: {
       index: false,
       follow: false,


### PR DESCRIPTION
<img width="587" alt="CleanShot 2024-05-04 at 16 39 57@2x" src="https://github.com/buchungapp/nationaal-watersportdiploma/assets/9018689/e9854948-65a2-4c3b-97b7-fcbb89abb02d">

On (mobile) safari the table's width was overflowing in x-direction. This PR fixes it. 