### PR TITLE
fix: changed filter from menu to popover

### DIFF
--- a/apps/web/src/app/(auth)/login/_components/login-form.tsx
+++ b/apps/web/src/app/(auth)/login/_components/login-form.tsx
@@ -12,7 +12,7 @@ export function SubmitButton({ children }: PropsWithChildren) {
   const { pending } = useFormStatus();
   return (
     <Button type="submit" color="blue" className="w-full" disabled={pending}>
-      {pending ? <Spinner className="h-5 w-5 text-white" /> : children}
+      {pending ? <Spinner className="text-white" /> : children}
     </Button>
   );
 }
@@ -44,7 +44,7 @@ function FakeCaret() {
 
 function OTPInputWithPending({ children }: PropsWithChildren) {
   const { pending } = useFormStatus();
-  return pending ? <Spinner className="h-5 w-5 text-black" /> : children;
+  return pending ? <Spinner className="text-black" /> : children;
 }
 
 export function OtpForm({

--- a/apps/web/src/app/(dashboard)/[location]/_components/search.tsx
+++ b/apps/web/src/app/(dashboard)/[location]/_components/search.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import clsx from "clsx";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useDeferredValue, useEffect, useState, useTransition } from "react";
+import Spinner from "~/app/_components/spinner";
 import { Input } from "../../_components/input";
 import { useSetQueryParams } from "../../_utils/set-query-params";
 
@@ -39,35 +39,7 @@ export default function Search() {
       />
       {isPending && (
         <div className="absolute inset-y-0 right-2 flex items-center">
-          <div className="h-5 w-5">
-            <div
-              style={{
-                position: "relative",
-                top: "50%",
-                left: "50%",
-              }}
-              className={clsx("loading-spinner", "h-5 w-5")}
-            >
-              {/* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */}
-              {[...Array(12)].map((_, i) => (
-                <div
-                  key={i}
-                  style={{
-                    animationDelay: `${-1.2 + 0.1 * i}s`,
-                    background: "gray",
-                    position: "absolute",
-                    borderRadius: "1rem",
-                    width: "30%",
-                    height: "8%",
-                    left: "-10%",
-                    top: "-4%",
-                    transform: `rotate(${30 * i}deg) translate(120%)`,
-                  }}
-                  className="animate-spinner"
-                />
-              ))}
-            </div>
-          </div>
+          <Spinner />
         </div>
       )}
     </div>

--- a/apps/web/src/app/(dashboard)/[location]/diplomas/page.tsx
+++ b/apps/web/src/app/(dashboard)/[location]/diplomas/page.tsx
@@ -20,7 +20,7 @@ export default async function Page({
   const certificatesFuse = new Fuse(certificates, {
     includeMatches: true,
     keys: [
-      "name",
+      "handle",
       "student.firstName",
       "student.lastNamePrefix",
       "student.lastName",

--- a/apps/web/src/app/(dashboard)/[location]/personen/_components/filter.tsx
+++ b/apps/web/src/app/(dashboard)/[location]/personen/_components/filter.tsx
@@ -1,16 +1,45 @@
 "use client";
 
 import { ChevronDownIcon } from "@heroicons/react/16/solid";
+import clsx from "clsx";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useDeferredValue, useEffect, useState } from "react";
+import { ComponentProps, useDeferredValue, useEffect, useState } from "react";
 import { useSetQueryParams } from "~/app/(dashboard)/_utils/set-query-params";
 import { Checkbox } from "../../../_components/checkbox";
 import {
-  Dropdown,
-  DropdownButton,
-  DropdownItem,
-  DropdownMenu,
-} from "../../../_components/dropdown";
+  Popover,
+  PopoverButton,
+  PopoverPanel,
+} from "../../../_components/popover";
+
+function CheckboxButton({
+  children,
+  className,
+  onClick,
+  ...props
+}: Pick<ComponentProps<"button">, "onClick" | "className" | "children"> &
+  ComponentProps<typeof Checkbox>) {
+  return (
+    <button
+      className={clsx([
+        className,
+
+        // Base
+        "relative isolate inline-flex items-center gap-x-2 rounded-lg text-base/6",
+
+        // Sizing
+        "px-[calc(theme(spacing[3.5])-1px)] py-[calc(theme(spacing[2.5])-1px)] sm:px-[calc(theme(spacing.3)-1px)] sm:py-[calc(theme(spacing[1.5])-1px)] sm:text-sm/6",
+
+        // Disabled
+        "data-[disabled]:opacity-50",
+      ])}
+      onClick={onClick}
+    >
+      <Checkbox {...props} />
+      {children}
+    </button>
+  );
+}
 
 export function FilterSelect() {
   const router = useRouter();
@@ -31,13 +60,12 @@ export function FilterSelect() {
   }, [deferredStatus]);
 
   return (
-    <Dropdown>
-      <DropdownButton outline className={"min-w-32"}>
-        Filter
-        <ChevronDownIcon />
-      </DropdownButton>
-      <DropdownMenu anchor="bottom end">
-        <DropdownItem
+    <Popover className="relative">
+      <PopoverButton className={"min-w-32"}>
+        Filter <ChevronDownIcon />
+      </PopoverButton>
+      <PopoverPanel anchor="bottom end" className="flex flex-col gap-1">
+        <CheckboxButton
           onClick={() => {
             setSelectedStatus((prev) =>
               prev.includes("student")
@@ -45,11 +73,11 @@ export function FilterSelect() {
                 : [...prev, "student"],
             );
           }}
+          checked={_selectedStatus.includes("student")}
         >
-          <Checkbox checked={_selectedStatus.includes("student")} />
-          <span className="ml-2">Cursist</span>
-        </DropdownItem>
-        <DropdownItem
+          Cursist
+        </CheckboxButton>
+        <CheckboxButton
           onClick={() => {
             setSelectedStatus((prev) =>
               prev.includes("instructor")
@@ -57,11 +85,11 @@ export function FilterSelect() {
                 : [...prev, "instructor"],
             );
           }}
+          checked={_selectedStatus.includes("instructor")}
         >
-          <Checkbox checked={_selectedStatus.includes("instructor")} />
-          <span className="ml-2">Instructeur</span>
-        </DropdownItem>
-        <DropdownItem
+          Instructeur
+        </CheckboxButton>
+        <CheckboxButton
           onClick={() => {
             setSelectedStatus((prev) =>
               prev.includes("location-admin")
@@ -69,11 +97,11 @@ export function FilterSelect() {
                 : [...prev, "location-admin"],
             );
           }}
+          checked={_selectedStatus.includes("location-admin")}
         >
-          <Checkbox checked={_selectedStatus.includes("location-admin")} />
-          <span className="ml-2">Locatie-beheerder</span>
-        </DropdownItem>
-      </DropdownMenu>
-    </Dropdown>
+          Locatie-beheerder
+        </CheckboxButton>
+      </PopoverPanel>
+    </Popover>
   );
 }

--- a/apps/web/src/app/(dashboard)/[location]/personen/_components/filter.tsx
+++ b/apps/web/src/app/(dashboard)/[location]/personen/_components/filter.tsx
@@ -3,7 +3,8 @@
 import { ChevronDownIcon } from "@heroicons/react/16/solid";
 import clsx from "clsx";
 import { useRouter, useSearchParams } from "next/navigation";
-import { ComponentProps, useDeferredValue, useEffect, useState } from "react";
+import type { ComponentProps } from "react";
+import { useDeferredValue, useEffect, useState } from "react";
 import { useSetQueryParams } from "~/app/(dashboard)/_utils/set-query-params";
 import { Checkbox } from "../../../_components/checkbox";
 import {

--- a/apps/web/src/app/(dashboard)/[location]/personen/_components/filter.tsx
+++ b/apps/web/src/app/(dashboard)/[location]/personen/_components/filter.tsx
@@ -4,8 +4,9 @@ import { ChevronDownIcon } from "@heroicons/react/16/solid";
 import clsx from "clsx";
 import { useRouter, useSearchParams } from "next/navigation";
 import type { ComponentProps } from "react";
-import { useDeferredValue, useEffect, useState } from "react";
+import { useDeferredValue, useEffect, useState, useTransition } from "react";
 import { useSetQueryParams } from "~/app/(dashboard)/_utils/set-query-params";
+import Spinner from "~/app/_components/spinner";
 import { Checkbox } from "../../../_components/checkbox";
 import {
   Popover,
@@ -20,6 +21,8 @@ function CheckboxButton({
   ...props
 }: Pick<ComponentProps<"button">, "onClick" | "className" | "children"> &
   ComponentProps<typeof Checkbox>) {
+  const [isPending, startTransition] = useTransition();
+
   return (
     <button
       className={clsx([
@@ -34,9 +37,19 @@ function CheckboxButton({
         // Disabled
         "data-[disabled]:opacity-50",
       ])}
-      onClick={onClick}
+      onClick={(...e) => {
+        if (!onClick) return;
+
+        return startTransition(() => {
+          onClick(...e);
+        });
+      }}
     >
-      <Checkbox {...props} />
+      {isPending ? (
+        <Spinner className="text-gray-700" size="sm" />
+      ) : (
+        <Checkbox {...props} />
+      )}
       {children}
     </button>
   );

--- a/apps/web/src/app/(dashboard)/_components/popover.tsx
+++ b/apps/web/src/app/(dashboard)/_components/popover.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import {
+  Popover as HeadlessPopover,
+  PopoverButton as HeadlessPopoverButton,
+  PopoverPanel as HeadlessPopoverPanel,
+  Transition as HeadlessTransition,
+  type PopoverPanelProps as HeadlessPopoverPanelProps,
+  type PopoverProps as HeadlessPopoverProps,
+} from "@headlessui/react";
+import clsx from "clsx";
+import React, { Fragment } from "react";
+import { Button } from "./button";
+
+export { HeadlessPopoverButton };
+
+/****************************************************************
+ * TODO: this popover is temporary used should be from catalyst
+ ****************************************************************/
+
+export function Popover(props: HeadlessPopoverProps) {
+  return <HeadlessPopover {...props} />;
+}
+
+export function PopoverButton<T extends React.ElementType = typeof Button>(
+  props: React.ComponentProps<typeof HeadlessPopoverButton<T>>,
+) {
+  return <HeadlessPopoverButton as={Button} {...props} />;
+}
+
+export function PopoverPanel({
+  anchor = "bottom",
+  ...props
+}: HeadlessPopoverPanelProps) {
+  return (
+    <HeadlessTransition
+      as={Fragment}
+      leave="duration-100 ease-in"
+      leaveTo="opacity-0"
+    >
+      <HeadlessPopoverPanel
+        {...props}
+        anchor={anchor}
+        className={clsx(
+          props.className,
+
+          // Anchor positioning
+          "[--anchor-gap:theme(spacing.2)] [--anchor-padding:theme(spacing.3)] data-[anchor~=end]:[--anchor-offset:4px] data-[anchor~=start]:[--anchor-offset:-4px]",
+
+          // Base styles
+          "isolate w-max rounded-xl p-1",
+
+          // Invisible border that is only visible in `forced-colors` mode for accessibility purposes
+          "outline outline-1 outline-transparent focus:outline-none",
+
+          // Handle scrolling when menu won't fit in viewport
+          "overflow-y-auto",
+
+          // Popover background
+          "bg-white/75 backdrop-blur-xl dark:bg-zinc-800/75",
+
+          // Shadows
+          "shadow-lg ring-1 ring-zinc-950/10 dark:ring-inset dark:ring-white/10",
+        )}
+      />
+    </HeadlessTransition>
+  );
+}

--- a/apps/web/src/app/_components/spinner.tsx
+++ b/apps/web/src/app/_components/spinner.tsx
@@ -1,30 +1,48 @@
 import clsx from "clsx";
 
+const sizeToClassName = {
+  xs: "h-3 w-3",
+  sm: "h-4 w-4",
+  md: "h-5 w-5",
+  lg: "h-6 w-6",
+} as const;
+
 export default function Spinner({
-  className = "h-5 w-5 text-white",
+  className = "text-gray-700",
+  size = "md",
 }: {
   className?: string;
+  size?: "sm" | "md" | "lg";
 }) {
   return (
-    <svg
-      className={clsx("animate-spin", className)}
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-    >
-      <circle
-        className="opacity-25"
-        cx="12"
-        cy="12"
-        r="10"
-        stroke="currentColor"
-        strokeWidth="4"
-      ></circle>
-      <path
-        className="opacity-75"
-        fill="currentColor"
-        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-      ></path>
-    </svg>
+    <div className={clsx(sizeToClassName[size], className)}>
+      <div
+        style={{
+          position: "relative",
+          top: "50%",
+          left: "50%",
+        }}
+        className={clsx("loading-spinner", sizeToClassName[size], className)}
+      >
+        {/* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */}
+        {[...Array(12)].map((_, i) => (
+          <div
+            key={i}
+            style={{
+              animationDelay: `${-1.2 + 0.1 * i}s`,
+              background: "currentColor",
+              position: "absolute",
+              borderRadius: "1rem",
+              width: "30%",
+              height: "8%",
+              left: "-10%",
+              top: "-4%",
+              transform: `rotate(${30 * i}deg) translate(120%)`,
+            }}
+            className="animate-spinner"
+          />
+        ))}
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
This pr changes the `filter` button on the persons page from a headless menu to a headless popover, so that the popover doesn't close when clicking on one of the boxes.

![image](https://github.com/buchungapp/nationaal-watersportdiploma/assets/44841260/8373976e-eb84-4f03-8cb9-6ec9c144236d)
