### PR TITLE
Don't throw an application error if a auth user has no personalities

### DIFF
--- a/apps/web/src/app/(dashboard)/(account)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/layout.tsx
@@ -1,7 +1,6 @@
 import {
   ArrowRightStartOnRectangleIcon,
   ChevronDownIcon,
-  Cog8ToothIcon,
   LifebuoyIcon,
   ShieldCheckIcon,
 } from "@heroicons/react/16/solid";
@@ -59,11 +58,11 @@ function PersonDropdownMenu() {
         />
         <DropdownLabel>Workcation</DropdownLabel>
       </DropdownItem> */}
-      <DropdownDivider />
+      {/* <DropdownDivider />
       <DropdownItem href="/profiel/personen">
         <Cog8ToothIcon />
         <DropdownLabel>Beheer personen</DropdownLabel>
-      </DropdownItem>
+      </DropdownItem> */}
     </DropdownMenu>
   );
 }
@@ -88,7 +87,7 @@ export default async function Layout({
                   <DropdownButton as={NavbarItem}>
                     <Avatar
                       src=""
-                      initials={user.displayName ?? user.email.slice(0, 2)}
+                      initials={(user.displayName ?? user.email).slice(0, 2)}
                       square
                     />
                   </DropdownButton>
@@ -147,7 +146,10 @@ export default async function Layout({
         <Navbar>
           <Dropdown>
             <DropdownButton as={NavbarItem} className="max-lg:hidden">
-              <Avatar src={""} initials={firstPerson.firstName.slice(0, 2)} />
+              <Avatar
+                src={""}
+                initials={(user.displayName ?? user.email).slice(0, 2)}
+              />
               <NavbarLabel>
                 {[
                   firstPerson.firstName,
@@ -176,7 +178,7 @@ export default async function Layout({
                 <DropdownButton as={NavbarItem}>
                   <Avatar
                     src=""
-                    initials={user.displayName ?? user.email.slice(0, 2)}
+                    initials={(user.displayName ?? user.email).slice(0, 2)}
                     square
                   />
                 </DropdownButton>
@@ -214,7 +216,7 @@ export default async function Layout({
               <DropdownButton as={SidebarItem} className="lg:mb-2.5">
                 <Avatar
                   src={undefined}
-                  initials={user.displayName ?? user.email.slice(0, 2)}
+                  initials={(user.displayName ?? user.email).slice(0, 2)}
                 />
                 <SidebarLabel>Nationaal Watersportdiploma</SidebarLabel>
                 <ChevronDownIcon />

--- a/apps/web/src/app/(dashboard)/(account)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/layout.tsx
@@ -5,7 +5,7 @@ import {
   LifebuoyIcon,
   ShieldCheckIcon,
 } from "@heroicons/react/16/solid";
-import { listPersonsForUser } from "~/lib/nwd";
+import { getUserOrThrow, listPersonsForUser } from "~/lib/nwd";
 import { LogOutDropdownItem } from "../_components/auth";
 import { Avatar } from "../_components/avatar";
 import {
@@ -73,6 +73,7 @@ export default async function Layout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const user = await getUserOrThrow();
   const persons = await listPersonsForUser().catch(() => null);
 
   if (!persons || persons.length < 1) {
@@ -85,7 +86,11 @@ export default async function Layout({
               <FeedbackProvider>
                 <Dropdown>
                   <DropdownButton as={NavbarItem}>
-                    <Avatar src="" initials="mm" square />
+                    <Avatar
+                      src=""
+                      initials={user.displayName ?? user.email.slice(0, 2)}
+                      square
+                    />
                   </DropdownButton>
                   <DropdownMenu className="min-w-64" anchor="bottom end">
                     {/* <DropdownItem href="/instellingen">
@@ -169,7 +174,11 @@ export default async function Layout({
             <FeedbackProvider>
               <Dropdown>
                 <DropdownButton as={NavbarItem}>
-                  <Avatar src="" initials="mm" square />
+                  <Avatar
+                    src=""
+                    initials={user.displayName ?? user.email.slice(0, 2)}
+                    square
+                  />
                 </DropdownButton>
                 <DropdownMenu className="min-w-64" anchor="bottom end">
                   {/* <DropdownItem href="/instellingen">
@@ -203,7 +212,10 @@ export default async function Layout({
           <SidebarHeader>
             <Dropdown>
               <DropdownButton as={SidebarItem} className="lg:mb-2.5">
-                <Avatar src={undefined} initials="mm" />
+                <Avatar
+                  src={undefined}
+                  initials={user.displayName ?? user.email.slice(0, 2)}
+                />
                 <SidebarLabel>Nationaal Watersportdiploma</SidebarLabel>
                 <ChevronDownIcon />
               </DropdownButton>

--- a/apps/web/src/app/(dashboard)/(account)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/layout.tsx
@@ -39,9 +39,9 @@ import FeedbackDialog, {
 } from "./_components/feedback";
 
 const navItems = [
-  { label: "Paspoort", url: "/profiel" },
-  { label: "Diploma's", url: "/diploma" },
-  { label: "Vaarlocaties", url: "/vaarlocaties" },
+  // { label: "Paspoort", url: "/profiel" },
+  // { label: "Diploma's", url: "/diploma" },
+  { label: "Vaarlocaties", url: "/profiel" },
 ] as const;
 
 function PersonDropdownMenu() {
@@ -73,7 +73,66 @@ export default async function Layout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const persons = await listPersonsForUser();
+  const persons = await listPersonsForUser().catch(() => null);
+
+  if (!persons || persons.length < 1) {
+    return (
+      <StackedLayout
+        navbar={
+          <Navbar>
+            <NavbarSpacer />
+            <NavbarSection>
+              <FeedbackProvider>
+                <Dropdown>
+                  <DropdownButton as={NavbarItem}>
+                    <Avatar src="" initials="mm" square />
+                  </DropdownButton>
+                  <DropdownMenu className="min-w-64" anchor="bottom end">
+                    {/* <DropdownItem href="/instellingen">
+                      <Cog8ToothIcon />
+                      <DropdownLabel>Instellingen</DropdownLabel>
+                    </DropdownItem>
+                    <DropdownDivider /> */}
+                    <DropdownItem href="/help">
+                      <LifebuoyIcon />
+                      <DropdownLabel>Helpcentrum</DropdownLabel>
+                    </DropdownItem>
+                    <FeedbackButton />
+                    <DropdownItem href="/privacy">
+                      <ShieldCheckIcon />
+                      <DropdownLabel>Privacybeleid</DropdownLabel>
+                    </DropdownItem>
+                    <DropdownDivider />
+                    <LogOutDropdownItem>
+                      <ArrowRightStartOnRectangleIcon />
+                      <DropdownLabel>Uitloggen</DropdownLabel>
+                    </LogOutDropdownItem>
+                  </DropdownMenu>
+                </Dropdown>
+                <FeedbackDialog />
+              </FeedbackProvider>
+            </NavbarSection>
+          </Navbar>
+        }
+        sidebar={
+          <Sidebar>
+            <SidebarHeader></SidebarHeader>
+            <SidebarBody>
+              <SidebarSection>
+                {navItems.map(({ label, url }) => (
+                  <SidebarItem key={label} href={url}>
+                    {label}
+                  </SidebarItem>
+                ))}
+              </SidebarSection>
+            </SidebarBody>
+          </Sidebar>
+        }
+      >
+        {children}
+      </StackedLayout>
+    );
+  }
 
   const firstPerson = persons[0]!;
 
@@ -113,11 +172,11 @@ export default async function Layout({
                   <Avatar src="" initials="mm" square />
                 </DropdownButton>
                 <DropdownMenu className="min-w-64" anchor="bottom end">
-                  <DropdownItem href="/instellingen">
+                  {/* <DropdownItem href="/instellingen">
                     <Cog8ToothIcon />
                     <DropdownLabel>Instellingen</DropdownLabel>
                   </DropdownItem>
-                  <DropdownDivider />
+                  <DropdownDivider /> */}
                   <DropdownItem href="/help">
                     <LifebuoyIcon />
                     <DropdownLabel>Helpcentrum</DropdownLabel>
@@ -145,7 +204,7 @@ export default async function Layout({
             <Dropdown>
               <DropdownButton as={SidebarItem} className="lg:mb-2.5">
                 <Avatar src={undefined} initials="mm" />
-                <SidebarLabel>Tailwind Labs</SidebarLabel>
+                <SidebarLabel>Nationaal Watersportdiploma</SidebarLabel>
                 <ChevronDownIcon />
               </DropdownButton>
               <PersonDropdownMenu />

--- a/apps/web/src/app/(dashboard)/(account)/profiel/page.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/page.tsx
@@ -1,9 +1,18 @@
 import { listLocationsForPerson } from "~/lib/nwd";
 import { Subheading } from "../../_components/heading";
-import { TextLink } from "../../_components/text";
+import { Text, TextLink } from "../../_components/text";
 
 export default async function Page() {
-  const locations = await listLocationsForPerson();
+  const locations = await listLocationsForPerson().catch(() => null);
+
+  if (!locations) {
+    return (
+      <Text>
+        Je bent nog niet aan een vaarlocatie gekoppeld. Weet je zeker dat je het
+        goede mailadres hebt gebruikt?
+      </Text>
+    );
+  }
 
   return (
     <div className="p-4 max-w-prose mx-auto">

--- a/apps/web/src/app/(dashboard)/(management)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/layout.tsx
@@ -1,13 +1,13 @@
 import {
   ArrowRightStartOnRectangleIcon,
-  Cog8ToothIcon,
-  InboxIcon,
-  LightBulbIcon,
-  MagnifyingGlassIcon,
   ShieldCheckIcon,
   UserIcon,
 } from "@heroicons/react/16/solid";
+import { constants } from "@nawadi/lib";
 import React from "react";
+import { Github } from "~/app/_components/socials";
+import { getUserOrThrow } from "~/lib/nwd";
+import { LogOutDropdownItem } from "../_components/auth";
 import { Avatar } from "../_components/avatar";
 import {
   Dropdown,
@@ -25,52 +25,47 @@ import {
 } from "../_components/navbar";
 import { SidebarLayout } from "../_components/sidebar-layout";
 
-export default function Layout({
+export default async function Layout({
   children,
   sidebar,
 }: Readonly<{
   children: React.ReactNode;
   sidebar: React.ReactNode;
 }>) {
+  const user = await getUserOrThrow();
+
   return (
     <SidebarLayout
       navbar={
         <Navbar>
           <NavbarSpacer />
           <NavbarSection>
-            <NavbarItem href="/search" aria-label="Search">
-              <MagnifyingGlassIcon />
-            </NavbarItem>
-            <NavbarItem href="/inbox" aria-label="Inbox">
-              <InboxIcon />
-            </NavbarItem>
             <Dropdown>
               <DropdownButton as={NavbarItem}>
-                <Avatar src="/profile-photo.jpg" square />
+                <Avatar
+                  initials={(user.displayName ?? user.email).slice(0, 2)}
+                  square
+                />
               </DropdownButton>
               <DropdownMenu className="min-w-64" anchor="bottom end">
-                <DropdownItem href="/my-profile">
+                <DropdownItem href="/account">
                   <UserIcon />
-                  <DropdownLabel>My profile</DropdownLabel>
-                </DropdownItem>
-                <DropdownItem href="/settings">
-                  <Cog8ToothIcon />
-                  <DropdownLabel>Settings</DropdownLabel>
+                  <DropdownLabel>Mijn account</DropdownLabel>
                 </DropdownItem>
                 <DropdownDivider />
-                <DropdownItem href="/privacy-policy">
+                <DropdownItem href="/privacy" target="_blank">
                   <ShieldCheckIcon />
-                  <DropdownLabel>Privacy policy</DropdownLabel>
+                  <DropdownLabel>Privacyverklaring</DropdownLabel>
                 </DropdownItem>
-                <DropdownItem href="/share-feedback">
-                  <LightBulbIcon />
-                  <DropdownLabel>Share feedback</DropdownLabel>
+                <DropdownItem href={constants.GITHUB_URL} target="_blank">
+                  <Github data-slot="icon" />
+                  <DropdownLabel>GitHub</DropdownLabel>
                 </DropdownItem>
                 <DropdownDivider />
-                <DropdownItem href="/logout">
+                <LogOutDropdownItem>
                   <ArrowRightStartOnRectangleIcon />
-                  <DropdownLabel>Sign out</DropdownLabel>
-                </DropdownItem>
+                  <DropdownLabel>Uitloggen</DropdownLabel>
+                </LogOutDropdownItem>
               </DropdownMenu>
             </Dropdown>
           </NavbarSection>


### PR DESCRIPTION
Previously, an error occurred when a user tried to log in with an unknown email address. Although the system would create an authentication user, an error would be triggered because no personas were attached. Now, we display a simple error message indicating that the authentication user is not associated with any locations yet.
While add it, also improve some mobile UI buttons. 

![CleanShot 2024-07-08 at 13 38 59@2x](https://github.com/buchungapp/nationaal-watersportdiploma/assets/9018689/3862cedc-c603-444d-8efb-5153c1013810)
