### PR TITLE
Fix/cant-issue-certificates

### DIFF
--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/table-actions.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/table-actions.tsx
@@ -179,8 +179,7 @@ export function IssueCertificateDialog({
                   name="visibleFrom"
                   type="datetime-local"
                   aria-label="Zichtbaar vanaf"
-                  required={delayVisibility}
-                  disabled={!delayVisibility}
+                  required={true}
                   defaultValue={
                     (defaultVisibleFrom ?? dayjs().toISOString()).split(".")[0]
                   }

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/[student-allocation]/_components/student-module.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/[student-allocation]/_components/student-module.tsx
@@ -49,7 +49,7 @@ export function CompleteAllCoreModules({
   return (
     <Button
       outline
-      disabled={disabled ?? isBusy}
+      disabled={disabled || isBusy}
       onClick={() => {
         startTransition(
           async () =>
@@ -172,7 +172,7 @@ export function Module({
                 </DisclosureButton>
 
                 <CourseCardCheckbox
-                  disabled={disabled ?? areAllCompetenciesCompleted}
+                  disabled={disabled || areAllCompetenciesCompleted}
                   checked={
                     areAllCompetenciesCompleted || areSomeCompetenciesSelected
                   }
@@ -237,7 +237,7 @@ export function Module({
                   return (
                     <CourseCardCheckbox
                       key={competency.id}
-                      disabled={disabled ?? isCompletedInPreviousCertification}
+                      disabled={disabled || isCompletedInPreviousCertification}
                       checked={
                         isCompletedInPreviousCertification ||
                         competencyProgress > 0

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/[student-allocation]/_components/student-module.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/[student-allocation]/_components/student-module.tsx
@@ -49,6 +49,7 @@ export function CompleteAllCoreModules({
   return (
     <Button
       outline
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       disabled={disabled || isBusy}
       onClick={() => {
         startTransition(
@@ -172,6 +173,7 @@ export function Module({
                 </DisclosureButton>
 
                 <CourseCardCheckbox
+                  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                   disabled={disabled || areAllCompetenciesCompleted}
                   checked={
                     areAllCompetenciesCompleted || areSomeCompetenciesSelected
@@ -237,6 +239,7 @@ export function Module({
                   return (
                     <CourseCardCheckbox
                       key={competency.id}
+                      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                       disabled={disabled || isCompletedInPreviousCertification}
                       checked={
                         isCompletedInPreviousCertification ||

--- a/packages/core/src/models/cohort/cohort.ts
+++ b/packages/core/src/models/cohort/cohort.ts
@@ -266,6 +266,8 @@ export const setDefaultVisibleFromDate = withZod(
       })
       .then(singleRow)
 
-    return result as { visibleFromDate: string }
+    return {
+      visibleFromDate: dayjs(result.visibleFromDate).toISOString(),
+    }
   },
 )


### PR DESCRIPTION
This PR addresses and fixes some edge cases encountered in the system:

1.	Delayed visibility on issuing certificates:
**Issue**: Users experienced an error when setting a delayed visibility for issuing certificates from a cohort. The root cause was an invalid ISO string being returned, despite the business logic succeeding.
**Fix**: Corrected the logic to ensure a valid ISO string is returned, eliminating the error.
2.	Disabled field on course card:
**Issue**: The disabled field on the course card was broken due to incorrect usage of the ?? operator.
**Fix**: Replaced the wrongly used ?? operator with the appropriate logic to ensure the disabled field functions correctly.