### PR TITLE
fix: space not allowed in search

### DIFF
--- a/apps/web/src/app/(dashboard)/(management)/_components/search.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/_components/search.tsx
@@ -25,7 +25,7 @@ export default function Search({ placeholder = "Zoeken..." }) {
         value={decodeURIComponent(query)}
         onChange={(e) => {
           void setQuery({
-            query: encodeURIComponent(e.target.value.trim()),
+            query: encodeURIComponent(e.target.value),
             page: null,
             limit: null,
           });


### PR DESCRIPTION
The search input had a `trim` on the input value. This removed trailing spaces, thus not allowing the user to type a `space` in the search bar.