### PR TITLE
fix: diplomas bulk not updating, temporary fix by resetting selection

### DIFF
--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/students-table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/students-table.tsx
@@ -553,6 +553,7 @@ export default function StudentsTable({
             rows={actionRows}
             cohortId={cohortId}
             defaultVisibleFrom={defaultCertificateVisibleFromDate}
+            resetSelection={() => setRowSelection({})}
           />
         </div>
       </div>

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/table-actions.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/table-actions.tsx
@@ -219,8 +219,10 @@ export function IssueCertificateDialog({
                 : null,
               cohortId,
             })
-              .then(() => setIsOpen(false))
-              .then(() => resetSelection())
+              .then(() => {
+                setIsOpen(false);
+                resetSelection();
+              })
               .catch((error) => {
                 if (error instanceof Error) {
                   return setError(error.message);
@@ -319,8 +321,10 @@ export function RemoveCertificateDialog({
                 certificateIds: rows.map((row) => row.certificate!.id),
                 cohortId,
               })
-                .then(() => setIsOpen(false))
-                .then(() => resetSelection())
+                .then(() => {
+                  setIsOpen(false);
+                  resetSelection();
+                })
                 .catch((error) => {
                   if (error instanceof Error) {
                     return setError(error.message);

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/table-actions.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/table-actions.tsx
@@ -62,6 +62,7 @@ interface Props {
   }[];
   cohortId: string;
   defaultVisibleFrom?: string;
+  resetSelection: () => void;
 }
 
 export function ActionButtons(props: Props) {
@@ -192,6 +193,7 @@ export function IssueCertificateDialog({
   defaultVisibleFrom,
   isOpen,
   setIsOpen,
+  resetSelection,
 }: Props & {
   isOpen: boolean;
   setIsOpen: (value: boolean) => void;
@@ -218,6 +220,7 @@ export function IssueCertificateDialog({
               cohortId,
             })
               .then(() => setIsOpen(false))
+              .then(() => resetSelection())
               .catch((error) => {
                 if (error instanceof Error) {
                   return setError(error.message);
@@ -281,6 +284,7 @@ export function RemoveCertificateDialog({
   isOpen,
   cohortId,
   setIsOpen,
+  resetSelection,
 }: Props & {
   isOpen: boolean;
   setIsOpen: (value: boolean) => void;
@@ -316,6 +320,7 @@ export function RemoveCertificateDialog({
                 cohortId,
               })
                 .then(() => setIsOpen(false))
+                .then(() => resetSelection())
                 .catch((error) => {
                   if (error instanceof Error) {
                     return setError(error.message);
@@ -338,6 +343,7 @@ function CompleteCoreModulesDialog({
   rows,
   isOpen,
   setIsOpen,
+  resetSelection,
 }: Props & {
   isOpen: boolean;
   setIsOpen: (value: boolean) => void;
@@ -352,6 +358,7 @@ function CompleteCoreModulesDialog({
 
       toast.success("Kernmodules afgerond");
       setIsOpen(false);
+      resetSelection();
     } catch (error) {
       toast.error("Er is iets misgegaan");
     }
@@ -418,6 +425,7 @@ function DownloadCertificatesDialog({
   rows,
   isOpen,
   setIsOpen,
+  resetSelection,
 }: Props & {
   isOpen: boolean;
   setIsOpen: (value: boolean) => void;
@@ -442,6 +450,7 @@ function DownloadCertificatesDialog({
 
       toast.success("Bestand gedownload");
       setIsOpen(false);
+      resetSelection();
     } catch (error) {
       toast.error("Er is iets misgegaan");
     }


### PR DESCRIPTION
When a bulk action is successfully performed the row selection in diplomas table is reset.

This way the user has to reselect the rows, thus making the bulk button update