### PR TITLE
feat: breakout component to 'breakout' of layouts max-width

### DIFF
--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/students-table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/students-table.tsx
@@ -22,6 +22,9 @@ import { useParams } from "next/navigation";
 import React from "react";
 import Search from "~/app/(dashboard)/(management)/_components/search";
 import { Badge } from "~/app/(dashboard)/_components/badge";
+import Breakout, {
+  BreakoutCenter,
+} from "~/app/(dashboard)/_components/breakout";
 import { Button } from "~/app/(dashboard)/_components/button";
 import {
   Checkbox,
@@ -422,113 +425,119 @@ export default function StudentsTable({
             <TableDisplay table={table} />
           </div>
         </div>
-        <Table
-          className="mt-4 [--gutter:theme(spacing.6)] lg:[--gutter:theme(spacing.10)]"
-          dense
-        >
-          <TableHead>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => {
-                  const sortingHandler =
-                    header.column.getToggleSortingHandler?.();
-                  const getAriaSortValue = (
-                    isSorted: false | SortDirection,
-                  ) => {
-                    switch (isSorted) {
-                      case "asc":
-                        return "ascending";
-                      case "desc":
-                        return "descending";
-                      case false:
-                      default:
-                        return "none";
-                    }
-                  };
-
-                  return (
-                    <TableHeader
-                      key={header.id}
-                      onClick={sortingHandler}
-                      onKeyDown={(event) => {
-                        if (event.key === "Enter" && sortingHandler) {
-                          sortingHandler(event);
+        <Breakout>
+          <Table className="mt-4 max-lg:[--gutter:theme(spacing.6)]" dense>
+            <BreakoutCenter>
+              <TableHead>
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <TableRow key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => {
+                      const sortingHandler =
+                        header.column.getToggleSortingHandler?.();
+                      const getAriaSortValue = (
+                        isSorted: false | SortDirection,
+                      ) => {
+                        switch (isSorted) {
+                          case "asc":
+                            return "ascending";
+                          case "desc":
+                            return "descending";
+                          case false:
+                          default:
+                            return "none";
                         }
-                      }}
-                      className={clsx(
-                        header.column.getCanSort()
-                          ? "cursor-pointer select-none"
-                          : "",
-                      )}
-                      tabIndex={header.column.getCanSort() ? 0 : -1}
-                      aria-sort={getAriaSortValue(header.column.getIsSorted())}
-                    >
-                      <div
-                        className={clsx(
-                          header.column.columnDef.enableSorting === false
-                            ? header.column.columnDef.meta?.align
-                            : "flex items-center justify-between gap-2 hover:bg-gray-50 hover:dark:bg-gray-900 px-3 py-1.5 -mx-3 -my-1.5",
-                          "rounded-md",
-                        )}
-                      >
-                        {flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                        {header.column.getCanSort() &&
-                          (header.column.getIsSorted() === false ? (
-                            <ArrowsUpDownIcon className="size-3 text-gray-900 dark:text-gray-50 opacity-30" />
-                          ) : header.column.getIsSorted() === "desc" ? (
-                            <ArrowUpIcon
-                              className="size-3 text-gray-900 dark:text-gray-50"
-                              aria-hidden={true}
-                            />
-                          ) : (
-                            <ArrowDownIcon
-                              className="size-3 text-gray-900 dark:text-gray-50"
-                              aria-hidden={true}
-                            />
-                          ))}
-                      </div>
-                    </TableHeader>
-                  );
-                })}
-              </TableRow>
-            ))}
-          </TableHead>
-          <TableBody>
-            {table.getRowCount() <= 0 ? (
-              <TableRow>
-                <TableCell colSpan={columns.length} className="text-center">
-                  {noOptionsLabel}
-                </TableCell>
-              </TableRow>
-            ) : null}
-            {table.getRowModel().rows.map((row) => (
-              <TableRow
-                className={clsx(
-                  row.getIsSelected()
-                    ? "bg-zinc-950/[1.5%] dark:bg-zinc-950/[1.5%]"
-                    : "",
-                )}
-                key={row.id}
-                href={`/locatie/${params.location as string}/cohorten/${params.cohort as string}/${row.id}`}
-              >
-                {row.getVisibleCells().map((cell, index) => (
-                  <TableCell
-                    key={cell.id}
-                    className={clsx(cell.column.columnDef.meta?.align)}
-                  >
-                    {index === 0 && row.getIsSelected() && (
-                      <div className="absolute inset-y-0 left-0 w-0.5 bg-branding-light" />
-                    )}
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
+                      };
+
+                      return (
+                        <TableHeader
+                          key={header.id}
+                          onClick={sortingHandler}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter" && sortingHandler) {
+                              sortingHandler(event);
+                            }
+                          }}
+                          className={clsx(
+                            header.column.getCanSort()
+                              ? "cursor-pointer select-none"
+                              : "",
+                          )}
+                          tabIndex={header.column.getCanSort() ? 0 : -1}
+                          aria-sort={getAriaSortValue(
+                            header.column.getIsSorted(),
+                          )}
+                        >
+                          <div
+                            className={clsx(
+                              header.column.columnDef.enableSorting === false
+                                ? header.column.columnDef.meta?.align
+                                : "flex items-center justify-between gap-2 hover:bg-gray-50 hover:dark:bg-gray-900 px-3 py-1.5 -mx-3 -my-1.5",
+                              "rounded-md",
+                            )}
+                          >
+                            {flexRender(
+                              header.column.columnDef.header,
+                              header.getContext(),
+                            )}
+                            {header.column.getCanSort() &&
+                              (header.column.getIsSorted() === false ? (
+                                <ArrowsUpDownIcon className="size-3 text-gray-900 dark:text-gray-50 opacity-30" />
+                              ) : header.column.getIsSorted() === "desc" ? (
+                                <ArrowUpIcon
+                                  className="size-3 text-gray-900 dark:text-gray-50"
+                                  aria-hidden={true}
+                                />
+                              ) : (
+                                <ArrowDownIcon
+                                  className="size-3 text-gray-900 dark:text-gray-50"
+                                  aria-hidden={true}
+                                />
+                              ))}
+                          </div>
+                        </TableHeader>
+                      );
+                    })}
+                  </TableRow>
                 ))}
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+              </TableHead>
+              <TableBody>
+                {table.getRowCount() <= 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={columns.length} className="text-center">
+                      {noOptionsLabel}
+                    </TableCell>
+                  </TableRow>
+                ) : null}
+                {table.getRowModel().rows.map((row) => (
+                  <TableRow
+                    className={clsx(
+                      row.getIsSelected()
+                        ? "bg-zinc-950/[1.5%] dark:bg-zinc-950/[1.5%]"
+                        : "",
+                    )}
+                    key={row.id}
+                    href={`/locatie/${params.location as string}/cohorten/${params.cohort as string}/${row.id}`}
+                  >
+                    {row.getVisibleCells().map((cell, index) => (
+                      <TableCell
+                        key={cell.id}
+                        className={clsx(cell.column.columnDef.meta?.align)}
+                      >
+                        {index === 0 && row.getIsSelected() && (
+                          <div className="absolute inset-y-0 left-0 w-0.5 bg-branding-light" />
+                        )}
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext(),
+                        )}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </BreakoutCenter>
+          </Table>
+        </Breakout>
       </TableOrderingContext>
 
       <TableFooter>

--- a/apps/web/src/app/(dashboard)/_components/breakout.tsx
+++ b/apps/web/src/app/(dashboard)/_components/breakout.tsx
@@ -2,6 +2,7 @@ import clsx from "clsx";
 import React, { type PropsWithChildren } from "react";
 
 const DEFAULT_COMPONENT = "div";
+
 export default function Breakout<
   TTag extends React.ElementType = typeof DEFAULT_COMPONENT,
 >({
@@ -19,7 +20,7 @@ export default function Breakout<
     <Cmp
       {...rest}
       className={clsx(
-        ...(rest.className ? [rest.className] : []),
+        rest.className,
         "lg:w-[calc(100vw-16rem-5rem)] lg:-ml-[max(calc(calc(100vw-72rem-16rem-5rem)/2),0px)]",
       )}
     >
@@ -45,7 +46,7 @@ export function BreakoutCenter<
     <Cmp
       {...rest}
       className={clsx(
-        ...(rest.className ? [rest.className] : []),
+        rest.className,
         "lg:px-[max(calc(calc(100vw-72rem-16rem-5rem)/2),0px)]",
       )}
     >

--- a/apps/web/src/app/(dashboard)/_components/breakout.tsx
+++ b/apps/web/src/app/(dashboard)/_components/breakout.tsx
@@ -1,26 +1,54 @@
+import clsx from "clsx";
 import React, { PropsWithChildren } from "react";
 
-export default function Breakout({
+const DEFAULT_COMPONENT = "div" as const;
+export default function Breakout<
+  TTag extends React.ElementType = typeof DEFAULT_COMPONENT,
+>({
   children,
-  as: Cmp = "div",
-}: PropsWithChildren<{
-  as?: React.ElementType;
-}>) {
+  ...props
+}: PropsWithChildren<
+  {
+    as?: TTag;
+  } & React.ComponentPropsWithoutRef<TTag>
+>) {
+  const { as: cmp, ...rest } = props;
+  const Cmp: React.ElementType = cmp ?? DEFAULT_COMPONENT;
+
   return (
-    <Cmp className="lg:w-[calc(100vw-16rem-5rem)] lg:-ml-[max(calc(calc(100vw-72rem-16rem-5rem)/2),0px)]">
+    <Cmp
+      {...rest}
+      className={clsx(
+        ...(rest.className ? [rest.className] : []),
+        "lg:w-[calc(100vw-16rem-5rem)] lg:-ml-[max(calc(calc(100vw-72rem-16rem-5rem)/2),0px)]",
+      )}
+    >
       {children}
     </Cmp>
   );
 }
 
-export function BreakoutCenter({
+export function BreakoutCenter<
+  TTag extends React.ElementType = typeof DEFAULT_COMPONENT,
+>({
   children,
-  as: Cmp = "div",
-}: PropsWithChildren<{
-  as?: React.ElementType;
-}>) {
+  ...props
+}: PropsWithChildren<
+  {
+    as?: TTag;
+  } & React.ComponentPropsWithoutRef<TTag>
+>) {
+  const { as: cmp, ...rest } = props;
+  const Cmp: React.ElementType = cmp ?? DEFAULT_COMPONENT;
+
   return (
-    <Cmp className="lg:px-[max(calc(calc(100vw-72rem-16rem-5rem)/2),0px)]">
+    <Cmp
+      {...rest}
+      className={clsx(
+        ...(rest.className ? [rest.className] : []),
+        "lg:px-[max(calc(calc(100vw-72rem-16rem-5rem)/2),0px)]",
+      )}
+    >
       {children}
     </Cmp>
   );

--- a/apps/web/src/app/(dashboard)/_components/breakout.tsx
+++ b/apps/web/src/app/(dashboard)/_components/breakout.tsx
@@ -1,7 +1,7 @@
 import clsx from "clsx";
-import React, { PropsWithChildren } from "react";
+import React, { type PropsWithChildren } from "react";
 
-const DEFAULT_COMPONENT = "div" as const;
+const DEFAULT_COMPONENT = "div";
 export default function Breakout<
   TTag extends React.ElementType = typeof DEFAULT_COMPONENT,
 >({

--- a/apps/web/src/app/(dashboard)/_components/breakout.tsx
+++ b/apps/web/src/app/(dashboard)/_components/breakout.tsx
@@ -1,0 +1,27 @@
+import React, { PropsWithChildren } from "react";
+
+export default function Breakout({
+  children,
+  as: Cmp = "div",
+}: PropsWithChildren<{
+  as?: React.ElementType;
+}>) {
+  return (
+    <Cmp className="lg:w-[calc(100vw-16rem-5rem)] lg:-ml-[max(calc(calc(100vw-72rem-16rem-5rem)/2),0px)]">
+      {children}
+    </Cmp>
+  );
+}
+
+export function BreakoutCenter({
+  children,
+  as: Cmp = "div",
+}: PropsWithChildren<{
+  as?: React.ElementType;
+}>) {
+  return (
+    <Cmp className="lg:px-[max(calc(calc(100vw-72rem-16rem-5rem)/2),0px)]">
+      {children}
+    </Cmp>
+  );
+}


### PR DESCRIPTION
Allows content to break out of `max-width` that is on the main content panel. This is use full for example tables on extra wide screens

![image](https://github.com/user-attachments/assets/673b1a5b-c352-49e5-a7b7-e021a742464e)
