### PR TITLE
fix: auto break words in headlines with hypens

### DIFF
--- a/apps/web/src/app/(public)/actueel/(article)/_components/news-article.tsx
+++ b/apps/web/src/app/(public)/actueel/(article)/_components/news-article.tsx
@@ -43,7 +43,7 @@ export function ArticleLayout({
               Terug naar alle artikelen
             </TekstButton>
 
-            <h1 className="text-4xl font-bold lg:leading-[1.15] lg:text-5xl max-w-prose">
+            <h1 className="text-4xl font-bold lg:leading-[1.15] lg:text-5xl max-w-prose break-words hyphens-auto">
               {article.title}
             </h1>
           </div>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e19b3dc0-9505-4e2c-8b91-02a2a69d907f)
![image](https://github.com/user-attachments/assets/3396d712-46c0-4f34-9681-0ebed5f2d7f8)
