### PR TITLE
fix: diploma's page didn't contain functioning url

### DIFF
--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_components/table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_components/table.tsx
@@ -202,7 +202,8 @@ export default function CertificateTable({
                   : "",
               )}
               key={row.id}
-              href={`#TODO`}
+              target="_blank"
+              href={`/diploma/${row.original.id}?nummer=${row.original.handle}&datum=${dayjs(row.original.issuedAt).format("YYYYMMDD")}`}
             >
               {row.getVisibleCells().map((cell, index) => (
                 <TableCell


### PR DESCRIPTION
It now opens a new page with the certificate