### PR TITLE
fix: added old defaults to nuqs use query

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -50,6 +50,12 @@ const nextConfig = {
       },
     ];
   },
+  /** Uncomment to enable WhyDidYouRender */
+  // webpack: (config, context) => {
+  //   injectWhyDidYouRender(config, context);
+
+  //   return config;
+  // },
 };
 
 const withMDX = nextMDX({

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -86,6 +86,7 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@types/svg-to-pdfkit": "^0.1.3",
+    "@welldone-software/why-did-you-render": "^10.0.1",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.47",
     "tailwindcss": "^4.0.6",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,7 +30,7 @@
     "@supabase/ssr": "^0.4.1",
     "@supabase/supabase-js": "^2.45.4",
     "@tailwindcss/postcss": "^4.0.6",
-    "@tanstack/react-table": "^8.20.5",
+    "@tanstack/react-table": "^8.21.2",
     "@tremor/react": "4.0.0-beta-tremor-v4.4",
     "@vercel/flags": "^2.6.0",
     "@vercel/otel": "^1.10.0",

--- a/apps/web/rerender/index.js
+++ b/apps/web/rerender/index.js
@@ -1,0 +1,31 @@
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/** @typedef {Parameters<import('next').NextConfig['webpack']>[1]} WebpackConfigContext */
+const injectionSource = path.join(__dirname, "injection.ts");
+
+/**
+ * @param {import('webpack').Configuration} config
+ * @param {WebpackConfigContext} context
+ */
+export default function (config, context) {
+  if (context.dev && !context.isServer) {
+    const originalEntry = config.entry;
+
+    config.entry = async () => {
+      const entries = await originalEntry();
+
+      if (
+        entries["main-app"] &&
+        !entries["main-app"].includes(injectionSource)
+      ) {
+        entries["main-app"].unshift(injectionSource);
+      }
+
+      return entries;
+    };
+  }
+}

--- a/apps/web/rerender/injection.ts
+++ b/apps/web/rerender/injection.ts
@@ -1,0 +1,20 @@
+import React from "react";
+
+import whyDidYouRender from "@welldone-software/why-did-you-render";
+
+// eslint-disable-next-line no-console -- Show information that `whyDidYouRender` has been applied to the website.
+console.debug(
+  "Applying whyDidYouRender, to help you locate unnecessary re-renders during development. See https://github.com/welldone-software/why-did-you-render",
+);
+
+// See https://github.com/welldone-software/why-did-you-render#options
+whyDidYouRender(React, {
+  // trackAllPureComponents: true,
+  // trackHooks: true,
+  // logOwnerReasons: true,
+  // collapseGroups: true,
+  include: [/./],
+
+  // This is for testing, remove it, if you don't want to log on different values
+  // logOnDifferentValues: true,
+});

--- a/apps/web/src/app/(dashboard)/(management)/_components/search.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/_components/search.tsx
@@ -18,6 +18,7 @@ export default function Search({ placeholder = "Zoeken..." }) {
       startTransition,
       // https://nuqs.47ng.com/docs/options#throttling-url-updates
       throttleMs: 300,
+      shallow: false,
     },
   );
 

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/_components/filters.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/_components/filters.tsx
@@ -17,6 +17,7 @@ export function SetView({
       .withDefault(defaultView)
       .withOptions({
         startTransition,
+        shallow: false,
       }),
   );
 

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/_components/students-table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/_components/students-table.tsx
@@ -225,7 +225,6 @@ export default function StudentsTable({
     >
   >({});
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const onRowSelectionChange = React.useCallback<OnChangeFn<RowSelectionState>>(
     (updater) => {
       setRowSelection((prev) => {
@@ -240,9 +239,9 @@ export default function StudentsTable({
             const student = students.find((student) => student.id === key);
             return [
               key,
-              Object.hasOwn(rowSelection, key)
+              Object.hasOwn(prev, key)
                 ? // biome-ignore lint/style/noNonNullAssertion: <explanation>
-                  rowSelection[key]!
+                  prev[key]!
                 : {
                     // biome-ignore lint/style/noNonNullAssertion: <explanation>
                     instructor: student!.instructor,

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/filter.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/filter.tsx
@@ -29,6 +29,7 @@ export function FilterSelect() {
     "weergave",
     parseAsArrayOf(parseAsStringLiteral(options)).withOptions({
       startTransition,
+      shallow: false,
     }),
   );
 

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/page.tsx
@@ -9,12 +9,23 @@ import {
 } from "~/lib/nwd";
 
 import {
-  createSearchParamsCache,
+  createLoader,
   parseAsArrayOf,
   parseAsString,
   parseAsStringLiteral,
 } from "nuqs/server";
 import StudentsTable from "./_components/students-table";
+
+const searchParamsParser = createLoader({
+  weergave: parseAsArrayOf(
+    parseAsStringLiteral([
+      "uitgegeven",
+      "klaar-voor-uitgifte",
+      "geen-voortgang",
+    ] as const),
+  ),
+  query: parseAsString,
+});
 
 export default async function Page(props: {
   params: Promise<{ location: string; cohort: string }>;
@@ -39,16 +50,7 @@ export default async function Page(props: {
     ),
   ]);
 
-  const parsedSq = createSearchParamsCache({
-    weergave: parseAsArrayOf(
-      parseAsStringLiteral([
-        "uitgegeven",
-        "klaar-voor-uitgifte",
-        "geen-voortgang",
-      ] as const),
-    ),
-    query: parseAsString,
-  }).parse(searchParams);
+  const parsedSq = searchParamsParser(searchParams);
 
   const filteredStudents =
     parsedSq.weergave && parsedSq.weergave.length > 0

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/_components/filter.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/_components/filter.tsx
@@ -26,6 +26,7 @@ export function FilterSelect() {
     parseAsArrayOf(parseAsStringLiteral(options))
       .withOptions({
         startTransition,
+        shallow: false,
       })
       .withDefault(["open", "aankomend"]),
   );

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/page.tsx
@@ -1,7 +1,7 @@
 import FlexSearch from "flexsearch";
 
 import {
-  createSearchParamsCache,
+  createLoader,
   parseAsArrayOf,
   parseAsString,
   parseAsStringLiteral,
@@ -17,6 +17,13 @@ import Search from "../../../_components/search";
 import CreateDialog from "./_components/create-dialog";
 import { FilterSelect } from "./_components/filter";
 import Table from "./_components/table";
+
+const searchParamsParser = createLoader({
+  weergave: parseAsArrayOf(
+    parseAsStringLiteral(["verleden", "aankomend", "open"] as const),
+  ).withDefault(["open", "aankomend"]),
+  query: parseAsString,
+});
 
 export default async function Page(props: {
   params: Promise<{
@@ -34,12 +41,7 @@ export default async function Page(props: {
   ]);
   const isLocationAdmin = rolesInCurrentLocation.includes("location_admin");
 
-  const parsedSq = createSearchParamsCache({
-    weergave: parseAsArrayOf(
-      parseAsStringLiteral(["verleden", "aankomend", "open"] as const),
-    ).withDefault(["open", "aankomend"]),
-    query: parseAsString,
-  }).parse(searchParams);
+  const parsedSq = searchParamsParser(searchParams);
 
   const filteredCohorts =
     parsedSq.weergave && parsedSq.weergave.length > 0

--- a/apps/web/src/app/(dashboard)/_components/navigation.tsx
+++ b/apps/web/src/app/(dashboard)/_components/navigation.tsx
@@ -9,7 +9,7 @@ export function RouterPreviousButton({ children }: PropsWithChildren) {
   return (
     <button
       type="button"
-      className="inline-flex items-center gap-2 text-sm/6 text-zinc-500 dark:text-zinc-400"
+      className="inline-flex items-center gap-2 text-sm/6 text-zinc-500 dark:text-zinc-400 cursor-pointer"
       onClick={() => router.back()}
     >
       <ChevronLeftIcon className="size-4 fill-zinc-400 dark:fill-zinc-500" />

--- a/apps/web/src/app/(dashboard)/_hooks/use-column-ordering.tsx
+++ b/apps/web/src/app/(dashboard)/_hooks/use-column-ordering.tsx
@@ -84,6 +84,7 @@ export function useColumnOrdering(orderableColumns: OrderableColumn[]) {
     parseAsArrayOf(parseAsString)
       .withOptions({
         clearOnDefault: false,
+        shallow: false,
       })
       .withDefault(defaultOrder),
   );

--- a/apps/web/src/app/(dashboard)/_hooks/use-column-ordering.tsx
+++ b/apps/web/src/app/(dashboard)/_hooks/use-column-ordering.tsx
@@ -81,13 +81,22 @@ export function useColumnOrdering(orderableColumns: OrderableColumn[]) {
 
   const [columnOrder, setColumnOrder] = useQueryState<ColumnOrderState>(
     "volgorde",
-    parseAsArrayOf(parseAsString).withDefault(defaultOrder),
+    parseAsArrayOf(parseAsString)
+      .withOptions({
+        clearOnDefault: false,
+      })
+      .withDefault(defaultOrder),
   );
 
   const [columnVisibility, setColumnVisibility] =
     useQueryState<VisibilityState>(
       "toon",
-      parseAsColumnVisibility(defaultOrder).withDefault(defaultVisibility),
+      parseAsColumnVisibility(defaultOrder)
+        .withOptions({
+          clearOnDefault: false,
+          shallow: false,
+        })
+        .withDefault(defaultVisibility),
     );
 
   const onColumnVisibilityChange = useCallback(

--- a/apps/web/src/app/(dashboard)/_hooks/use-column-ordering.tsx
+++ b/apps/web/src/app/(dashboard)/_hooks/use-column-ordering.tsx
@@ -81,23 +81,13 @@ export function useColumnOrdering(orderableColumns: OrderableColumn[]) {
 
   const [columnOrder, setColumnOrder] = useQueryState<ColumnOrderState>(
     "volgorde",
-    parseAsArrayOf(parseAsString)
-      .withOptions({
-        clearOnDefault: false,
-        shallow: false,
-      })
-      .withDefault(defaultOrder),
+    parseAsArrayOf(parseAsString).withDefault(defaultOrder),
   );
 
   const [columnVisibility, setColumnVisibility] =
     useQueryState<VisibilityState>(
       "toon",
-      parseAsColumnVisibility(defaultOrder)
-        .withOptions({
-          clearOnDefault: false,
-          shallow: false,
-        })
-        .withDefault(defaultVisibility),
+      parseAsColumnVisibility(defaultOrder).withDefault(defaultVisibility),
     );
 
   const onColumnVisibilityChange = useCallback(

--- a/apps/web/src/app/(dashboard)/_hooks/use-sorting.tsx
+++ b/apps/web/src/app/(dashboard)/_hooks/use-sorting.tsx
@@ -1,6 +1,6 @@
 import type { SortingState } from "@tanstack/react-table";
-import { createParser, useQueryState } from "nuqs";
-import { useMemo } from "react";
+import { createParser } from "nuqs";
+import { useMemo, useState } from "react";
 import type { Optional } from "~/types/optional";
 
 interface SortableColumn {
@@ -51,15 +51,13 @@ export function useSorting({
   sortableColumnIds: SortableColumn["id"][];
   defaultSorting?: SortingState;
 }) {
-  const [sorting, setSorting] = useQueryState<SortingState>(
-    "sorteer",
-    parseAsSorting(sortableColumnIds)
-      .withOptions({
-        clearOnDefault: false,
-        shallow: false,
-      })
-      .withDefault(defaultSorting),
-  );
+  // TODO: fix use query state causes infinite loop
+  // const [sorting, setSorting] = useQueryState<SortingState>(
+  //   "sorteer",
+  //   parseAsSorting(sortableColumnIds).withDefault(defaultSorting),
+  // );
+
+  const [sorting, setSorting] = useState(defaultSorting);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const options = useMemo(
@@ -69,7 +67,7 @@ export function useSorting({
       },
       onSortingChange: setSorting,
     }),
-    [JSON.stringify(sorting), setSorting],
+    [sorting, setSorting],
   );
 
   return options;

--- a/apps/web/src/app/(dashboard)/_hooks/use-sorting.tsx
+++ b/apps/web/src/app/(dashboard)/_hooks/use-sorting.tsx
@@ -53,7 +53,12 @@ export function useSorting({
 }) {
   const [sorting, setSorting] = useQueryState<SortingState>(
     "sorteer",
-    parseAsSorting(sortableColumnIds).withDefault(defaultSorting),
+    parseAsSorting(sortableColumnIds)
+      .withOptions({
+        clearOnDefault: false,
+        shallow: false,
+      })
+      .withDefault(defaultSorting),
   );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>

--- a/apps/web/src/app/(dashboard)/_hooks/use-sorting.tsx
+++ b/apps/web/src/app/(dashboard)/_hooks/use-sorting.tsx
@@ -1,6 +1,6 @@
 import type { SortingState } from "@tanstack/react-table";
-import { createParser } from "nuqs";
-import { useMemo, useState } from "react";
+import { parseAsString, useQueryState } from "nuqs";
+import { useCallback, useMemo } from "react";
 import type { Optional } from "~/types/optional";
 
 interface SortableColumn {
@@ -8,30 +8,52 @@ interface SortableColumn {
   enableSorting?: boolean;
 }
 
-const parseAsSorting = (validSortingKeys: string[]) => {
-  return createParser<SortingState>({
-    parse(queryValue) {
-      const sorting = queryValue.split(",");
-      const sortingState = sorting.map((sort) => {
-        const [id, direction] = sort.split(".");
+function parseSorting(queryValue: string, validSortingKeys: string[]) {
+  const sorting = queryValue.split(",");
+  const sortingState = sorting.map((sort) => {
+    const [id, direction] = sort.split(".");
 
-        return {
-          id,
-          desc: direction === "za",
-        };
-      });
-
-      return sortingState.filter(
-        (sort) => sort.id && validSortingKeys.includes(sort.id),
-      ) as SortingState;
-    },
-    serialize(value) {
-      return value
-        .map((sort) => `${sort.id}.${sort.desc ? "za" : "az"}`)
-        .join(",");
-    },
+    return {
+      id,
+      desc: direction === "za",
+    };
   });
-};
+
+  return sortingState.filter(
+    (sort) => sort.id && validSortingKeys.includes(sort.id),
+  ) as SortingState;
+}
+
+function serializeSorting(value: SortingState | null) {
+  if (!value) return "";
+  return value.map((sort) => `${sort.id}.${sort.desc ? "za" : "az"}`).join(",");
+}
+
+// TODO: using the parseAsSorting function, causes an infinite loop with tanstack table, this work around is not nice
+// const parseAsSorting = (validSortingKeys: string[]) => {
+//   return createParser<SortingState>({
+//     parse(queryValue) {
+//       const sorting = queryValue.split(",");
+//       const sortingState = sorting.map((sort) => {
+//         const [id, direction] = sort.split(".");
+
+//         return {
+//           id,
+//           desc: direction === "za",
+//         };
+//       });
+
+//       return sortingState.filter(
+//         (sort) => sort.id && validSortingKeys.includes(sort.id),
+//       ) as SortingState;
+//     },
+//     serialize(value) {
+//       return value
+//         .map((sort) => `${sort.id}.${sort.desc ? "za" : "az"}`)
+//         .join(",");
+//     },
+//   });
+// };
 
 export function getSortableColumnIds(
   columns: Optional<SortableColumn, "id">[],
@@ -51,23 +73,36 @@ export function useSorting({
   sortableColumnIds: SortableColumn["id"][];
   defaultSorting?: SortingState;
 }) {
-  // TODO: fix use query state causes infinite loop
-  // const [sorting, setSorting] = useQueryState<SortingState>(
-  //   "sorteer",
-  //   parseAsSorting(sortableColumnIds).withDefault(defaultSorting),
-  // );
+  // TODO: using the parseAsSorting function, causes an infinite loop with tanstack table, this work around is not nice
+  const [sorting, setSorting] = useQueryState(
+    "sorteer",
+    parseAsString.withDefault(serializeSorting(defaultSorting)),
+  );
 
-  const [sorting, setSorting] = useState(defaultSorting);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+  const wrapper = useCallback(
+    (
+      value: SortingState | ((old: SortingState) => SortingState | null) | null,
+    ) => {
+      const newValue =
+        typeof value === "function"
+          ? value(parseSorting(sorting, sortableColumnIds))
+          : value;
+
+      setSorting(serializeSorting(newValue));
+    },
+    [setSorting, sorting],
+  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const options = useMemo(
     () => ({
       state: {
-        sorting,
+        sorting: parseSorting(sorting, sortableColumnIds),
       },
-      onSortingChange: setSorting,
+      onSortingChange: wrapper,
     }),
-    [sorting, setSorting],
+    [sorting, wrapper],
   );
 
   return options;

--- a/apps/web/src/app/style/animations.css
+++ b/apps/web/src/app/style/animations.css
@@ -1,27 +1,27 @@
 @theme {
   /* Animations */
-  --animate-spinner: "spinner 1.2s linear infinite";
-  --animate-caret-blink: "caret-blink 1.2s ease-out infinite";
+  --animate-spinner: spinner 1.2s linear infinite;
+  --animate-caret-blink: caret-blink 1.2s ease-out infinite;
+}
 
-  @keyframes caret-blink {
-    0%,
-    70%,
-    100% {
-      opacity: 1;
-    }
-    20%,
-    50% {
-      opacity: 0;
-    }
+@keyframes caret-blink {
+  0%,
+  70%,
+  100% {
+    opacity: 1;
+  }
+  20%,
+  50% {
+    opacity: 0;
+  }
+}
+
+@keyframes spinner {
+  0% {
+    opacity: 1;
   }
 
-  @keyframes spinner {
-    0% {
-      opacity: 1;
-    }
-
-    100% {
-      opacity: 0;
-    }
+  100% {
+    opacity: 0;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,6 +337,9 @@ importers:
       '@types/svg-to-pdfkit':
         specifier: ^0.1.3
         version: 0.1.3
+      '@welldone-software/why-did-you-render':
+        specifier: ^10.0.1
+        version: 10.0.1(react@19.0.0)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.47)
@@ -2755,6 +2758,11 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
+
+  '@welldone-software/why-did-you-render@10.0.1':
+    resolution: {integrity: sha512-tMgGkt30iVYeLMUKExNmtm019QgyjLtA7lwB0QAizYNEuihlCG2eoAWBBaz/bDeI7LeqAJ9msC6hY3vX+JB97g==}
+    peerDependencies:
+      react: ^19
 
   abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
@@ -9612,6 +9620,11 @@ snapshots:
       fast-deep-equal: 3.1.3
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
+
+  '@welldone-software/why-did-you-render@10.0.1(react@19.0.0)':
+    dependencies:
+      lodash: 4.17.21
+      react: 19.0.0
 
   abbrev@2.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: 15.1.6
       version: 15.1.6
     nuqs:
-      specifier: 2.3.0
-      version: 2.3.0
+      specifier: 2.4.0
+      version: 2.4.0
     postgres:
       specifier: ^3.4.4
       version: 3.4.5
@@ -245,7 +245,7 @@ importers:
         version: 7.0.0-next.47(@types/json-schema@7.0.15)(next@15.1.6(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(zod-to-json-schema@3.24.1(zod@3.23.8))(zod@3.23.8)
       nuqs:
         specifier: 'catalog:'
-        version: 2.3.0(next@15.1.6(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+        version: 2.4.0(next@15.1.6(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
       p-limit:
         specifier: ^6.1.0
         version: 6.1.0
@@ -5601,13 +5601,13 @@ packages:
     resolution: {integrity: sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  nuqs@2.3.0:
-    resolution: {integrity: sha512-ChS56bJZdaTQzCJb6jPel6cIHYh8/V/GSIjZoIe5yAssGdcrVaBFBgzHfJW6IewbR6yc1Zch2CmGsdgztR+xmA==}
+  nuqs@2.4.0:
+    resolution: {integrity: sha512-+yOdX0q/wdYlseSYtWC8StDDt2QFcYX/zV5/E67J1cOJo3PR0mggxMx4acZGC0Hu66xFHENKQkqI2zSpH742xQ==}
     peerDependencies:
       '@remix-run/react': '>=2'
       next: '>=14.2.0'
       react: '>=18.2.0 || ^19.0.0-0'
-      react-router: ^7
+      react-router: ^6 || ^7
       react-router-dom: ^6 || ^7
     peerDependenciesMeta:
       '@remix-run/react':
@@ -13241,7 +13241,7 @@ snapshots:
 
   npm-normalize-package-bin@4.0.0: {}
 
-  nuqs@2.3.0(next@15.1.6(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0):
+  nuqs@2.4.0(next@15.1.6(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0):
     dependencies:
       mitt: 3.0.1
       react: 19.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,8 +175,8 @@ importers:
         specifier: ^4.0.6
         version: 4.0.6
       '@tanstack/react-table':
-        specifier: ^8.20.5
-        version: 8.20.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: ^8.21.2
+        version: 8.21.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tremor/react':
         specifier: 4.0.0-beta-tremor-v4.4
         version: 4.0.0-beta-tremor-v4.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwindcss@4.0.6)
@@ -2364,8 +2364,8 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
-  '@tanstack/react-table@8.20.5':
-    resolution: {integrity: sha512-WEHopKw3znbUZ61s9i0+i9g8drmDo6asTWbrQh8Us63DAk/M0FkmIqERew6P71HI75ksZ2Pxyuf4vvKh9rAkiA==}
+  '@tanstack/react-table@8.21.2':
+    resolution: {integrity: sha512-11tNlEDTdIhMJba2RBH+ecJ9l1zgS2kjmexDPAraulc8jeNA4xocSNeyzextT0XJyASil4XsCYlJmf5jEWAtYg==}
     engines: {node: '>=12'}
     peerDependencies:
       react: '>=16.8'
@@ -2377,8 +2377,8 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/table-core@8.20.5':
-    resolution: {integrity: sha512-P9dF7XbibHph2PFRz8gfBKEXEY/HJPOhym8CHmjF8y3q5mWpKx9xtZapXQUWCgkqvsK0R46Azuz+VaxD4Xl+Tg==}
+  '@tanstack/table-core@8.21.2':
+    resolution: {integrity: sha512-uvXk/U4cBiFMxt+p9/G7yUWI/UbHYbyghLCjlpWZ3mLeIZiUBSKcUnw9UnKkdRz7Z/N4UBuFLWQdJCjUe7HjvA==}
     engines: {node: '>=12'}
 
   '@tanstack/virtual-core@3.12.0':
@@ -9278,9 +9278,9 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.0.6
 
-  '@tanstack/react-table@8.20.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@tanstack/react-table@8.21.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@tanstack/table-core': 8.20.5
+      '@tanstack/table-core': 8.21.2
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
@@ -9290,7 +9290,7 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  '@tanstack/table-core@8.20.5': {}
+  '@tanstack/table-core@8.21.2': {}
 
   '@tanstack/virtual-core@3.12.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ catalog:
   drizzle-orm: 0.38.3
 
   next: 15.1.6
-  nuqs: 2.3.0
+  nuqs: 2.4.0
   react: 19.0.0
   react-dom: 19.0.0
   "@types/react": 19.0.8


### PR DESCRIPTION
When updating to Nuqs v2 some default options where changed. These default options broke some of the functionality of tables and filters.

**Changes**
- Updated @tanstack/table
- Added shallow false to useQueryState that needs server updates
- Removed nuqs use cache params and changes to createLoader as described in the docs
- Temporary fix for table useSorting hook
- Fixed spinning animations
- Added missing cursor pointer to button, this makes it similar to other navigation buttons
- Added WhyDidYouRender