### PR TITLE
NWD-49 | fix: validatePersonAccessCheck now uses Person.isLinkedToLocation instead of checking actors

### DIFF
--- a/apps/web/src/lib/nwd.ts
+++ b/apps/web/src/lib/nwd.ts
@@ -436,10 +436,9 @@ async function validatePersonAccessCheck({
     .catch(() => false);
 
   const isRequestedPersonAnActivePersonForLocationRequest =
-    isActiveActorTypeInLocation({
-      actorType: ["instructor", "student", "location_admin"],
-      locationId,
+    User.Person.isLinkedToLocation({
       personId: requestedPersonId,
+      locationId,
     });
 
   const [

--- a/packages/core/src/models/user/person.ts
+++ b/packages/core/src/models/user/person.ts
@@ -192,6 +192,31 @@ export const createLocationLink = wrapCommand(
   ),
 );
 
+export const isLinkedToLocation = wrapQuery(
+  "user.person.isLinkedToLocation",
+  withZod(
+    z.object({ personId: uuidSchema, locationId: uuidSchema }),
+    z.boolean(),
+    async (input) => {
+      const query = useQuery();
+
+      const result = await query
+        .select()
+        .from(s.personLocationLink)
+        .where(
+          and(
+            eq(s.personLocationLink.personId, input.personId),
+            eq(s.personLocationLink.locationId, input.locationId),
+            eq(s.personLocationLink.status, "linked"),
+          ),
+        )
+        .then(possibleSingleRow);
+
+      return result !== null;
+    },
+  ),
+);
+
 export const byIdOrHandle = wrapQuery(
   "user.person.byIdOrHandle",
   withZod(


### PR DESCRIPTION
`validatePersonAccessCheck` now uses a new method User.Person.isLinkedToLocation which uses the `personLocationLink` table to check access.

`validatePersonAccessCheck` is used for the following:
- persoon information + certificates + external certificates + logbooks
- roles for location