### PR TITLE
NWD-54 | fix: diploma download not working a second time after router.push, use window.open instead

### DIFF
--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/table-actions.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/table-actions.tsx
@@ -11,7 +11,6 @@ import {
   type InferUseActionHookReturn,
   useAction,
 } from "next-safe-action/hooks";
-import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import {
   Alert,
@@ -448,10 +447,8 @@ function DownloadCertificatesDialog({
 }) {
   const closeDialog = () => {
     close();
-    window.location.reload();
+    reset();
   };
-
-  const router = useRouter();
 
   const { execute, input, reset, result } = useAction(
     downloadCertificatesAction.bind(
@@ -464,7 +461,7 @@ function DownloadCertificatesDialog({
         resetSelection();
         if (result?.data?.redirectUrl) {
           // Automatically start download
-          router.push(result.data.redirectUrl);
+          window.open(result.data.redirectUrl, "_blank");
         }
       },
       onError: () => {
@@ -486,10 +483,10 @@ function DownloadCertificatesDialog({
         <AlertTitle>Diploma's downloaden</AlertTitle>
         {downloadUrl ? (
           <AlertDescription className="space-y-3">
-            <p className="text-green-600 font-medium">
+            <p className="font-medium text-green-600">
               ✓ Download wordt automatisch gestart...
             </p>
-            <p className="text-sm text-gray-600">
+            <p className="text-gray-600 text-sm">
               Werkt de download niet?
               <a
                 href={downloadUrl}

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_components/table-actions.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_components/table-actions.tsx
@@ -6,7 +6,6 @@ import {
 } from "@headlessui/react";
 import { ChevronRightIcon } from "@heroicons/react/16/solid";
 import { useAction } from "next-safe-action/hooks";
-import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useFormStatus } from "react-dom";
 import { toast } from "sonner";
@@ -63,10 +62,8 @@ function DownloadCertificatesDialog({
 }) {
   const closeDialog = () => {
     close();
-    window.location.reload();
+    reset();
   };
-
-  const router = useRouter();
 
   const { execute, input, reset, result } = useAction(
     downloadCertificatesAction.bind(
@@ -78,7 +75,7 @@ function DownloadCertificatesDialog({
         resetSelection();
         if (result?.data?.redirectUrl) {
           // Automatically start download
-          router.push(result.data.redirectUrl);
+          window.open(result.data.redirectUrl, "_blank");
         }
       },
       onError: () => {
@@ -100,10 +97,10 @@ function DownloadCertificatesDialog({
         <AlertTitle>Diploma's downloaden</AlertTitle>
         {downloadUrl ? (
           <AlertDescription className="space-y-3">
-            <p className="text-green-600 font-medium">
+            <p className="font-medium text-green-600">
               ✓ Download wordt automatisch gestart...
             </p>
-            <p className="text-sm text-gray-600">
+            <p className="text-gray-600 text-sm">
               Werkt de download niet?
               <a
                 href={downloadUrl}


### PR DESCRIPTION
### Problem
When downloading bulk diploma's for a second time: 
- The download never starts
- A POST request is made instead of a GET request, resulting in 405

The original code used the `redirect(redirectURL)` in the action, the current code uses `router.push(redirectURL)`
Both have the same problem. The current solution is to perform a window reload

### Findings
The POST request that causes the 405 is the server action that is called the second time, but instead of posting to `/diplomas` or `/cohort/.../diplomas` the post request is made to the redirected url. Some where in Next the redirect url from the previous download is used as the current window location.

### Solution
Instead of redirecting, or pushing on the same tab, open a new tab using `window.open(redirectURL, "_blank")`