### PR TITLE
feat: add eigenvaardigheid overview to instructor page

### DIFF
--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
@@ -35,19 +35,16 @@ export async function EigenvaardigheidOverview({
     );
   }
 
-  const grouped: GroupedByDiscipline[] = certificates.reduce(
-    (acc, cert) => {
-      const courseTitle = cert.program.course.title;
-      let group = acc.find((g) => g.courseTitle === courseTitle);
-      if (!group) {
-        group = { courseTitle, certificates: [] };
-        acc.push(group);
-      }
-      group.certificates.push(cert);
-      return acc;
-    },
-    [] as GroupedByDiscipline[],
-  );
+  const grouped: GroupedByDiscipline[] = certificates.reduce((acc, cert) => {
+    const courseTitle = cert.program.course.title;
+    let group = acc.find((g) => g.courseTitle === courseTitle);
+    if (!group) {
+      group = { courseTitle, certificates: [] };
+      acc.push(group);
+    }
+    group.certificates.push(cert);
+    return acc;
+  }, [] as GroupedByDiscipline[]);
 
   return (
     <div className="mt-8">

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
@@ -1,0 +1,117 @@
+import dayjs from "~/lib/dayjs";
+import { listCertificatesForPersonAsAdmin } from "~/lib/nwd";
+
+type Certificate = Awaited<
+  ReturnType<typeof listCertificatesForPersonAsAdmin>
+>[number];
+
+interface GroupedByDiscipline {
+  courseTitle: string;
+  certificates: Certificate[];
+}
+
+export async function EigenvaardigheidOverview({
+  personId,
+}: {
+  personId: string;
+}) {
+  const certificates = await listCertificatesForPersonAsAdmin(personId);
+
+  if (certificates.length === 0) {
+    return (
+      <div className="mt-8">
+        <div className="mb-6">
+          <h3 className="text-lg leading-6 font-medium text-gray-900 dark:text-white">
+            Eigenvaardigheid
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Behaalde NWD-diploma&apos;s van deze persoon
+          </p>
+        </div>
+        <p className="text-sm text-gray-500 dark:text-gray-400 italic">
+          Geen NWD-diploma&apos;s gevonden.
+        </p>
+      </div>
+    );
+  }
+
+  const grouped: GroupedByDiscipline[] = certificates.reduce(
+    (acc, cert) => {
+      const courseTitle = cert.program.course.title;
+      let group = acc.find((g) => g.courseTitle === courseTitle);
+      if (!group) {
+        group = { courseTitle, certificates: [] };
+        acc.push(group);
+      }
+      group.certificates.push(cert);
+      return acc;
+    },
+    [] as GroupedByDiscipline[],
+  );
+
+  return (
+    <div className="mt-8">
+      <div className="mb-6">
+        <h3 className="text-lg leading-6 font-medium text-gray-900 dark:text-white">
+          Eigenvaardigheid
+        </h3>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Behaalde NWD-diploma&apos;s van deze persoon
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        {grouped.map((group) => (
+          <div
+            key={group.courseTitle}
+            className="bg-white dark:bg-gray-800 shadow overflow-hidden sm:rounded-lg"
+          >
+            <div className="px-4 py-5 sm:px-6">
+              <h4 className="text-base font-medium text-gray-900 dark:text-white capitalize">
+                {group.courseTitle}
+              </h4>
+            </div>
+            <div className="border-t border-gray-200 dark:border-gray-700">
+              <table className="min-w-full">
+                <thead className="bg-gray-50 dark:bg-gray-700">
+                  <tr>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Niveau
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Vaartuig
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Behaald op
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Locatie
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                  {group.certificates.map((cert) => (
+                    <tr key={cert.id}>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                        {cert.program.degree.title}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                        {cert.gearType.title}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                        {dayjs(cert.issuedAt).format("DD-MM-YYYY")}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                        {cert.location.name}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
@@ -6,7 +6,7 @@ type Certificate = Awaited<
 >[number];
 
 interface GroupedByDiscipline {
-  courseTitle: string;
+  disciplineTitle: string;
   certificates: Certificate[];
 }
 
@@ -36,10 +36,10 @@ export async function EigenvaardigheidOverview({
   }
 
   const grouped: GroupedByDiscipline[] = certificates.reduce((acc, cert) => {
-    const courseTitle = cert.program.course.title;
-    let group = acc.find((g) => g.courseTitle === courseTitle);
+    const disciplineTitle = cert.program.course.discipline.title;
+    let group = acc.find((g) => g.disciplineTitle === disciplineTitle);
     if (!group) {
-      group = { courseTitle, certificates: [] };
+      group = { disciplineTitle, certificates: [] };
       acc.push(group);
     }
     group.certificates.push(cert);
@@ -60,12 +60,12 @@ export async function EigenvaardigheidOverview({
       <div className="space-y-4">
         {grouped.map((group) => (
           <div
-            key={group.courseTitle}
+            key={group.disciplineTitle}
             className="bg-white dark:bg-gray-800 shadow overflow-hidden sm:rounded-lg"
           >
             <div className="px-4 py-5 sm:px-6">
               <h4 className="text-base font-medium text-gray-900 dark:text-white capitalize">
-                {group.courseTitle}
+                {group.disciplineTitle}
               </h4>
             </div>
             <div className="border-t border-gray-200 dark:border-gray-700">

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
@@ -36,7 +36,7 @@ export async function EigenvaardigheidOverview({
   }
 
   const grouped: GroupedByDiscipline[] = certificates.reduce((acc, cert) => {
-    const disciplineTitle = cert.program.course.discipline.title;
+    const disciplineTitle = cert.program.course.discipline.title ?? "Onbekend";
     let group = acc.find((g) => g.disciplineTitle === disciplineTitle);
     if (!group) {
       group = { disciplineTitle, certificates: [] };

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
@@ -15,7 +15,10 @@ export async function EigenvaardigheidOverview({
 }: {
   personId: string;
 }) {
-  const certificates = await listCertificatesForPersonAsAdmin(personId);
+  const allCertificates = await listCertificatesForPersonAsAdmin(personId);
+  const certificates = allCertificates.filter(
+    (cert) => cert.program.degree.rang >= 5,
+  );
 
   if (certificates.length === 0) {
     return (

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/page.tsx
@@ -42,7 +42,13 @@ async function KwalificatiesContent({
   return (
     <>
       <PersonInfo person={person} />
-      <Suspense fallback={<div className="mt-8 text-sm text-gray-500">Eigenvaardigheid laden...</div>}>
+      <Suspense
+        fallback={
+          <div className="mt-8 text-sm text-gray-500">
+            Eigenvaardigheid laden...
+          </div>
+        }
+      >
         <EigenvaardigheidOverview personId={person.id} />
       </Suspense>
       <KwalificatiesTable

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/page.tsx
@@ -10,6 +10,7 @@ import { Heading } from "~/app/(dashboard)/_components/heading";
 import { Text } from "~/app/(dashboard)/_components/text";
 import { isSystemAdmin } from "~/lib/authorization";
 import { getUserOrThrow, listCourses } from "~/lib/nwd";
+import { EigenvaardigheidOverview } from "./_components/eigenvaardigheid-overview";
 import KwalificatiesTable from "./_components/kwalificaties-table";
 import { PersonInfo } from "./_components/person-info";
 
@@ -41,6 +42,9 @@ async function KwalificatiesContent({
   return (
     <>
       <PersonInfo person={person} />
+      <Suspense fallback={<div className="mt-8 text-sm text-gray-500">Eigenvaardigheid laden...</div>}>
+        <EigenvaardigheidOverview personId={person.id} />
+      </Suspense>
       <KwalificatiesTable
         personId={person.id}
         detailedKwalificaties={detailedKwalificaties}

--- a/apps/web/src/lib/nwd.ts
+++ b/apps/web/src/lib/nwd.ts
@@ -498,6 +498,25 @@ export const listCertificatesForPerson = cache(
   },
 );
 
+export const listCertificatesForPersonAsAdmin = cache(
+  async (personId: string) => {
+    return makeRequest(async () => {
+      const requestingUser = await getUserOrThrow();
+      const { isSystemAdmin } = await import("~/lib/authorization");
+
+      if (!isSystemAdmin(requestingUser.email)) {
+        throw new Error("Unauthorized");
+      }
+
+      const certificates = await Certificate.list({
+        filter: { personId },
+      });
+
+      return certificates.items;
+    });
+  },
+);
+
 export const listExternalCertificatesForPerson = cache(
   async (personId: string, locationId?: string) => {
     return makeRequest(async () => {


### PR DESCRIPTION
## Summary
- Show NWD sailing diplomas (Niveau A/B/C per discipline) on the secretariaat instructor detail page, between the person info and the kwalificaties table
- Adds `listCertificatesForPersonAsAdmin` for system-admin access to certificates without requiring a locationId
- Groups certificates by discipline and displays them in a table consistent with the existing `KwalificatiesTable` styling

## Test plan
- [ ] Navigate to Secretariaat > Instructeur > [person] and verify the Eigenvaardigheid section appears between person info and kwalificaties
- [ ] Verify certificates are grouped by discipline (e.g. Zwaardboot, Catamaran)
- [ ] Verify each group shows Niveau, Vaartuig, Behaald op, and Locatie columns
- [ ] Verify a non-system-admin cannot access the data (authorization check)
- [ ] Verify the 'Geen eigenvaardigheid gevonden' message shows for persons without certificates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new certificate read path without `respectVisibility`, limited to system admins on a page that is already admin-only; scope is small but touches sensitive qualification data.
> 
> **Overview**
> Adds an **Eigenvaardigheid** block on the secretariaat instructor detail page (between person info and kwalificaties), loaded in its own `Suspense` boundary with a Dutch loading state.
> 
> The section uses a new **`listCertificatesForPersonAsAdmin`** helper that lists a person’s NWD certificates for **system admins only** (no `locationId`, unlike `listCertificatesForPerson`). The UI keeps diplomas with **`program.degree.rang >= 5`**, groups them by discipline, and shows niveau, vaartuig, issue date, and locatie in tables aligned with existing kwalificaties styling, with an empty state when none match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ab237b03c277288eb1a276259c2579837f3ca30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Eigenvaardigheid" overview to the instructor management page.
  * Displays NWD certificates grouped by discipline, showing degree level, vessel/gear type, issue date (DD-MM-YYYY) and location.
  * Only shows higher-level NWD diplomas (degree level 5 and up) and includes loading and empty-state messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->