### PR TITLE
feat: add vaarlocaties page to secretariaat

### DIFF
--- a/apps/web/src/app/(dashboard)/(management)/@sidebar/secretariaat/_components/sidebar-menu.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/@sidebar/secretariaat/_components/sidebar-menu.tsx
@@ -102,7 +102,7 @@ export function SecretariaatSidebarMenu() {
           {
             name: "Overzicht",
             href: "/secretariaat/locaties",
-            current: lastSegment === "cohorten",
+            current: lastSegment === "locaties",
           },
         ].map((item) => (
           <SidebarItem key={item.name} href={item.href} current={item.current}>

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/gebruikers/_components/merge-persons-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/gebruikers/_components/merge-persons-dialog.tsx
@@ -1,12 +1,9 @@
 "use client";
 
-import * as Headless from "@headlessui/react";
 import {
   ArrowsRightLeftIcon,
   ExclamationTriangleIcon,
 } from "@heroicons/react/20/solid";
-import type { User } from "@nawadi/core";
-import clsx from "clsx";
 import { useAction } from "next-safe-action/hooks";
 import { parseAsBoolean, parseAsString, useQueryState } from "nuqs";
 import { useCallback, useEffect, useState } from "react";
@@ -27,12 +24,9 @@ import {
   DialogTitle,
 } from "~/app/(dashboard)/_components/dialog";
 import { Field, Fieldset, Label } from "~/app/(dashboard)/_components/fieldset";
+import { PersonSearchCombobox } from "~/app/(dashboard)/_components/person-search-combobox";
 import { Code } from "~/app/(dashboard)/_components/text";
 import { usePersonSearch } from "~/app/(dashboard)/_hooks/swr/use-person-search";
-
-type SearchPerson = Awaited<
-  ReturnType<typeof User.Person.searchForAutocomplete>
->[number];
 
 type PreflightData = NonNullable<
   Awaited<ReturnType<typeof getMergePreflightAction>>["data"]
@@ -41,171 +35,6 @@ type PreflightData = NonNullable<
 type PersonData = NonNullable<
   Awaited<ReturnType<typeof getPersonByIdAction>>["data"]
 >;
-
-// --- Combobox CSS (reused from the wrapper component) ---
-
-const controlClasses = clsx(
-  "relative block w-full",
-  "before:absolute before:inset-px before:rounded-[calc(var(--radius-lg)-1px)] before:bg-white before:shadow-sm",
-  "dark:before:hidden",
-  "after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:ring-transparent after:ring-inset sm:focus-within:after:ring-2 sm:focus-within:after:ring-blue-500",
-  "has-data-disabled:opacity-50 has-data-disabled:before:bg-zinc-950/5 has-data-disabled:before:shadow-none",
-  "has-data-invalid:before:shadow-red-500/10",
-);
-
-const inputClasses = clsx(
-  "relative block w-full appearance-none rounded-lg py-[calc(--spacing(2.5)-1px)] sm:py-[calc(--spacing(1.5)-1px)]",
-  "pr-[calc(--spacing(10)-1px)] pl-[calc(--spacing(3.5)-1px)] sm:pr-[calc(--spacing(9)-1px)] sm:pl-[calc(--spacing(3)-1px)]",
-  "text-base/6 text-zinc-950 placeholder:text-zinc-500 sm:text-sm/6 dark:text-white",
-  "border border-zinc-950/10 data-hover:border-zinc-950/20 dark:border-white/10 dark:data-hover:border-white/20",
-  "bg-transparent dark:bg-white/5",
-  "focus:outline-hidden",
-  "data-invalid:border-red-500 data-invalid:data-hover:border-red-500 dark:data-invalid:border-red-500 dark:data-invalid:data-hover:border-red-500",
-  "data-disabled:border-zinc-950/20 dark:data-disabled:border-white/15 dark:data-disabled:bg-white/[2.5%] dark:data-hover:data-disabled:border-white/15",
-  "dark:scheme-dark",
-);
-
-const optionsClasses = clsx(
-  "[--anchor-gap:--spacing(2)] [--anchor-padding:--spacing(4)] sm:data-[anchor~=start]:[--anchor-offset:-4px]",
-  "isolate min-w-[calc(var(--input-width)+8px)] scroll-py-1 rounded-xl p-1 select-none empty:invisible",
-  "outline outline-transparent focus:outline-hidden",
-  "overflow-y-scroll overscroll-contain",
-  "bg-white/75 backdrop-blur-xl dark:bg-zinc-800/75",
-  "shadow-lg ring-1 ring-zinc-950/10 dark:ring-white/10 dark:ring-inset",
-  "transition-opacity duration-100 ease-in data-closed:data-leave:opacity-0 data-transition:pointer-events-none",
-);
-
-const optionClasses = clsx(
-  "group/option grid w-full cursor-default grid-cols-[1fr_--spacing(5)] items-baseline gap-x-2 rounded-lg py-2.5 pr-2 pl-3.5 sm:grid-cols-[1fr_--spacing(4)] sm:py-1.5 sm:pr-2 sm:pl-3",
-  "text-base/6 text-zinc-950 sm:text-sm/6 dark:text-white forced-colors:text-[CanvasText]",
-  "outline-hidden data-focus:bg-blue-500 data-focus:text-white",
-  "forced-color-adjust-none forced-colors:data-focus:bg-[Highlight] forced-colors:data-focus:text-[HighlightText]",
-  "data-disabled:opacity-50",
-);
-
-// --- PersonSearchCombobox ---
-
-function PersonSearchCombobox({
-  selectedPersonName,
-  onSelect,
-  label,
-  isSearching,
-  results,
-  query,
-  debouncedQuery,
-  onQueryChange,
-}: {
-  selectedPersonName: string | null;
-  onSelect: (person: SearchPerson) => void;
-  label: string;
-  isSearching: boolean;
-  results: SearchPerson[];
-  query: string;
-  debouncedQuery: string | null;
-  onQueryChange: (query: string) => void;
-}) {
-  const isTyping = query.length > 0;
-
-  return (
-    <Headless.Combobox
-      immediate
-      onChange={(person: SearchPerson | null) => {
-        if (person) {
-          onSelect(person);
-        }
-        onQueryChange("");
-      }}
-      onClose={() => onQueryChange("")}
-    >
-      <span data-slot="control" className={controlClasses}>
-        <Headless.ComboboxInput
-          aria-label={label}
-          data-slot="control"
-          value={isTyping ? query : (selectedPersonName ?? "")}
-          onChange={(event) => {
-            onQueryChange(event.target.value);
-          }}
-          placeholder="Typ om te zoeken…"
-          autoComplete="off"
-          spellCheck={false}
-          className={inputClasses}
-        />
-        <Headless.ComboboxButton
-          className="group right-0 absolute inset-y-0 flex items-center px-2"
-          aria-label="Opties tonen"
-        >
-          <svg
-            className="stroke-zinc-500 dark:group-data-hover:stroke-zinc-300 dark:stroke-zinc-400 forced-colors:stroke-[CanvasText] group-data-disabled:stroke-zinc-600 group-data-hover:stroke-zinc-700 size-5 sm:size-4"
-            viewBox="0 0 16 16"
-            aria-hidden="true"
-            fill="none"
-          >
-            <path
-              d="M5.75 10.75L8 13L10.25 10.75"
-              strokeWidth={1.5}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-            <path
-              d="M10.25 5.25L8 3L5.75 5.25"
-              strokeWidth={1.5}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </Headless.ComboboxButton>
-      </span>
-      <Headless.ComboboxOptions
-        transition
-        anchor="bottom"
-        className={optionsClasses}
-      >
-        {isSearching && (
-          <div
-            className="flex items-center gap-2 px-3.5 py-2 text-sm text-zinc-500"
-            aria-live="polite"
-          >
-            <Spinner className="h-3 w-3" aria-hidden="true" /> Zoeken…
-          </div>
-        )}
-        {!isSearching && debouncedQuery && results.length === 0 && (
-          <div className="px-3.5 py-2 text-sm text-zinc-500" aria-live="polite">
-            Geen personen gevonden
-          </div>
-        )}
-        {results.map((person) => {
-          const name = [
-            person.firstName,
-            person.lastNamePrefix,
-            person.lastName,
-          ]
-            .filter(Boolean)
-            .join(" ");
-          return (
-            <Headless.ComboboxOption
-              key={person.id}
-              value={person}
-              className={optionClasses}
-            >
-              <span className="flex min-w-0 flex-col">
-                <span className="ml-2.5 truncate first:ml-0 sm:ml-2 sm:first:ml-0">
-                  {name}
-                </span>
-                <span className="flex flex-1 overflow-hidden text-zinc-500 group-data-focus/option:text-white before:w-2 before:min-w-0 before:shrink dark:text-zinc-400">
-                  <span className="flex-1 truncate">
-                    {person.email ?? "Geen e-mail"} · {person.handle}
-                    {person.dateOfBirth &&
-                      ` · Geb. ${new Intl.DateTimeFormat("nl-NL", { day: "numeric", month: "long", year: "numeric" }).format(new Date(person.dateOfBirth))}`}
-                  </span>
-                </span>
-              </span>
-            </Headless.ComboboxOption>
-          );
-        })}
-      </Headless.ComboboxOptions>
-    </Headless.Combobox>
-  );
-}
 
 // --- PersonPreviewCard ---
 

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
@@ -1,21 +1,17 @@
 "use client";
 
-import * as Headless from "@headlessui/react";
 import { EllipsisHorizontalIcon } from "@heroicons/react/20/solid";
-import type { User } from "@nawadi/core";
 import {
   createColumnHelper,
   getCoreRowModel,
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import clsx from "clsx";
 import { useAction } from "next-safe-action/hooks";
 import { useState } from "react";
 import { toast } from "sonner";
 import { addLocationAdminAsSystemAdminAction } from "~/app/_actions/location/add-location-admin-action";
 import { DEFAULT_SERVER_ERROR_MESSAGE } from "~/app/_actions/utils";
-import Spinner from "~/app/_components/spinner";
 import {
   Alert,
   AlertActions,
@@ -31,6 +27,10 @@ import {
   DropdownMenu,
 } from "~/app/(dashboard)/_components/dropdown";
 import { Field, Fieldset, Label } from "~/app/(dashboard)/_components/fieldset";
+import {
+  PersonSearchCombobox,
+  type SearchPerson,
+} from "~/app/(dashboard)/_components/person-search-combobox";
 import { Table, TableBody } from "~/app/(dashboard)/_components/table";
 import {
   DefaultTableCell,
@@ -49,170 +49,6 @@ import { usePersonSearch } from "~/app/(dashboard)/_hooks/swr/use-person-search"
 import type { listAllLocationsAsAdmin } from "~/lib/nwd";
 
 type Location = Awaited<ReturnType<typeof listAllLocationsAsAdmin>>[number];
-type SearchPerson = Awaited<
-  ReturnType<typeof User.Person.searchForAutocomplete>
->[number];
-
-const controlClasses = clsx(
-  "relative block w-full",
-  "before:absolute before:inset-px before:rounded-[calc(var(--radius-lg)-1px)] before:bg-white before:shadow-sm",
-  "dark:before:hidden",
-  "after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:ring-transparent after:ring-inset sm:focus-within:after:ring-2 sm:focus-within:after:ring-blue-500",
-  "has-data-disabled:opacity-50 has-data-disabled:before:bg-zinc-950/5 has-data-disabled:before:shadow-none",
-  "has-data-invalid:before:shadow-red-500/10",
-);
-
-const inputClasses = clsx(
-  "relative block w-full appearance-none rounded-lg py-[calc(--spacing(2.5)-1px)] sm:py-[calc(--spacing(1.5)-1px)]",
-  "pr-[calc(--spacing(10)-1px)] pl-[calc(--spacing(3.5)-1px)] sm:pr-[calc(--spacing(9)-1px)] sm:pl-[calc(--spacing(3)-1px)]",
-  "text-base/6 text-zinc-950 placeholder:text-zinc-500 sm:text-sm/6 dark:text-white",
-  "border border-zinc-950/10 data-hover:border-zinc-950/20 dark:border-white/10 dark:data-hover:border-white/20",
-  "bg-transparent dark:bg-white/5",
-  "focus:outline-hidden",
-  "data-invalid:border-red-500 data-invalid:data-hover:border-red-500 dark:data-invalid:border-red-500 dark:data-invalid:data-hover:border-red-500",
-  "data-disabled:border-zinc-950/20 dark:data-disabled:border-white/15 dark:data-disabled:bg-white/[2.5%] dark:data-hover:data-disabled:border-white/15",
-  "dark:scheme-dark",
-);
-
-const optionsClasses = clsx(
-  "[--anchor-gap:--spacing(2)] [--anchor-padding:--spacing(4)] sm:data-[anchor~=start]:[--anchor-offset:-4px]",
-  "isolate min-w-[calc(var(--input-width)+8px)] scroll-py-1 rounded-xl p-1 select-none empty:invisible",
-  "outline outline-transparent focus:outline-hidden",
-  "overflow-y-scroll overscroll-contain",
-  "bg-white/75 backdrop-blur-xl dark:bg-zinc-800/75",
-  "shadow-lg ring-1 ring-zinc-950/10 dark:ring-white/10 dark:ring-inset",
-  "transition-opacity duration-100 ease-in data-closed:data-leave:opacity-0 data-transition:pointer-events-none",
-);
-
-const optionClasses = clsx(
-  "group/option grid w-full cursor-default grid-cols-[1fr_--spacing(5)] items-baseline gap-x-2 rounded-lg py-2.5 pr-2 pl-3.5 sm:grid-cols-[1fr_--spacing(4)] sm:py-1.5 sm:pr-2 sm:pl-3",
-  "text-base/6 text-zinc-950 sm:text-sm/6 dark:text-white forced-colors:text-[CanvasText]",
-  "outline-hidden data-focus:bg-blue-500 data-focus:text-white",
-  "forced-color-adjust-none forced-colors:data-focus:bg-[Highlight] forced-colors:data-focus:text-[HighlightText]",
-  "data-disabled:opacity-50",
-);
-
-function PersonSearchCombobox({
-  selectedPersonName,
-  onSelect,
-  label,
-  isSearching,
-  results,
-  query,
-  debouncedQuery,
-  onQueryChange,
-}: {
-  selectedPersonName: string | null;
-  onSelect: (person: SearchPerson) => void;
-  label: string;
-  isSearching: boolean;
-  results: SearchPerson[];
-  query: string;
-  debouncedQuery: string | null;
-  onQueryChange: (query: string) => void;
-}) {
-  const isTyping = query.length > 0;
-
-  return (
-    <Headless.Combobox
-      immediate
-      onChange={(person: SearchPerson | null) => {
-        if (person) {
-          onSelect(person);
-        }
-        onQueryChange("");
-      }}
-      onClose={() => onQueryChange("")}
-    >
-      <span data-slot="control" className={controlClasses}>
-        <Headless.ComboboxInput
-          aria-label={label}
-          data-slot="control"
-          value={isTyping ? query : (selectedPersonName ?? "")}
-          onChange={(event) => {
-            onQueryChange(event.target.value);
-          }}
-          placeholder="Typ om te zoeken…"
-          autoComplete="off"
-          spellCheck={false}
-          className={inputClasses}
-        />
-        <Headless.ComboboxButton
-          className="group right-0 absolute inset-y-0 flex items-center px-2"
-          aria-label="Opties tonen"
-        >
-          <svg
-            className="stroke-zinc-500 dark:group-data-hover:stroke-zinc-300 dark:stroke-zinc-400 forced-colors:stroke-[CanvasText] group-data-disabled:stroke-zinc-600 group-data-hover:stroke-zinc-700 size-5 sm:size-4"
-            viewBox="0 0 16 16"
-            aria-hidden="true"
-            fill="none"
-          >
-            <path
-              d="M5.75 10.75L8 13L10.25 10.75"
-              strokeWidth={1.5}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-            <path
-              d="M10.25 5.25L8 3L5.75 5.25"
-              strokeWidth={1.5}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </Headless.ComboboxButton>
-      </span>
-      <Headless.ComboboxOptions
-        transition
-        anchor="bottom"
-        className={optionsClasses}
-      >
-        {isSearching && (
-          <div
-            className="flex items-center gap-2 px-3.5 py-2 text-sm text-zinc-500"
-            aria-live="polite"
-          >
-            <Spinner className="h-3 w-3" aria-hidden="true" /> Zoeken…
-          </div>
-        )}
-        {!isSearching && debouncedQuery && results.length === 0 && (
-          <div className="px-3.5 py-2 text-sm text-zinc-500" aria-live="polite">
-            Geen personen gevonden
-          </div>
-        )}
-        {results.map((person) => {
-          const name = [
-            person.firstName,
-            person.lastNamePrefix,
-            person.lastName,
-          ]
-            .filter(Boolean)
-            .join(" ");
-          return (
-            <Headless.ComboboxOption
-              key={person.id}
-              value={person}
-              className={optionClasses}
-            >
-              <span className="flex min-w-0 flex-col">
-                <span className="ml-2.5 truncate first:ml-0 sm:ml-2 sm:first:ml-0">
-                  {name}
-                </span>
-                <span className="flex flex-1 overflow-hidden text-zinc-500 group-data-focus/option:text-white before:w-2 before:min-w-0 before:shrink dark:text-zinc-400">
-                  <span className="flex-1 truncate">
-                    {person.email ?? "Geen e-mail"} · {person.handle}
-                    {person.dateOfBirth &&
-                      ` · Geb. ${new Intl.DateTimeFormat("nl-NL", { day: "numeric", month: "long", year: "numeric" }).format(new Date(person.dateOfBirth))}`}
-                  </span>
-                </span>
-              </span>
-            </Headless.ComboboxOption>
-          );
-        })}
-      </Headless.ComboboxOptions>
-    </Headless.Combobox>
-  );
-}
 
 const columnHelper = createColumnHelper<Location>();
 

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
@@ -3,13 +3,13 @@
 import * as Headless from "@headlessui/react";
 import { EllipsisHorizontalIcon } from "@heroicons/react/20/solid";
 import type { User } from "@nawadi/core";
-import clsx from "clsx";
 import {
   createColumnHelper,
   getCoreRowModel,
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
+import clsx from "clsx";
 import { useAction } from "next-safe-action/hooks";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -323,7 +323,10 @@ function RowActions({ location }: { location: Location }) {
             disabled={!selectedPersonId}
             onClick={() => {
               if (selectedPersonId) {
-                execute({ locationId: location.id, personId: selectedPersonId });
+                execute({
+                  locationId: location.id,
+                  personId: selectedPersonId,
+                });
               }
             }}
           >

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+import * as Headless from "@headlessui/react";
+import { EllipsisHorizontalIcon } from "@heroicons/react/20/solid";
+import type { User } from "@nawadi/core";
+import clsx from "clsx";
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { useAction } from "next-safe-action/hooks";
+import { useState } from "react";
+import { toast } from "sonner";
+import { addLocationAdminAsSystemAdminAction } from "~/app/_actions/location/add-location-admin-action";
+import { DEFAULT_SERVER_ERROR_MESSAGE } from "~/app/_actions/utils";
+import Spinner from "~/app/_components/spinner";
+import {
+  Alert,
+  AlertActions,
+  AlertBody,
+  AlertDescription,
+  AlertTitle,
+} from "~/app/(dashboard)/_components/alert";
+import { Button } from "~/app/(dashboard)/_components/button";
+import {
+  Dropdown,
+  DropdownButton,
+  DropdownItem,
+  DropdownMenu,
+} from "~/app/(dashboard)/_components/dropdown";
+import { Field, Fieldset, Label } from "~/app/(dashboard)/_components/fieldset";
+import { Table, TableBody } from "~/app/(dashboard)/_components/table";
+import {
+  DefaultTableCell,
+  DefaultTableRows,
+  NoTableRows,
+  PlaceholderTableRows,
+} from "~/app/(dashboard)/_components/table-content";
+import {
+  TableFooter,
+  TablePagination,
+  TableRowSelection,
+} from "~/app/(dashboard)/_components/table-footer";
+import { DefaultTableHead } from "~/app/(dashboard)/_components/table-head";
+import { Code } from "~/app/(dashboard)/_components/text";
+import { usePersonSearch } from "~/app/(dashboard)/_hooks/swr/use-person-search";
+import type { listAllLocationsAsAdmin } from "~/lib/nwd";
+
+type Location = Awaited<ReturnType<typeof listAllLocationsAsAdmin>>[number];
+type SearchPerson = Awaited<
+  ReturnType<typeof User.Person.searchForAutocomplete>
+>[number];
+
+const controlClasses = clsx(
+  "relative block w-full",
+  "before:absolute before:inset-px before:rounded-[calc(var(--radius-lg)-1px)] before:bg-white before:shadow-sm",
+  "dark:before:hidden",
+  "after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:ring-transparent after:ring-inset sm:focus-within:after:ring-2 sm:focus-within:after:ring-blue-500",
+  "has-data-disabled:opacity-50 has-data-disabled:before:bg-zinc-950/5 has-data-disabled:before:shadow-none",
+  "has-data-invalid:before:shadow-red-500/10",
+);
+
+const inputClasses = clsx(
+  "relative block w-full appearance-none rounded-lg py-[calc(--spacing(2.5)-1px)] sm:py-[calc(--spacing(1.5)-1px)]",
+  "pr-[calc(--spacing(10)-1px)] pl-[calc(--spacing(3.5)-1px)] sm:pr-[calc(--spacing(9)-1px)] sm:pl-[calc(--spacing(3)-1px)]",
+  "text-base/6 text-zinc-950 placeholder:text-zinc-500 sm:text-sm/6 dark:text-white",
+  "border border-zinc-950/10 data-hover:border-zinc-950/20 dark:border-white/10 dark:data-hover:border-white/20",
+  "bg-transparent dark:bg-white/5",
+  "focus:outline-hidden",
+  "data-invalid:border-red-500 data-invalid:data-hover:border-red-500 dark:data-invalid:border-red-500 dark:data-invalid:data-hover:border-red-500",
+  "data-disabled:border-zinc-950/20 dark:data-disabled:border-white/15 dark:data-disabled:bg-white/[2.5%] dark:data-hover:data-disabled:border-white/15",
+  "dark:scheme-dark",
+);
+
+const optionsClasses = clsx(
+  "[--anchor-gap:--spacing(2)] [--anchor-padding:--spacing(4)] sm:data-[anchor~=start]:[--anchor-offset:-4px]",
+  "isolate min-w-[calc(var(--input-width)+8px)] scroll-py-1 rounded-xl p-1 select-none empty:invisible",
+  "outline outline-transparent focus:outline-hidden",
+  "overflow-y-scroll overscroll-contain",
+  "bg-white/75 backdrop-blur-xl dark:bg-zinc-800/75",
+  "shadow-lg ring-1 ring-zinc-950/10 dark:ring-white/10 dark:ring-inset",
+  "transition-opacity duration-100 ease-in data-closed:data-leave:opacity-0 data-transition:pointer-events-none",
+);
+
+const optionClasses = clsx(
+  "group/option grid w-full cursor-default grid-cols-[1fr_--spacing(5)] items-baseline gap-x-2 rounded-lg py-2.5 pr-2 pl-3.5 sm:grid-cols-[1fr_--spacing(4)] sm:py-1.5 sm:pr-2 sm:pl-3",
+  "text-base/6 text-zinc-950 sm:text-sm/6 dark:text-white forced-colors:text-[CanvasText]",
+  "outline-hidden data-focus:bg-blue-500 data-focus:text-white",
+  "forced-color-adjust-none forced-colors:data-focus:bg-[Highlight] forced-colors:data-focus:text-[HighlightText]",
+  "data-disabled:opacity-50",
+);
+
+function PersonSearchCombobox({
+  selectedPersonName,
+  onSelect,
+  label,
+  isSearching,
+  results,
+  query,
+  debouncedQuery,
+  onQueryChange,
+}: {
+  selectedPersonName: string | null;
+  onSelect: (person: SearchPerson) => void;
+  label: string;
+  isSearching: boolean;
+  results: SearchPerson[];
+  query: string;
+  debouncedQuery: string | null;
+  onQueryChange: (query: string) => void;
+}) {
+  const isTyping = query.length > 0;
+
+  return (
+    <Headless.Combobox
+      immediate
+      onChange={(person: SearchPerson | null) => {
+        if (person) {
+          onSelect(person);
+        }
+        onQueryChange("");
+      }}
+      onClose={() => onQueryChange("")}
+    >
+      <span data-slot="control" className={controlClasses}>
+        <Headless.ComboboxInput
+          aria-label={label}
+          data-slot="control"
+          value={isTyping ? query : (selectedPersonName ?? "")}
+          onChange={(event) => {
+            onQueryChange(event.target.value);
+          }}
+          placeholder="Typ om te zoeken…"
+          autoComplete="off"
+          spellCheck={false}
+          className={inputClasses}
+        />
+        <Headless.ComboboxButton
+          className="group right-0 absolute inset-y-0 flex items-center px-2"
+          aria-label="Opties tonen"
+        >
+          <svg
+            className="stroke-zinc-500 dark:group-data-hover:stroke-zinc-300 dark:stroke-zinc-400 forced-colors:stroke-[CanvasText] group-data-disabled:stroke-zinc-600 group-data-hover:stroke-zinc-700 size-5 sm:size-4"
+            viewBox="0 0 16 16"
+            aria-hidden="true"
+            fill="none"
+          >
+            <path
+              d="M5.75 10.75L8 13L10.25 10.75"
+              strokeWidth={1.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M10.25 5.25L8 3L5.75 5.25"
+              strokeWidth={1.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </Headless.ComboboxButton>
+      </span>
+      <Headless.ComboboxOptions
+        transition
+        anchor="bottom"
+        className={optionsClasses}
+      >
+        {isSearching && (
+          <div
+            className="flex items-center gap-2 px-3.5 py-2 text-sm text-zinc-500"
+            aria-live="polite"
+          >
+            <Spinner className="h-3 w-3" aria-hidden="true" /> Zoeken…
+          </div>
+        )}
+        {!isSearching && debouncedQuery && results.length === 0 && (
+          <div className="px-3.5 py-2 text-sm text-zinc-500" aria-live="polite">
+            Geen personen gevonden
+          </div>
+        )}
+        {results.map((person) => {
+          const name = [
+            person.firstName,
+            person.lastNamePrefix,
+            person.lastName,
+          ]
+            .filter(Boolean)
+            .join(" ");
+          return (
+            <Headless.ComboboxOption
+              key={person.id}
+              value={person}
+              className={optionClasses}
+            >
+              <span className="flex min-w-0 flex-col">
+                <span className="ml-2.5 truncate first:ml-0 sm:ml-2 sm:first:ml-0">
+                  {name}
+                </span>
+                <span className="flex flex-1 overflow-hidden text-zinc-500 group-data-focus/option:text-white before:w-2 before:min-w-0 before:shrink dark:text-zinc-400">
+                  <span className="flex-1 truncate">
+                    {person.email ?? "Geen e-mail"} · {person.handle}
+                    {person.dateOfBirth &&
+                      ` · Geb. ${new Intl.DateTimeFormat("nl-NL", { day: "numeric", month: "long", year: "numeric" }).format(new Date(person.dateOfBirth))}`}
+                  </span>
+                </span>
+              </span>
+            </Headless.ComboboxOption>
+          );
+        })}
+      </Headless.ComboboxOptions>
+    </Headless.Combobox>
+  );
+}
+
+const columnHelper = createColumnHelper<Location>();
+
+const columns = [
+  columnHelper.accessor("name", {
+    header: "Naam",
+    cell: ({ getValue }) => (
+      <div className="min-w-0">
+        <span className="truncate font-medium text-zinc-900 dark:text-white">
+          {getValue() ?? "-"}
+        </span>
+      </div>
+    ),
+  }),
+  columnHelper.accessor("handle", {
+    header: "Handle",
+    cell: ({ getValue }) => <Code>{getValue()}</Code>,
+  }),
+  columnHelper.display({
+    id: "actions",
+    header: "",
+    cell: ({ row }) => <RowActions location={row.original} />,
+  }),
+];
+
+function RowActions({ location }: { location: Location }) {
+  const [isAdminDialogOpen, setIsAdminDialogOpen] = useState(false);
+  const [selectedPersonId, setSelectedPersonId] = useState<string | null>(null);
+  const [selectedPersonName, setSelectedPersonName] = useState<string | null>(
+    null,
+  );
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const {
+    data: searchResults,
+    debouncedQuery,
+    isLoading: isSearching,
+  } = usePersonSearch(searchQuery);
+
+  const { execute, reset } = useAction(addLocationAdminAsSystemAdminAction, {
+    onSuccess: () => {
+      toast.success("Locatiebeheerder toegevoegd.");
+      closeAdminDialog();
+    },
+    onError: ({ error }) => {
+      toast.error(error.serverError ?? DEFAULT_SERVER_ERROR_MESSAGE);
+    },
+  });
+
+  const closeAdminDialog = () => {
+    setIsAdminDialogOpen(false);
+    setSelectedPersonId(null);
+    setSelectedPersonName(null);
+    setSearchQuery("");
+    reset();
+  };
+
+  const handleSelectPerson = (person: SearchPerson) => {
+    setSelectedPersonId(person.id);
+    const name = [person.firstName, person.lastNamePrefix, person.lastName]
+      .filter(Boolean)
+      .join(" ");
+    setSelectedPersonName(name);
+  };
+
+  return (
+    <div className="flex justify-end">
+      <Dropdown>
+        <DropdownButton plain aria-label="Acties">
+          <EllipsisHorizontalIcon className="h-5 w-5" aria-hidden="true" />
+        </DropdownButton>
+        <DropdownMenu anchor="bottom end">
+          <DropdownItem onClick={() => setIsAdminDialogOpen(true)}>
+            Locatiebeheerder toevoegen…
+          </DropdownItem>
+        </DropdownMenu>
+      </Dropdown>
+
+      <Alert open={isAdminDialogOpen} onClose={closeAdminDialog} size="md">
+        <AlertTitle>Locatiebeheerder toevoegen</AlertTitle>
+        <AlertDescription>
+          Zoek en selecteer de persoon die je als locatiebeheerder wilt
+          toevoegen voor {location.name}.
+        </AlertDescription>
+        <AlertBody>
+          <Fieldset>
+            <Field>
+              <Label>Persoon</Label>
+              <PersonSearchCombobox
+                selectedPersonName={selectedPersonName}
+                onSelect={handleSelectPerson}
+                label="Zoek persoon"
+                isSearching={isSearching}
+                results={searchResults}
+                query={searchQuery}
+                debouncedQuery={debouncedQuery}
+                onQueryChange={setSearchQuery}
+              />
+            </Field>
+          </Fieldset>
+        </AlertBody>
+        <AlertActions>
+          <Button plain onClick={closeAdminDialog}>
+            Annuleren
+          </Button>
+          <Button
+            color="branding-dark"
+            disabled={!selectedPersonId}
+            onClick={() => {
+              if (selectedPersonId) {
+                execute({ locationId: location.id, personId: selectedPersonId });
+              }
+            }}
+          >
+            Toevoegen
+          </Button>
+        </AlertActions>
+      </Alert>
+    </div>
+  );
+}
+
+export default function LocatiesTable({
+  locations,
+  totalItems,
+  placeholderRows,
+}: {
+  locations: Location[];
+  totalItems: number;
+  placeholderRows?: number;
+}) {
+  const table = useReactTable({
+    data: locations,
+    columns,
+    getRowId: (row) => row.id,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  return (
+    <>
+      <Table
+        className="mt-8 [--gutter:--spacing(6)] lg:[--gutter:--spacing(10)]"
+        dense
+      >
+        <DefaultTableHead table={table} />
+        <TableBody>
+          <PlaceholderTableRows table={table} rows={placeholderRows}>
+            <NoTableRows table={table}>Geen locaties gevonden</NoTableRows>
+            <DefaultTableRows table={table}>
+              {(cell, index, row) => (
+                <DefaultTableCell
+                  key={cell.id}
+                  cell={cell}
+                  index={index}
+                  row={row}
+                />
+              )}
+            </DefaultTableRows>
+          </PlaceholderTableRows>
+        </TableBody>
+      </Table>
+
+      <TableFooter>
+        <TableRowSelection table={table} totalItems={totalItems} />
+        <TablePagination totalItems={totalItems} />
+      </TableFooter>
+    </>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
@@ -4,7 +4,6 @@ import { EllipsisHorizontalIcon } from "@heroicons/react/20/solid";
 import {
   createColumnHelper,
   getCoreRowModel,
-  getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
 import { useAction } from "next-safe-action/hooks";
@@ -88,7 +87,7 @@ function RowActions({ location }: { location: Location }) {
     isLoading: isSearching,
   } = usePersonSearch(searchQuery);
 
-  const { execute, reset } = useAction(addLocationAdminAsSystemAdminAction, {
+  const { execute, reset, isExecuting } = useAction(addLocationAdminAsSystemAdminAction, {
     onSuccess: () => {
       toast.success("Locatiebeheerder toegevoegd.");
       closeAdminDialog();
@@ -156,7 +155,7 @@ function RowActions({ location }: { location: Location }) {
           </Button>
           <Button
             color="branding-dark"
-            disabled={!selectedPersonId}
+            disabled={!selectedPersonId || isExecuting}
             onClick={() => {
               if (selectedPersonId) {
                 execute({
@@ -166,7 +165,7 @@ function RowActions({ location }: { location: Location }) {
               }
             }}
           >
-            Toevoegen
+            {isExecuting ? "Toevoegen..." : "Toevoegen"}
           </Button>
         </AlertActions>
       </Alert>
@@ -188,7 +187,6 @@ export default function LocatiesTable({
     columns,
     getRowId: (row) => row.id,
     getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
   });
 
   return (

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
@@ -87,15 +87,18 @@ function RowActions({ location }: { location: Location }) {
     isLoading: isSearching,
   } = usePersonSearch(searchQuery);
 
-  const { execute, reset, isExecuting } = useAction(addLocationAdminAsSystemAdminAction, {
-    onSuccess: () => {
-      toast.success("Locatiebeheerder toegevoegd.");
-      closeAdminDialog();
+  const { execute, reset, isExecuting } = useAction(
+    addLocationAdminAsSystemAdminAction,
+    {
+      onSuccess: () => {
+        toast.success("Locatiebeheerder toegevoegd.");
+        closeAdminDialog();
+      },
+      onError: ({ error }) => {
+        toast.error(error.serverError ?? DEFAULT_SERVER_ERROR_MESSAGE);
+      },
     },
-    onError: ({ error }) => {
-      toast.error(error.serverError ?? DEFAULT_SERVER_ERROR_MESSAGE);
-    },
-  });
+  );
 
   const closeAdminDialog = () => {
     setIsAdminDialogOpen(false);

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
@@ -5,13 +5,28 @@ import { isSystemAdmin } from "~/lib/authorization";
 import { getUserOrThrow, listAllLocationsAsAdmin } from "~/lib/nwd";
 import Table from "./_components/table";
 
-async function LocatiesTableData() {
+async function LocatiesTableData(props: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const searchParams = await props.searchParams;
   const locations = await listAllLocationsAsAdmin();
 
-  return <Table locations={locations} totalItems={locations.length} />;
+  const paginationLimit = searchParams?.limit
+    ? Number(searchParams.limit)
+    : 25;
+  const currentPage = searchParams?.page ? Number(searchParams.page) : 1;
+
+  const paginatedLocations = locations.slice(
+    (currentPage - 1) * paginationLimit,
+    currentPage * paginationLimit,
+  );
+
+  return <Table locations={paginatedLocations} totalItems={locations.length} />;
 }
 
-export default async function LocatiesPage() {
+export default async function LocatiesPage(props: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
   const user = await getUserOrThrow();
 
   if (!isSystemAdmin(user.email)) {
@@ -33,7 +48,7 @@ export default async function LocatiesPage() {
       <Suspense
         fallback={<Table locations={[]} totalItems={0} placeholderRows={10} />}
       >
-        <LocatiesTableData />
+        <LocatiesTableData searchParams={props.searchParams} />
       </Suspense>
     </div>
   );

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
@@ -1,0 +1,42 @@
+import { Suspense } from "react";
+import { Heading } from "~/app/(dashboard)/_components/heading";
+import { Text } from "~/app/(dashboard)/_components/text";
+import { isSystemAdmin } from "~/lib/authorization";
+import { getUserOrThrow, listAllLocationsAsAdmin } from "~/lib/nwd";
+import Table from "./_components/table";
+
+async function LocatiesTableData() {
+  const locations = await listAllLocationsAsAdmin();
+
+  return <Table locations={locations} totalItems={locations.length} />;
+}
+
+export default async function LocatiesPage() {
+  const user = await getUserOrThrow();
+
+  if (!isSystemAdmin(user.email)) {
+    return (
+      <div className="mx-auto max-w-7xl">
+        <Heading level={1}>Geen toegang</Heading>
+        <Text className="mt-2">Je hebt geen toegang tot deze pagina.</Text>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-7xl">
+      <div className="mb-8">
+        <Heading level={1}>Vaarlocaties</Heading>
+        <Text className="mt-2">
+          Overzicht van alle vaarlocaties.
+        </Text>
+      </div>
+
+      <Suspense
+        fallback={<Table locations={[]} totalItems={0} placeholderRows={10} />}
+      >
+        <LocatiesTableData />
+      </Suspense>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
@@ -11,9 +11,7 @@ async function LocatiesTableData(props: {
   const searchParams = await props.searchParams;
   const locations = await listAllLocationsAsAdmin();
 
-  const paginationLimit = searchParams?.limit
-    ? Number(searchParams.limit)
-    : 25;
+  const paginationLimit = searchParams?.limit ? Number(searchParams.limit) : 25;
   const currentPage = searchParams?.page ? Number(searchParams.page) : 1;
 
   const paginatedLocations = locations.slice(

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
@@ -27,9 +27,7 @@ export default async function LocatiesPage() {
     <div className="mx-auto max-w-7xl">
       <div className="mb-8">
         <Heading level={1}>Vaarlocaties</Heading>
-        <Text className="mt-2">
-          Overzicht van alle vaarlocaties.
-        </Text>
+        <Text className="mt-2">Overzicht van alle vaarlocaties.</Text>
       </div>
 
       <Suspense

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
@@ -38,9 +38,11 @@ async function LocatiesTableData(props: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const searchParams = await props.searchParams;
-  const { query, page: rawPage, limit: rawLimit } = searchParamsParser(
-    searchParams ?? {},
-  );
+  const {
+    query,
+    page: rawPage,
+    limit: rawLimit,
+  } = searchParamsParser(searchParams ?? {});
   const { page, limit } = sanitizePagination(rawPage, rawLimit);
 
   const locations = await listAllLocationsAsAdmin();
@@ -51,7 +53,10 @@ async function LocatiesTableData(props: {
   );
 
   return (
-    <Table locations={paginatedLocations} totalItems={filteredLocations.length} />
+    <Table
+      locations={paginatedLocations}
+      totalItems={filteredLocations.length}
+    />
   );
 }
 

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
@@ -1,25 +1,58 @@
+import { createLoader, parseAsInteger, parseAsString } from "nuqs/server";
 import { Suspense } from "react";
 import { Heading } from "~/app/(dashboard)/_components/heading";
 import { Text } from "~/app/(dashboard)/_components/text";
 import { isSystemAdmin } from "~/lib/authorization";
 import { getUserOrThrow, listAllLocationsAsAdmin } from "~/lib/nwd";
+import Search from "../../_components/search";
 import Table from "./_components/table";
+
+const searchParamsParser = createLoader({
+  query: parseAsString.withDefault(""),
+  page: parseAsInteger.withDefault(1),
+  limit: parseAsInteger.withDefault(25),
+});
+
+function sanitizePagination(page: number, limit: number) {
+  return {
+    page: Number.isFinite(page) && page > 0 ? page : 1,
+    limit: Number.isFinite(limit) && limit > 0 ? limit : 25,
+  };
+}
+
+function filterLocations(
+  locations: Awaited<ReturnType<typeof listAllLocationsAsAdmin>>,
+  query: string,
+) {
+  const q = query.trim().toLowerCase();
+  if (!q) return locations;
+
+  return locations.filter(
+    (location) =>
+      location.name?.toLowerCase().includes(q) ||
+      location.handle.toLowerCase().includes(q),
+  );
+}
 
 async function LocatiesTableData(props: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const searchParams = await props.searchParams;
+  const { query, page: rawPage, limit: rawLimit } = searchParamsParser(
+    searchParams ?? {},
+  );
+  const { page, limit } = sanitizePagination(rawPage, rawLimit);
+
   const locations = await listAllLocationsAsAdmin();
-
-  const paginationLimit = searchParams?.limit ? Number(searchParams.limit) : 25;
-  const currentPage = searchParams?.page ? Number(searchParams.page) : 1;
-
-  const paginatedLocations = locations.slice(
-    (currentPage - 1) * paginationLimit,
-    currentPage * paginationLimit,
+  const filteredLocations = filterLocations(locations, query);
+  const paginatedLocations = filteredLocations.slice(
+    (page - 1) * limit,
+    page * limit,
   );
 
-  return <Table locations={paginatedLocations} totalItems={locations.length} />;
+  return (
+    <Table locations={paginatedLocations} totalItems={filteredLocations.length} />
+  );
 }
 
 export default async function LocatiesPage(props: {
@@ -41,6 +74,10 @@ export default async function LocatiesPage(props: {
       <div className="mb-8">
         <Heading level={1}>Vaarlocaties</Heading>
         <Text className="mt-2">Overzicht van alle vaarlocaties.</Text>
+      </div>
+
+      <div className="mt-4 max-w-xl">
+        <Search placeholder="Zoek op naam of handle…" />
       </div>
 
       <Suspense

--- a/apps/web/src/app/(dashboard)/_components/person-search-combobox.tsx
+++ b/apps/web/src/app/(dashboard)/_components/person-search-combobox.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import * as Headless from "@headlessui/react";
+import type { User } from "@nawadi/core";
+import clsx from "clsx";
+import Spinner from "~/app/_components/spinner";
+
+export type SearchPerson = Awaited<
+  ReturnType<typeof User.Person.searchForAutocomplete>
+>[number];
+
+const controlClasses = clsx(
+  "relative block w-full",
+  "before:absolute before:inset-px before:rounded-[calc(var(--radius-lg)-1px)] before:bg-white before:shadow-sm",
+  "dark:before:hidden",
+  "after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:ring-transparent after:ring-inset sm:focus-within:after:ring-2 sm:focus-within:after:ring-blue-500",
+  "has-data-disabled:opacity-50 has-data-disabled:before:bg-zinc-950/5 has-data-disabled:before:shadow-none",
+  "has-data-invalid:before:shadow-red-500/10",
+);
+
+const inputClasses = clsx(
+  "relative block w-full appearance-none rounded-lg py-[calc(--spacing(2.5)-1px)] sm:py-[calc(--spacing(1.5)-1px)]",
+  "pr-[calc(--spacing(10)-1px)] pl-[calc(--spacing(3.5)-1px)] sm:pr-[calc(--spacing(9)-1px)] sm:pl-[calc(--spacing(3)-1px)]",
+  "text-base/6 text-zinc-950 placeholder:text-zinc-500 sm:text-sm/6 dark:text-white",
+  "border border-zinc-950/10 data-hover:border-zinc-950/20 dark:border-white/10 dark:data-hover:border-white/20",
+  "bg-transparent dark:bg-white/5",
+  "focus:outline-hidden",
+  "data-invalid:border-red-500 data-invalid:data-hover:border-red-500 dark:data-invalid:border-red-500 dark:data-invalid:data-hover:border-red-500",
+  "data-disabled:border-zinc-950/20 dark:data-disabled:border-white/15 dark:data-disabled:bg-white/[2.5%] dark:data-hover:data-disabled:border-white/15",
+  "dark:scheme-dark",
+);
+
+const optionsClasses = clsx(
+  "[--anchor-gap:--spacing(2)] [--anchor-padding:--spacing(4)] sm:data-[anchor~=start]:[--anchor-offset:-4px]",
+  "isolate min-w-[calc(var(--input-width)+8px)] scroll-py-1 rounded-xl p-1 select-none empty:invisible",
+  "outline outline-transparent focus:outline-hidden",
+  "overflow-y-scroll overscroll-contain",
+  "bg-white/75 backdrop-blur-xl dark:bg-zinc-800/75",
+  "shadow-lg ring-1 ring-zinc-950/10 dark:ring-white/10 dark:ring-inset",
+  "transition-opacity duration-100 ease-in data-closed:data-leave:opacity-0 data-transition:pointer-events-none",
+);
+
+const optionClasses = clsx(
+  "group/option grid w-full cursor-default grid-cols-[1fr_--spacing(5)] items-baseline gap-x-2 rounded-lg py-2.5 pr-2 pl-3.5 sm:grid-cols-[1fr_--spacing(4)] sm:py-1.5 sm:pr-2 sm:pl-3",
+  "text-base/6 text-zinc-950 sm:text-sm/6 dark:text-white forced-colors:text-[CanvasText]",
+  "outline-hidden data-focus:bg-blue-500 data-focus:text-white",
+  "forced-color-adjust-none forced-colors:data-focus:bg-[Highlight] forced-colors:data-focus:text-[HighlightText]",
+  "data-disabled:opacity-50",
+);
+
+export function PersonSearchCombobox({
+  selectedPersonName,
+  onSelect,
+  label,
+  isSearching,
+  results,
+  query,
+  debouncedQuery,
+  onQueryChange,
+}: {
+  selectedPersonName: string | null;
+  onSelect: (person: SearchPerson) => void;
+  label: string;
+  isSearching: boolean;
+  results: SearchPerson[];
+  query: string;
+  debouncedQuery: string | null;
+  onQueryChange: (query: string) => void;
+}) {
+  const isTyping = query.length > 0;
+
+  return (
+    <Headless.Combobox
+      immediate
+      onChange={(person: SearchPerson | null) => {
+        if (person) {
+          onSelect(person);
+        }
+        onQueryChange("");
+      }}
+      onClose={() => onQueryChange("")}
+    >
+      <span data-slot="control" className={controlClasses}>
+        <Headless.ComboboxInput
+          aria-label={label}
+          data-slot="control"
+          value={isTyping ? query : (selectedPersonName ?? "")}
+          onChange={(event) => {
+            onQueryChange(event.target.value);
+          }}
+          placeholder="Typ om te zoeken…"
+          autoComplete="off"
+          spellCheck={false}
+          className={inputClasses}
+        />
+        <Headless.ComboboxButton
+          className="group right-0 absolute inset-y-0 flex items-center px-2"
+          aria-label="Opties tonen"
+        >
+          <svg
+            className="stroke-zinc-500 dark:group-data-hover:stroke-zinc-300 dark:stroke-zinc-400 forced-colors:stroke-[CanvasText] group-data-disabled:stroke-zinc-600 group-data-hover:stroke-zinc-700 size-5 sm:size-4"
+            viewBox="0 0 16 16"
+            aria-hidden="true"
+            fill="none"
+          >
+            <path
+              d="M5.75 10.75L8 13L10.25 10.75"
+              strokeWidth={1.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M10.25 5.25L8 3L5.75 5.25"
+              strokeWidth={1.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </Headless.ComboboxButton>
+      </span>
+      <Headless.ComboboxOptions
+        transition
+        anchor="bottom"
+        className={optionsClasses}
+      >
+        {isSearching && (
+          <div
+            className="flex items-center gap-2 px-3.5 py-2 text-sm text-zinc-500"
+            aria-live="polite"
+          >
+            <Spinner className="h-3 w-3" aria-hidden="true" /> Zoeken…
+          </div>
+        )}
+        {!isSearching && debouncedQuery && results.length === 0 && (
+          <div className="px-3.5 py-2 text-sm text-zinc-500" aria-live="polite">
+            Geen personen gevonden
+          </div>
+        )}
+        {results.map((person) => {
+          const name = [
+            person.firstName,
+            person.lastNamePrefix,
+            person.lastName,
+          ]
+            .filter(Boolean)
+            .join(" ");
+          return (
+            <Headless.ComboboxOption
+              key={person.id}
+              value={person}
+              className={optionClasses}
+            >
+              <span className="flex min-w-0 flex-col">
+                <span className="ml-2.5 truncate first:ml-0 sm:ml-2 sm:first:ml-0">
+                  {name}
+                </span>
+                <span className="flex flex-1 overflow-hidden text-zinc-500 group-data-focus/option:text-white before:w-2 before:min-w-0 before:shrink dark:text-zinc-400">
+                  <span className="flex-1 truncate">
+                    {person.email ?? "Geen e-mail"} · {person.handle}
+                    {person.dateOfBirth &&
+                      ` · Geb. ${new Intl.DateTimeFormat("nl-NL", { day: "numeric", month: "long", year: "numeric" }).format(new Date(person.dateOfBirth))}`}
+                  </span>
+                </span>
+              </span>
+            </Headless.ComboboxOption>
+          );
+        })}
+      </Headless.ComboboxOptions>
+    </Headless.Combobox>
+  );
+}

--- a/apps/web/src/app/_actions/location/add-location-admin-action.ts
+++ b/apps/web/src/app/_actions/location/add-location-admin-action.ts
@@ -1,0 +1,36 @@
+"use server";
+
+import { User } from "@nawadi/core";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { isSystemAdmin } from "~/lib/authorization";
+import { getUserOrThrow } from "~/lib/nwd";
+import { actionClientWithMeta } from "../safe-action";
+
+export const addLocationAdminAsSystemAdminAction = actionClientWithMeta
+  .metadata({ name: "location.add-admin-as-system-admin" })
+  .inputSchema(
+    z.object({
+      locationId: z.string().uuid(),
+      personId: z.string().uuid(),
+    }),
+  )
+  .action(async ({ parsedInput: { locationId, personId } }) => {
+    const user = await getUserOrThrow();
+    if (!isSystemAdmin(user.email)) {
+      throw new Error("Geen toegang");
+    }
+
+    await User.Person.createLocationLink({
+      personId,
+      locationId,
+    });
+
+    await User.Actor.upsert({
+      personId,
+      locationId,
+      type: "location_admin",
+    });
+
+    revalidatePath("/secretariaat/locaties", "page");
+  });

--- a/apps/web/src/app/_actions/location/add-location-admin-action.ts
+++ b/apps/web/src/app/_actions/location/add-location-admin-action.ts
@@ -1,10 +1,10 @@
 "use server";
 
-import { User } from "@nawadi/core";
+import { User, withSupabaseClient } from "@nawadi/core";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { isSystemAdmin } from "~/lib/authorization";
-import { getUserOrThrow } from "~/lib/nwd";
+import { getUserOrThrow, supabaseConfig } from "~/lib/nwd";
 import { actionClientWithMeta } from "../safe-action";
 
 export const addLocationAdminAsSystemAdminAction = actionClientWithMeta
@@ -21,15 +21,17 @@ export const addLocationAdminAsSystemAdminAction = actionClientWithMeta
       throw new Error("Geen toegang");
     }
 
-    await User.Person.createLocationLink({
-      personId,
-      locationId,
-    });
+    await withSupabaseClient(supabaseConfig, async () => {
+      await User.Person.createLocationLink({
+        personId,
+        locationId,
+      });
 
-    await User.Actor.upsert({
-      personId,
-      locationId,
-      type: "location_admin",
+      await User.Actor.upsert({
+        personId,
+        locationId,
+        type: "location_admin",
+      });
     });
 
     revalidatePath("/secretariaat/locaties", "page");

--- a/apps/web/src/app/_actions/location/add-location-admin-action.ts
+++ b/apps/web/src/app/_actions/location/add-location-admin-action.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { User, withSupabaseClient } from "@nawadi/core";
+import { User, withSupabaseClient, withTransaction } from "@nawadi/core";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { isSystemAdmin } from "~/lib/authorization";
@@ -22,15 +22,17 @@ export const addLocationAdminAsSystemAdminAction = actionClientWithMeta
     }
 
     await withSupabaseClient(supabaseConfig, async () => {
-      await User.Person.createLocationLink({
-        personId,
-        locationId,
-      });
+      await withTransaction(async () => {
+        await User.Person.ensureLocationLinkForAdmin({
+          personId,
+          locationId,
+        });
 
-      await User.Actor.upsert({
-        personId,
-        locationId,
-        type: "location_admin",
+        await User.Actor.upsert({
+          personId,
+          locationId,
+          type: "location_admin",
+        });
       });
     });
 

--- a/apps/web/src/lib/nwd.ts
+++ b/apps/web/src/lib/nwd.ts
@@ -1260,6 +1260,19 @@ export const listAllLocations = cache(async () => {
   });
 });
 
+export const listAllLocationsAsAdmin = cache(async () => {
+  return makeRequest(async () => {
+    const requestingUser = await getUserOrThrow();
+    const { isSystemAdmin } = await import("~/lib/authorization");
+
+    if (!isSystemAdmin(requestingUser.email)) {
+      throw new Error("Unauthorized");
+    }
+
+    return await Location.list();
+  });
+});
+
 export const createStudentForLocation = async (
   locationId: string,
   personInput: {

--- a/packages/core/src/models/user/person.ts
+++ b/packages/core/src/models/user/person.ts
@@ -917,39 +917,37 @@ export const linkToLocation = wrapCommand(
   ),
 );
 
-
 export const ensureLocationLinkForAdmin = wrapCommand(
   "user.person.ensureLocationLinkForAdmin",
   withZod(
-      z.object({ personId: uuidSchema, locationId: uuidSchema }),
-      z.void(),
-      async (input) => {
-        const query = useQuery();
+    z.object({ personId: uuidSchema, locationId: uuidSchema }),
+    z.void(),
+    async (input) => {
+      const query = useQuery();
 
-        await query
-          .insert(s.personLocationLink)
-          .values({
-            personId: input.personId,
-            locationId: input.locationId,
+      await query
+        .insert(s.personLocationLink)
+        .values({
+          personId: input.personId,
+          locationId: input.locationId,
+          status: "linked",
+          permissionLevel: "none",
+        })
+        .onConflictDoUpdate({
+          target: [
+            s.personLocationLink.personId,
+            s.personLocationLink.locationId,
+          ],
+          set: {
             status: "linked",
-            permissionLevel: "none",
-          })
-          .onConflictDoUpdate({
-            target: [
-              s.personLocationLink.personId,
-              s.personLocationLink.locationId,
-            ],
-            set: {
-              status: "linked",
-              revokedAt: null,
-              removedAt: null,
-              linkedAt: sql`NOW()`
-            },
-          });
-      },
+            revokedAt: null,
+            removedAt: null,
+            linkedAt: sql`NOW()`,
+          },
+        });
+    },
   ),
 );
-
 
 /**
  * Score a set of pasted candidate rows against the operator's location's

--- a/packages/core/src/models/user/person.ts
+++ b/packages/core/src/models/user/person.ts
@@ -917,6 +917,40 @@ export const linkToLocation = wrapCommand(
   ),
 );
 
+
+export const ensureLocationLinkForAdmin = wrapCommand(
+  "user.person.ensureLocationLinkForAdmin",
+  withZod(
+      z.object({ personId: uuidSchema, locationId: uuidSchema }),
+      z.void(),
+      async (input) => {
+        const query = useQuery();
+
+        await query
+          .insert(s.personLocationLink)
+          .values({
+            personId: input.personId,
+            locationId: input.locationId,
+            status: "linked",
+            permissionLevel: "none",
+          })
+          .onConflictDoUpdate({
+            target: [
+              s.personLocationLink.personId,
+              s.personLocationLink.locationId,
+            ],
+            set: {
+              status: "linked",
+              revokedAt: null,
+              removedAt: null,
+              linkedAt: sql`NOW()`
+            },
+          });
+      },
+  ),
+);
+
+
 /**
  * Score a set of pasted candidate rows against the operator's location's
  * linked-active persons. Returns matches grouped by row index plus the


### PR DESCRIPTION
## Summary
- Add a new vaarlocaties (sailing locations) page under /secretariaat/locaties listing all locations in a table
- Each location row has a three-dot menu with an option to add a Locatiebeheerder (location admin) via a person search dialog
- Adds `listAllLocationsAsAdmin` for system-admin access to all locations regardless of status
- Adds `addLocationAdminAsSystemAdminAction` server action for assigning the location admin role
- Fixes sidebar highlight for the locaties route

## Test plan
- [ ] Navigate to Secretariaat > Vaarlocaties and verify all locations are listed
- [ ] Verify the table shows Naam and Handle columns
- [ ] Click the three-dot menu on a location row and verify the Locatiebeheerder toevoegen option appears
- [ ] Open the add-admin dialog and verify the person search combobox works (search by name/email/handle)
- [ ] Select a person and click Toevoegen -- verify the action succeeds with a toast notification
- [ ] Verify a non-system-admin cannot access the page (authorization check)
- [ ] Verify the Vaarlocaties sidebar item is correctly highlighted when on the locaties page

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> System admins can assign `location_admin` across any location; checks exist on the page, data loader, and server action, but the operation is privileged and touches person–location links and roles.
> 
> **Overview**
> Adds a **system-admin-only** Secretariaat page at `/secretariaat/locaties` that lists all vaarlocaties (any status) via new `listAllLocationsAsAdmin`, with client-side search on naam/handle and pagination.
> 
> Each row exposes **Locatiebeheerder toevoegen** in a dialog: person search calls `addLocationAdminAsSystemAdminAction`, which links the person to the location (`ensureLocationLinkForAdmin`) and upserts a `location_admin` actor in one transaction.
> 
> **Person search UI** is extracted to shared `PersonSearchCombobox` (used by the new flow and `merge-persons-dialog`, which drops its inline combobox). The Vaarlocaties sidebar **Overzicht** active state is fixed to match `locaties` instead of `cohorten`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e392fb9d91e51b5f0da7a668418bcae416c8a230. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin-only “Vaarlocaties” page with search, pagination, and empty/loading states.
  * Added a “locaties” table with row actions to assign a location administrator and confirm via dialog, with success/error toasts.
  * Introduced a shared person search combobox and reused it in the merge-persons dialog.
* **Bug Fixes**
  * Corrected the sidebar active highlight for “Overzicht” in the locations section.
* **Security**
  * Enforced system-admin authorization for listing locations and for adding location administrators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->