### PR TITLE
feat: add secretariaat link to profile dropdown for admins

### DIFF
--- a/apps/web/src/app/(dashboard)/(account)/@selector/layout.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/@selector/layout.tsx
@@ -34,6 +34,15 @@ async function PersonsDropdownMenu() {
         <DropdownItem disabled>
           <DropdownLabel>Geen personen beschikbaar.</DropdownLabel>
         </DropdownItem>
+        {showSecretariaat && (
+          <>
+            <DropdownDivider />
+            <DropdownItem href="/secretariaat">
+              <Cog6ToothIcon />
+              <DropdownLabel>Secretariaat</DropdownLabel>
+            </DropdownItem>
+          </>
+        )}
         <DropdownDivider />
         <DropdownItem href="/account">
           <UserIcon />

--- a/apps/web/src/app/(dashboard)/(account)/@selector/layout.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/@selector/layout.tsx
@@ -1,11 +1,13 @@
 import {
   ArrowRightStartOnRectangleIcon,
+  Cog6ToothIcon,
   LifebuoyIcon,
   ShieldCheckIcon,
   UserIcon,
 } from "@heroicons/react/16/solid";
 import { connection } from "next/server";
 import { type PropsWithChildren, Suspense } from "react";
+import { isSystemAdmin } from "~/lib/authorization";
 import { getUserOrThrow } from "~/lib/nwd";
 import { LogOutDropdownItem } from "../../_components/auth";
 import {
@@ -23,7 +25,8 @@ import { PersonItem } from "./_components/person-item";
 
 async function PersonsDropdownMenu() {
   await connection();
-  const { persons } = await getUserOrThrow();
+  const { persons, email } = await getUserOrThrow();
+  const showSecretariaat = isSystemAdmin(email);
 
   if (persons.length === 0) {
     return (
@@ -70,6 +73,15 @@ async function PersonsDropdownMenu() {
         <ShieldCheckIcon />
         <DropdownLabel>Privacybeleid</DropdownLabel>
       </DropdownItem>
+      {showSecretariaat && (
+        <>
+          <DropdownDivider />
+          <DropdownItem href="/secretariaat">
+            <Cog6ToothIcon />
+            <DropdownLabel>Secretariaat</DropdownLabel>
+          </DropdownItem>
+        </>
+      )}
       <DropdownDivider />
       <DropdownItem href="/account">
         <UserIcon />


### PR DESCRIPTION
## Summary
- Show a Secretariaat menu item in the account profile dropdown, visible only to system administrators
- The link is placed between its own dividers for clear visual separation
- Uses the existing `isSystemAdmin` check on the user's email

## Test plan
- [ ] Log in as a system admin and open the profile dropdown -- verify the Secretariaat item appears between dividers
- [ ] Click it and verify navigation to /secretariaat works
- [ ] Log in as a non-admin user and verify the Secretariaat item is not shown

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change gated by an existing admin check; minimal impact aside from conditional navigation visibility.
> 
> **Overview**
> Adds a *system-admin-only* `Secretariaat` entry to the account/profile dropdown, linking to `/secretariaat` and visually separated by dividers.
> 
> The dropdown now fetches the user `email` from `getUserOrThrow()` and conditionally renders the new item (with `Cog6ToothIcon`) using the existing `isSystemAdmin(email)` check, including when no persons are available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b8d552170fc517d161fda793c63fe0c4096a9b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->