### PR TITLE
fix(web): scherper temporeel kader in CWO-instructeur FAQ

### DIFF
--- a/apps/web/src/app/(public)/erkenningen/page.tsx
+++ b/apps/web/src/app/(public)/erkenningen/page.tsx
@@ -75,7 +75,7 @@ const faqItems: FaqItem[] = [
     question:
       "Ik heb mijn instructeurskwalificatie via CWO behaald — moet ik die opnieuw halen bij het NWD?",
     answer:
-      "Nee. KSS-kwalificaties zijn onderdeel van een landelijk systeem en horen bij jou als persoon, niet bij een specifieke opleidingsroute. Als je je instructeursstatus op een erkende manier hebt behaald, blijft die automatisch geldig bij zowel NWD-vaarscholen als de Watersport Academy. Wel geldt: vanaf 1 januari 2026 kun je je kwalificatie alleen inzetten op door het Watersportverbond erkende opleidingslocaties, en nieuwe of hogere instructeurskwalificaties kun je uitsluitend daar behalen.",
+      "Heb je je kwalificatie vóór 1 januari 2026 via een toen door het Watersportverbond erkende locatie behaald? Dan niet. KSS-kwalificaties zijn onderdeel van een landelijk systeem en horen bij jou als persoon, niet bij een specifieke opleidingsroute. Je instructeursstatus blijft in dat geval automatisch geldig bij zowel NWD-vaarscholen als de Watersport Academy. Vanaf 1 januari 2026 kun je je kwalificatie wel alleen nog inzetten op door het Watersportverbond erkende opleidingslocaties, en nieuwe of hogere instructeurskwalificaties kun je uitsluitend daar behalen.",
   },
   {
     question: "Worden NWD-diploma's internationaal erkend?",


### PR DESCRIPTION
## Summary

Scherpt het antwoord op de FAQ *"Ik heb mijn instructeurskwalificatie via CWO behaald — moet ik die opnieuw halen bij het NWD?"* op [/erkenningen](https://www.nationaalwatersportdiploma.nl/erkenningen) aan.

## Waarom

De vorige formulering begon met *"Nee. ... Als je je instructeursstatus op een erkende manier hebt behaald, blijft die automatisch geldig ..."*. Voor veel lezers kwam dat binnen als een algemene geruststelling — ook als je nu een CWO-instructeurskwalificatie zou halen, zou die volgens deze tekst automatisch doortellen. Dat is niet waar: sinds 1 januari 2026 zijn CWO-locaties geen door het Watersportverbond erkende opleidingslocaties meer, dus nieuw behaalde CWO-instructeurskwalificaties vallen niet onder de landelijke erkenning.

De voorwaarde stond er wel impliciet ("op een erkende manier"), maar was te subtiel. Het antwoord opent nu met een expliciete vraag die de scope meteen dichttimmert:

> "Heb je je kwalificatie vóór 1 januari 2026 via een toen door het Watersportverbond erkende locatie behaald? Dan niet."

## Test plan

- [ ] `/erkenningen` rendert; FAQ-item over CWO-instructeurskwalificatie toont de nieuwe formulering
- [ ] JSON-LD FAQ-schema is consistent met de nieuwe tekst (gegenereerd uit dezelfde `faqItems`-array)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Laag risico: het is een tekstwijziging in een publieke FAQ zonder impact op runtime-logica of dataverwerking, behalve dat ook het JSON-LD FAQ-schema dezelfde aangepaste tekst uitserveert.
> 
> **Overview**
> Verandert het FAQ-item op `/erkenningen` over CWO-instructeurskwalificaties door het antwoord te herformuleren naar een expliciete *voorwaarde* (behaald **vóór 1 januari 2026** via een toen door het Watersportverbond erkende locatie) voordat wordt gesteld dat opnieuw halen niet nodig is.
> 
> Deze aangescherpte formulering wordt daarmee ook doorgevoerd in de automatisch gegenereerde `FAQPage` JSON-LD omdat die direct uit dezelfde `faqItems`-tekst wordt opgebouwd.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80d5d2e090d53721d582deadf9069c3cb032a55c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->