### PR TITLE
fix(web): force-include @napi-rs/canvas via outputFileTracingIncludes

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -81,6 +81,34 @@ const nextConfig = {
       "./src/assets/certificates/**/*",
     ],
     "/api/og": ["./src/assets/fonts/**/*"],
+    // @napi-rs/canvas must be present alongside pdfjs-dist at runtime —
+    // pdfjs-dist@5 loads it via `try { require("@napi-rs/canvas") }`,
+    // a dynamic require that Next's file tracer can't follow statically.
+    // Without these explicit hints Vercel ships pdfjs-dist to /var/task
+    // but leaves @napi-rs/canvas behind, and the require throws
+    // ReferenceError: DOMMatrix is not defined at module-load time.
+    //
+    // Path patterns cover:
+    //   - node_modules/@napi-rs/canvas          → pnpm's wrapper symlink
+    //   - node_modules/.pnpm/@napi-rs+canvas*  → the actual binaries,
+    //     including the platform-specific sub-packages
+    //     (@napi-rs+canvas-linux-x64-gnu, -linux-arm64-gnu, etc.)
+    //
+    // Applied on every route that can reach the PDF-extract pipeline:
+    // all of /leercoach, any /api/leercoach/* server action, and the
+    // /profiel/[handle]/portfolios upload flow.
+    "/profiel/[handle]/leercoach/**/*": [
+      "../../node_modules/@napi-rs/canvas/**/*",
+      "../../node_modules/.pnpm/@napi-rs+canvas*/**/*",
+    ],
+    "/profiel/[handle]/portfolios/**/*": [
+      "../../node_modules/@napi-rs/canvas/**/*",
+      "../../node_modules/.pnpm/@napi-rs+canvas*/**/*",
+    ],
+    "/api/leercoach/**/*": [
+      "../../node_modules/@napi-rs/canvas/**/*",
+      "../../node_modules/.pnpm/@napi-rs+canvas*/**/*",
+    ],
     "/": ["./src/app/(public)/**/*.mdx"],
   },
   images: {


### PR DESCRIPTION
## Summary

Follow-up to #437 — same `DOMMatrix is not defined` symptom still hit prod after that merge. Turns out installing `@napi-rs/canvas` wasn't enough; Vercel's deploy was still shipping pdfjs-dist to `/var/task` **without** the canvas package alongside it.

## Root cause

`pdfjs-dist` loads the polyfill via a dynamic require wrapped in try/catch:

```js
try { require("@napi-rs/canvas") } catch { /* no-op */ }
```

Next.js's File Tracer (NFT) walks the static `require()` graph to figure out which files to include in each route's deployment bundle. Dynamic / conditional requires aren't always picked up — and this one isn't, because it's wrapped in a try/catch that NFT treats as optional.

Result: `@napi-rs/canvas` sits in `node_modules` locally and in the lockfile, but gets trimmed from the deployed function bundle.

## Fix

Explicit `outputFileTracingIncludes` entries so Vercel ships `@napi-rs/canvas` alongside pdfjs-dist on every route that can reach the extract pipeline:

- `/profiel/[handle]/leercoach/**/*` — chat + portfolio pages, server actions
- `/profiel/[handle]/portfolios/**/*` — upload flow
- `/api/leercoach/**/*` — compaction, synthesis, stream routes

Both glob patterns needed per route:

```js
"../../node_modules/@napi-rs/canvas/**/*"        // pnpm wrapper symlink
"../../node_modules/.pnpm/@napi-rs+canvas*/**/*" // actual binaries +
                                                 // platform sub-packages
                                                 // (-linux-x64-gnu, etc.)
```

## Test plan

- [ ] Deploy
- [ ] Check prod logs — `Cannot load @napi-rs/canvas` warning should be gone
- [ ] Edit a portfolio document → TipTap auto-save should return 200
- [ ] Upload a PDF artefact → ingest should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts Next.js output file tracing for multiple routes, which can change what gets deployed to Vercel and affect serverless bundle size/limits and runtime behavior of PDF processing.
> 
> **Overview**
> Fixes a production `DOMMatrix is not defined` crash by explicitly forcing `@napi-rs/canvas` (including pnpm’s symlink and platform-specific binary packages) to be included in Vercel’s traced server bundles.
> 
> Adds `outputFileTracingIncludes` entries for `/profiel/[handle]/leercoach/**/*`, `/profiel/[handle]/portfolios/**/*`, and `/api/leercoach/**/*` so routes that transitively hit the PDF extract pipeline reliably ship `@napi-rs/canvas` alongside `pdfjs-dist` at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3af94d940bea26bf7960263bb3e63f0b1b8a2ece. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->