### PR TITLE
fix(leercoach): generate UUIDs for message ids on client + server

### DIFF
--- a/apps/web/src/app/_components/ai-chat/AiChat.tsx
+++ b/apps/web/src/app/_components/ai-chat/AiChat.tsx
@@ -149,6 +149,14 @@ function Provider({
     id: chatId,
     messages: initialMessages as UIMessage[],
     resume,
+    // Override the AI SDK's default id generator (nanoid-style,
+    // e.g. "msg_4h3jk2h4") with a real UUID. The server's leercoach
+    // message table stores `id uuid NOT NULL` and core's Zod schema
+    // enforces uuidSchema, so non-UUID ids from the client's submit
+    // path throw `Invalid uuid` on save. `crypto.randomUUID()` is
+    // available in every modern browser + every Node runtime we
+    // target, so no polyfill needed.
+    generateId: () => crypto.randomUUID(),
     transport: new DefaultChatTransport({
       api: apiEndpoint,
       // Trigger-aware body shape required by resumable streams: the

--- a/apps/web/src/app/api/leercoach/chat/route.ts
+++ b/apps/web/src/app/api/leercoach/chat/route.ts
@@ -404,7 +404,11 @@ export async function POST(req: Request) {
 
   return result.toUIMessageStreamResponse({
     originalMessages: messages,
-    generateMessageId: generateId,
+    // crypto.randomUUID() instead of the AI SDK's default `generateId`
+    // (nanoid-style). leercoach_message.id is `uuid NOT NULL`; the
+    // assistant response saved in onFinish below must match that
+    // format or the Zod uuidSchema in Message.save throws.
+    generateMessageId: () => crypto.randomUUID(),
     onFinish: async ({ responseMessage, isContinuation }) => {
       // `responseMessage` is the single new-or-extended assistant
       // message for this turn (see AI SDK's UIMessageStreamOnFinish


### PR DESCRIPTION
## Summary

Follow-up to #439. Now that the chat route actually runs in prod, the first real message-send surfaced a **UUID validation error** that's been latent since the leercoach feature shipped.

## Root cause

- `leercoach_message.id` is `uuid NOT NULL`
- `Leercoach.Message.save`'s Zod schema uses `uuidSchema` (pinned UUID format)
- But `useChat` (client) and `toUIMessageStreamResponse` (server) both used the AI SDK's default `generateId` — a **nanoid-style** id like `"msg_4h3jk2h4"`, not a UUID
- First save after today's pdfjs-dist fixes landed → first-ever successful reach into `Message.save` → `Error [ZodError]: Invalid uuid at path ["id"]`

## Fix

Two-line override, one each side:

```tsx
// apps/web/src/app/_components/ai-chat/AiChat.tsx
useChat({
  ...,
  generateId: () => crypto.randomUUID(),
})
```

```ts
// apps/web/src/app/api/leercoach/chat/route.ts
result.toUIMessageStreamResponse({
  ...,
  generateMessageId: () => crypto.randomUUID(),
})
```

`crypto.randomUUID()` is native in every modern browser + Node runtime we target — no polyfill. The existing `generateId` import from `"ai"` stays because `streamId` (for resumable streams) lives in a text column; no format constraint there.

## Why it only surfaced now

Every chat-route request in prod was 500'ing at module-load due to pdfjs-dist (#437, #438) or getting trimmed by the 250 MB function limit (fixed in #439). Requests never reached `Message.save`, so the UUID mismatch stayed invisible. After #439's unpdf swap made the route runnable end-to-end, this was the next layer of the onion.

## Test plan

- [ ] Send a message on prod `/profiel/.../leercoach/chat/[id]` → message persists, assistant replies stream, everything 200
- [ ] Refresh mid-stream → resumable reconnect still works (uses UUIDs now, so no reconciliation issues)
- [ ] Regenerate a turn → new assistant message gets a fresh UUID id

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches chat message id generation and persistence paths; mistakes could break streaming/resume/regenerate or cause DB write failures, but changes are small and scoped.
> 
> **Overview**
> Fixes leercoach chat persistence by forcing **UUID** message ids on both the client (`useChat.generateId`) and server streaming response (`toUIMessageStreamResponse.generateMessageId`), avoiding `Invalid uuid` failures when saving messages.
> 
> Increases Next.js route/page `maxDuration` to **300s** for the leercoach chat page and portfolios page so long-running upload/ingest server actions (PDF extraction + LLM processing) don’t hit the default 30s serverless timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b94d3325972e5684362d6c77092523600b29d53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->