### PR TITLE
feat(leercoach): durable portfolio ingest via Upstash Workflow

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -23,3 +23,20 @@ AXIOM_API_KEY="your-axiom-api-key"
 # The sandbox + the corpus anonymiser both go through Vercel AI Gateway so we
 # get unified logging, spend controls, and provider routing in one place.
 AI_GATEWAY_API_KEY="vck_..."
+
+# Upstash QStash — powers the durable portfolio-ingest workflow
+# (apps/web/src/app/api/workflow/ingest-portfolio/route.ts).
+#
+# Local dev: run `pnpm dev:qstash` in a sidecar terminal. The CLI
+# starts an in-memory QStash server on :8080 and prints four sets of
+# test credentials. Pick the first one for these three env vars; the
+# server restart resets state, so treat it as ephemeral.
+#
+# Production: create a QStash project at https://console.upstash.com/qstash
+# and paste the token + signing keys from the dashboard. Point
+# QSTASH_URL at https://qstash.upstash.io (the default, can be
+# omitted in prod).
+QSTASH_URL="http://127.0.0.1:8080"
+QSTASH_TOKEN="eyJVc2VySUQiOiJkZWZhdWx0VXNlciIsIlBhc3N3b3JkIjoiZGVmYXVsdFBhc3N3b3JkIn0="
+QSTASH_CURRENT_SIGNING_KEY="sig_7kYjw8V4fCpUMiDrQrQm2JZ4WK..."
+QSTASH_NEXT_SIGNING_KEY="sig_5jKKLaE5pGtNvN7BHuxm..."

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "dev:workspace": "pnpm -w turbo run dev --filter=@nawadi/web...",
+    "dev:qstash": "npx -y @upstash/qstash-cli dev",
     "build": "next build",
     "build:all-ts-errors": "set __NEXT_TEST_MODE=true && pnpm build",
     "start": "next start",
@@ -67,6 +68,8 @@
     "@tiptap/react": "^3.22.4",
     "@tiptap/starter-kit": "^3.22.4",
     "@tremor/react": "3.18.7",
+    "@upstash/qstash": "^2.10.1",
+    "@upstash/workflow": "^1.2.0",
     "@vercel/otel": "2.1.0",
     "@vercel/speed-insights": "1.2.0",
     "@vis.gl/react-google-maps": "1.5.2",

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/leercoach/_components/PortfolioUpload.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/leercoach/_components/PortfolioUpload.tsx
@@ -125,11 +125,14 @@ function AutoSendBridge() {
 
   useEffect(() => {
     if (!pendingSuccess) return;
-    const { result, niveauRang } = pendingSuccess;
+    const { niveauRang } = pendingSuccess;
     const niveauLabel = niveauRang ? `niveau-${niveauRang} ` : "";
-    const message = result.alreadyIngested
-      ? `Ik heb mijn ${niveauLabel}portfolio geüpload — maar ik zie dat dezelfde versie er al stond, dus niets nieuws toegevoegd.`
-      : `Ik heb zojuist mijn ${niveauLabel}portfolio geüpload (${result.pageCount} pagina's, ${result.chunkCount} fragmenten). Neem even de tijd om erin te kijken, dan kunnen we daarna bespreken hoe we dit gebruiken.`;
+    // Single message shape since the async workflow doesn't surface
+    // "already ingested" vs "fresh" to the client — the dedup check
+    // lives inside the workflow's ingest step. If we ever want to
+    // re-introduce that distinction, extend the status endpoint to
+    // return a { freshInsert: boolean } flag from the source insert.
+    const message = `Ik heb zojuist mijn ${niveauLabel}portfolio geüpload. Neem even de tijd om erin te kijken, dan kunnen we daarna bespreken hoe we dit gebruiken.`;
     sendMessage({ text: message });
     clearPendingSuccess();
   }, [pendingSuccess, sendMessage, clearPendingSuccess]);

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/leercoach/_components/portfolio-upload-context.ts
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/leercoach/_components/portfolio-upload-context.ts
@@ -18,13 +18,13 @@
 // sendMessage dependency stays inside AiChatWindow.
 
 import { createContext, use } from "react";
-import type { UploadPriorPortfolioResult } from "../../portfolios/actions";
+import type { UploadSuccessCtx } from "../../portfolios/_components/upload/useUploadPortfolioForm";
 
-export type PortfolioUploadSuccessCtx = {
-  result: Extract<UploadPriorPortfolioResult, { ok: true }>;
-  niveauRang: number | null;
-  label: string;
-};
+// Re-export under the compound's name so consumers outside the
+// portfolio flow see a PortfolioUpload-shaped name. Structurally
+// identical; the durable-ingest refactor moved the canonical type
+// into the upload-form hook.
+export type PortfolioUploadSuccessCtx = UploadSuccessCtx;
 
 export type PortfolioUploadState = {
   dialogOpen: boolean;

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/PortfolioUploadDialog.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/PortfolioUploadDialog.tsx
@@ -6,11 +6,11 @@ import {
   DialogPanel,
   DialogTitle,
 } from "@headlessui/react";
-import type { UploadPriorPortfolioResult } from "../actions";
 import { UploadFields } from "./upload/UploadFields";
 import { UploadResultBanner } from "./upload/UploadResultBanner";
 import {
   type ProfielOption,
+  type UploadSuccessCtx,
   useUploadPortfolioForm,
 } from "./upload/useUploadPortfolioForm";
 
@@ -32,12 +32,13 @@ export type PortfolioUploadDialogProps = {
   handle: string;
   open: boolean;
   onClose: () => void;
-  /** Called after a successful upload — caller composes its follow-up (chat auto-send, toast, revalidate). */
-  onSuccess?: (ctx: {
-    result: Extract<UploadPriorPortfolioResult, { ok: true }>;
-    niveauRang: number | null;
-    label: string;
-  }) => void;
+  /**
+   * Called after the async workflow completes successfully — caller
+   * composes its follow-up (chat auto-send, toast, revalidate). Not
+   * called on failure; consumers can read `form.state.kind === "failed"`
+   * if they need to react.
+   */
+  onSuccess?: (ctx: UploadSuccessCtx) => void;
   /** Pre-populate the file input (e.g. from a drag-drop on the caller). */
   preselectedFile?: File | null;
   /** Full list of kwalificatieprofielen for the scope picker. */
@@ -96,7 +97,7 @@ export function PortfolioUploadDialog({
             </p>
 
             <UploadFields form={form} idPrefix="prior-dialog" />
-            <UploadResultBanner result={form.result} />
+            <UploadResultBanner state={form.state} />
 
             <div className="flex items-center justify-end gap-2 pt-2">
               <button

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/PortfolioUploadDialog.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/PortfolioUploadDialog.tsx
@@ -64,22 +64,21 @@ export function PortfolioUploadDialog({
     preselectedFile,
     onSuccess: (ctx) => {
       onSuccess?.(ctx);
+      // Clear form state after a successful upload. Both consumers
+      // (PortfolioUpload.Provider + PortfolioDropZone) keep the dialog
+      // always-mounted via the `open` prop pattern, so without an
+      // explicit reset the next reopen would show stale banner + the
+      // previous file/profiel selection (bugbot finding).
+      form.reset();
       onClose();
     },
   });
 
-  // Block close while the async workflow is in flight. `form.isPending`
-  // is the `useTransition` flag, which only covers the ~1s the server
-  // action itself is running. Once the action returns, the job still
-  // goes through SWR-driven polling in states 'pending' → 'processing'
-  // → 'ready'. If we let the dialog close during polling, `form.reset()`
-  // clears `jobId`, which stops SWR, which means the onSuccess callback
-  // never fires — the auto-send chat message is silently dropped
-  // (bugbot finding). Guard both cancel-click and backdrop/Escape here.
-  const isWorkflowRunning =
-    form.isPending ||
-    form.state.kind === "pending" ||
-    form.state.kind === "processing";
+  // `isWorkflowRunning` lives on the form hook now (true during the
+  // useTransition action AND the SWR-driven polling phase). We read
+  // it here to gate the close affordance so the onSuccess callback
+  // can't be dropped by an early reset.
+  const { isWorkflowRunning } = form;
 
   function handleClose() {
     if (isWorkflowRunning) return;

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/PortfolioUploadDialog.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/PortfolioUploadDialog.tsx
@@ -68,8 +68,21 @@ export function PortfolioUploadDialog({
     },
   });
 
+  // Block close while the async workflow is in flight. `form.isPending`
+  // is the `useTransition` flag, which only covers the ~1s the server
+  // action itself is running. Once the action returns, the job still
+  // goes through SWR-driven polling in states 'pending' → 'processing'
+  // → 'ready'. If we let the dialog close during polling, `form.reset()`
+  // clears `jobId`, which stops SWR, which means the onSuccess callback
+  // never fires — the auto-send chat message is silently dropped
+  // (bugbot finding). Guard both cancel-click and backdrop/Escape here.
+  const isWorkflowRunning =
+    form.isPending ||
+    form.state.kind === "pending" ||
+    form.state.kind === "processing";
+
   function handleClose() {
-    if (form.isPending) return;
+    if (isWorkflowRunning) return;
     form.reset();
     onClose();
   }
@@ -103,7 +116,7 @@ export function PortfolioUploadDialog({
               <button
                 type="button"
                 onClick={handleClose}
-                disabled={form.isPending}
+                disabled={isWorkflowRunning}
                 className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
               >
                 Annuleer
@@ -113,7 +126,7 @@ export function PortfolioUploadDialog({
                 disabled={!form.canSubmit}
                 className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
               >
-                {form.isPending
+                {isWorkflowRunning
                   ? "Bezig met verwerken…"
                   : "Upload + anonimiseer"}
               </button>

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/PortfolioUploadDialog.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/PortfolioUploadDialog.tsx
@@ -6,6 +6,7 @@ import {
   DialogPanel,
   DialogTitle,
 } from "@headlessui/react";
+import { useRouter } from "next/navigation";
 import { UploadFields } from "./upload/UploadFields";
 import { UploadResultBanner } from "./upload/UploadResultBanner";
 import {
@@ -56,6 +57,7 @@ export function PortfolioUploadDialog({
   profielen,
   defaultProfielId,
 }: PortfolioUploadDialogProps) {
+  const router = useRouter();
   const form = useUploadPortfolioForm({
     open,
     handle,
@@ -70,6 +72,17 @@ export function PortfolioUploadDialog({
       // explicit reset the next reopen would show stale banner + the
       // previous file/profiel selection (bugbot finding).
       form.reset();
+      // Belt-and-braces cache refresh. The workflow's mark-ready step
+      // calls `revalidatePath`, but that runs inside a QStash webhook
+      // callback — bugbot flagged this as potentially flaky because
+      // Upstash's SDK wraps the request in its own signature/replay
+      // handling, which may or may not play nicely with Next.js's
+      // internal cache-invalidation plumbing. `router.refresh()` here
+      // forces the current route segment to re-fetch on the client's
+      // side, so even if the workflow's revalidate silently degraded,
+      // the user's immediate view of /profiel/:handle/portfolios is
+      // fresh.
+      router.refresh();
       onClose();
     },
   });

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/UploadFields.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/UploadFields.tsx
@@ -40,7 +40,13 @@ const RICHTING_OPTIONS: PortfolioRichting[] = [
 ];
 
 export function UploadFields({ form, idPrefix }: Props) {
-  const disabled = form.isPending;
+  // Use `isWorkflowRunning` — not just `isPending` — so fields stay
+  // disabled during the 30-60s SWR polling phase too. Otherwise the
+  // user can edit profiel/label/consent after the server action
+  // returns but before the workflow finishes, and the onSuccess
+  // callback would close over the edited values instead of the
+  // submitted ones (bugbot finding).
+  const disabled = form.isWorkflowRunning;
 
   function handlePickClick() {
     form.fileInputRef.current?.click();

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/UploadFields.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/UploadFields.tsx
@@ -266,6 +266,50 @@ export function UploadFields({ form, idPrefix }: Props) {
           className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
         />
       </div>
+
+      {/* Data-handling disclosure + opt-in checkbox. Transparent by
+          default: the user is told both WHAT we keep (original stays
+          in their account) and WHAT they can optionally share (the
+          anonymised version, for model improvement). Default is
+          opt-out — only the anonymised version used for their own
+          coaching sessions, nothing shared. */}
+      <div className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-slate-50 p-3">
+        <div className="flex flex-col gap-1 text-sm text-slate-700">
+          <p className="font-semibold text-slate-900">
+            Bewaren en verbeteren
+          </p>
+          <p className="text-slate-600">
+            We bewaren je originele portfolio veilig onder je account,
+            zodat je hem later altijd terug kunt vinden of downloaden.
+            Alleen jij hebt er toegang toe.
+          </p>
+          <p className="text-slate-600">
+            Daarnaast maken we een geanonimiseerde versie: namen,
+            plaatsen, verenigingen en datums vervangen we door
+            generieke labels.
+          </p>
+        </div>
+
+        <label className="flex cursor-pointer items-start gap-2 text-sm text-slate-700">
+          <input
+            type="checkbox"
+            checked={form.consentShared}
+            onChange={(e) => form.setConsentShared(e.target.checked)}
+            disabled={disabled}
+            className="mt-0.5"
+          />
+          <span>
+            <span className="font-medium text-slate-900">
+              Ik geef toestemming dat de geanonimiseerde versie
+              gebruikt wordt om de digitale leercoach voor andere
+              kandidaten te verbeteren.
+            </span>
+            <span className="mt-0.5 block text-xs text-slate-500">
+              Optioneel — je originele blijft sowieso privé.
+            </span>
+          </span>
+        </label>
+      </div>
     </>
   );
 }

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/UploadResultBanner.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/UploadResultBanner.tsx
@@ -1,35 +1,64 @@
 "use client";
 
-// Stateless banner for the upload result. Split from the dialog so
+// Stateless banner for the upload lifecycle. Split from the dialog so
 // consumers that embed the upload form inline (no dialog) can render
 // the same result treatment without duplicating markup.
+//
+// Four states → four visual treatments:
+//   - idle                  → render nothing (caller shows the form)
+//   - pending | processing  → blue "verwerken..." with animated spinner
+//   - ready                 → green success banner
+//   - failed                → red error banner with the reason
 
-import type { UploadPriorPortfolioResult } from "../../actions";
+import { ArrowPathIcon } from "@heroicons/react/20/solid";
+import type { UploadState } from "./useUploadPortfolioForm";
 
 type Props = {
-  result: UploadPriorPortfolioResult | null;
+  state: UploadState;
 };
 
-export function UploadResultBanner({ result }: Props) {
-  if (!result) return null;
+export function UploadResultBanner({ state }: Props) {
+  if (state.kind === "idle") return null;
 
-  if (result.ok) {
+  if (state.kind === "pending" || state.kind === "processing") {
     return (
-      <div className="rounded-lg border border-green-300 bg-green-50 p-3 text-sm text-green-900">
-        <p className="font-semibold">
-          {result.alreadyIngested
-            ? "Deze versie stond er al."
-            : `Succes: ${result.chunkCount} fragmenten opgenomen.`}
+      <div className="flex items-center gap-2 rounded-lg border border-blue-300 bg-blue-50 p-3 text-sm text-blue-900">
+        <ArrowPathIcon
+          aria-hidden="true"
+          className="size-4 shrink-0 animate-spin"
+        />
+        <p>
+          <span className="font-semibold">Verwerken…</span>{" "}
+          {state.kind === "pending"
+            ? "Upload ontvangen, anonimisering gestart."
+            : "We anonimiseren je portfolio. Dit kan een minuut duren."}
         </p>
       </div>
     );
   }
 
-  return (
-    <div className="rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-900">
-      <p>
-        <span className="font-semibold">Mislukt:</span> {result.reason}
-      </p>
-    </div>
-  );
+  if (state.kind === "ready") {
+    return (
+      <div className="rounded-lg border border-green-300 bg-green-50 p-3 text-sm text-green-900">
+        <p className="font-semibold">Klaar.</p>
+        <p className="mt-0.5 text-green-800">
+          Je portfolio is geanonimiseerd en opgeslagen. Je originele bestand
+          blijft beschikbaar onder je account.
+        </p>
+      </div>
+    );
+  }
+
+  if (state.kind === "failed") {
+    return (
+      <div className="rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-900">
+        <p>
+          <span className="font-semibold">Mislukt:</span> {state.errorMessage}
+        </p>
+      </div>
+    );
+  }
+
+  // Exhaustiveness — every UploadState branch handled above.
+  return null;
 }

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/useUploadPortfolioForm.ts
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/useUploadPortfolioForm.ts
@@ -225,6 +225,9 @@ export function useUploadPortfolioForm({
     setJobId(null);
     setSubmitError(null);
     submittedSnapshotRef.current = null;
+    // Re-enable polling for the next submission — a previous error
+    // on this form shouldn't permanently disable the poll.
+    pollDisabledRef.current = false;
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
@@ -254,20 +257,41 @@ export function useUploadPortfolioForm({
     | { status: "ready"; sourceId: string }
     | { status: "failed"; errorMessage: string };
 
+  // Tracks whether the status endpoint has errored. Needed because
+  // SWR's `refreshInterval` callback only receives the latest DATA,
+  // not the latest error — without this ref, a persistent fetch
+  // failure (e.g. expired auth returning 401 on every poll) would
+  // keep `latest` undefined, keep `!latest` true, and keep polling
+  // forever in the background even though the UI's failed state is
+  // already final (bugbot finding). `shouldRetryOnError: false`
+  // only disables SWR's internal backoff retry, NOT the refreshInterval
+  // timer. The ref flips on the first error via `onError` and the
+  // interval function returns 0, stopping the poll.
+  const pollDisabledRef = useRef(false);
   const { data: statusData, error: statusError } = useSWR<StatusResponse>(
     jobId ? `/api/upload-job/${jobId}/status` : null,
     fetchUploadJobStatus as (url: string) => Promise<StatusResponse>,
     {
-      refreshInterval: (latest) =>
-        !latest || latest.status === "pending" || latest.status === "processing"
-          ? POLL_INTERVAL_MS
-          : 0,
+      refreshInterval: (latest) => {
+        if (pollDisabledRef.current) return 0;
+        if (
+          !latest ||
+          latest.status === "pending" ||
+          latest.status === "processing"
+        ) {
+          return POLL_INTERVAL_MS;
+        }
+        return 0;
+      },
       // Status is a monotonic state machine — re-fetching on focus
       // gains nothing and just adds noise.
       revalidateOnFocus: false,
       // SWR's built-in error retry would mask terminal failures
       // behind extra fetches; we want to surface them immediately.
       shouldRetryOnError: false,
+      onError: () => {
+        pollDisabledRef.current = true;
+      },
     },
   );
 
@@ -354,6 +378,9 @@ export function useUploadPortfolioForm({
     // Reset any previous failure so re-submits don't show stale state.
     setSubmitError(null);
     setJobId(null);
+    // Re-enable polling — a previous job's error must not permanently
+    // disable the fresh submission we're about to fire.
+    pollDisabledRef.current = false;
 
     // Freeze the values we'll hand to onSuccess when the job completes.
     // Fields are disabled during polling (see `isWorkflowRunning`), but

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/useUploadPortfolioForm.ts
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/useUploadPortfolioForm.ts
@@ -309,13 +309,19 @@ export function useUploadPortfolioForm({
   // interval function returns 0, stopping the poll.
   const pollDisabledRef = useRef(false);
   const { data: statusData, error: statusError } = useSWR<StatusResponse>(
-    // Key goes null once the watchdog trips so SWR stops polling
-    // even if the refreshInterval below is somehow still running.
-    jobId && !pollTimedOut ? `/api/upload-job/${jobId}/status` : null,
+    // Key stays bound to jobId alone so any already-cached terminal
+    // response survives the polling-stop (bugbot round-11 finding:
+    // when the key went null on timeout, a `ready` response arriving
+    // in the same React batch was discarded and the user saw the
+    // timeout banner despite the server actually succeeding). Polling
+    // is stopped via `refreshInterval` + `pollDisabledRef` /
+    // `pollTimedOut` — NOT via the key.
+    jobId ? `/api/upload-job/${jobId}/status` : null,
     fetchUploadJobStatus as (url: string) => Promise<StatusResponse>,
     {
       refreshInterval: (latest) => {
         if (pollDisabledRef.current) return 0;
+        if (pollTimedOut) return 0;
         if (
           !latest ||
           latest.status === "pending" ||
@@ -350,6 +356,23 @@ export function useUploadPortfolioForm({
       return { kind: "failed", jobId: null, errorMessage: submitError };
     }
     if (!jobId) return { kind: "idle" };
+    // Server truth wins over any client-side heuristic (bugbot
+    // round-11 finding: if a `ready` response arrives in the same
+    // React batch as the polling watchdog trips, the client-side
+    // timeout banner used to mask it — the user saw "timed out" for
+    // a job that had actually succeeded). Check terminal statusData
+    // BEFORE `pollTimedOut` and BEFORE `statusError` so the cached
+    // final value always takes precedence.
+    if (statusData?.status === "ready") {
+      return { kind: "ready", jobId, sourceId: statusData.sourceId };
+    }
+    if (statusData?.status === "failed") {
+      return {
+        kind: "failed",
+        jobId,
+        errorMessage: statusData.errorMessage,
+      };
+    }
     if (pollTimedOut) {
       return {
         kind: "failed",
@@ -373,14 +396,12 @@ export function useUploadPortfolioForm({
       // as 'pending' so the UI already shows the spinner.
       return { kind: "pending", jobId };
     }
+    // Non-terminal statuses only reach this point — terminal ones
+    // (`ready` / `failed`) were handled by the early returns above.
     switch (statusData.status) {
       case "pending":
       case "processing":
         return { kind: statusData.status, jobId };
-      case "ready":
-        return { kind: "ready", jobId, sourceId: statusData.sourceId };
-      case "failed":
-        return { kind: "failed", jobId, errorMessage: statusData.errorMessage };
       default:
         // Defensive: if the server ever returns an unexpected shape
         // (e.g. a schema drift we didn't anticipate), don't let the

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/useUploadPortfolioForm.ts
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/useUploadPortfolioForm.ts
@@ -35,8 +35,34 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import useSWR from "swr";
-import { jsonFetcher } from "~/lib/swr";
 import { uploadPortfolioAction } from "../../actions";
+
+// Local fetcher specifically for the upload-job status endpoint.
+// The shared `~/lib/swr` jsonFetcher doesn't check `res.ok`, so
+// 401/404/500 bodies (typically `{ error: "..." }`) would slip
+// through as `data` instead of throwing — which SWR routes into
+// `data` and our downstream state-derivation `switch` would miss,
+// crashing the component with `state.kind` undefined (bugbot
+// finding). Throwing here puts non-2xx responses on SWR's `error`
+// channel and the state-derivation renders the "failed" branch
+// correctly.
+async function fetchUploadJobStatus(url: string): Promise<unknown> {
+  const res = await fetch(url, { cache: "no-store" });
+  if (!res.ok) {
+    let detail: string | null = null;
+    try {
+      const body = (await res.json()) as { error?: string };
+      detail = typeof body.error === "string" ? body.error : null;
+    } catch {
+      // Body wasn't JSON — fall back to the HTTP status line.
+    }
+    throw new Error(
+      detail ??
+        `Status ophalen mislukt (HTTP ${res.status} ${res.statusText}).`,
+    );
+  }
+  return res.json();
+}
 
 export type PortfolioRichting = "instructeur" | "leercoach" | "pvb_beoordelaar";
 
@@ -220,7 +246,7 @@ export function useUploadPortfolioForm({
 
   const { data: statusData, error: statusError } = useSWR<StatusResponse>(
     jobId ? `/api/upload-job/${jobId}/status` : null,
-    jsonFetcher,
+    fetchUploadJobStatus as (url: string) => Promise<StatusResponse>,
     {
       refreshInterval: (latest) =>
         !latest || latest.status === "pending" || latest.status === "processing"
@@ -271,6 +297,16 @@ export function useUploadPortfolioForm({
         return { kind: "ready", jobId, sourceId: statusData.sourceId };
       case "failed":
         return { kind: "failed", jobId, errorMessage: statusData.errorMessage };
+      default:
+        // Defensive: if the server ever returns an unexpected shape
+        // (e.g. a schema drift we didn't anticipate), don't let the
+        // IIFE return `undefined` and crash the component tree —
+        // surface it as a failure the user can at least see.
+        return {
+          kind: "failed",
+          jobId,
+          errorMessage: "Onverwacht statusantwoord van de server.",
+        };
     }
   })();
 

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/useUploadPortfolioForm.ts
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/useUploadPortfolioForm.ts
@@ -198,6 +198,15 @@ export function useUploadPortfolioForm({
     niveauRang: number | null;
     label: string;
   } | null>(null);
+  // Latest-wins ref over the caller's `onSuccess`. The ready-effect
+  // below only depends on `readySourceId` (to fire exactly once on
+  // the terminal transition), so if we closed over `onSuccess`
+  // directly a caller that re-creates the callback each render
+  // (typical when it closes over `onClose`) could end up firing the
+  // stale version (bugbot finding). Synced in render, read in effect
+  // at call time — always the freshest reference.
+  const onSuccessRef = useRef(onSuccess);
+  onSuccessRef.current = onSuccess;
 
   // Seed React state from a preselected file (drop-zone path). The
   // native <input type="file"> is hidden in the fields component, so
@@ -398,7 +407,9 @@ export function useUploadPortfolioForm({
     // see `submittedSnapshotRef`. Falls back to live values only if the
     // snapshot is missing (shouldn't happen; submit() always sets it).
     const snapshot = submittedSnapshotRef.current;
-    onSuccess?.({
+    // Read via ref so we always call the freshest callback, even if
+    // the caller re-creates it each render (see onSuccessRef comment).
+    onSuccessRef.current?.({
       jobId,
       sourceId: readySourceId,
       niveauRang: snapshot?.niveauRang ?? selectedProfiel?.niveauRang ?? null,

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/useUploadPortfolioForm.ts
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/useUploadPortfolioForm.ts
@@ -19,16 +19,17 @@
 //   - coverage: optional narrowing WITHIN the profiel. A kandidaat can
 //     say "this PDF only covers kerntaak 4.1" when their upload is a
 //     single-kerntaak document. Default is the whole profiel.
+//
+// Async lifecycle (new as of durable-ingest PR):
+//   - submit() returns fast (~1s) with a jobId from the upload action.
+//     The heavy work (PDF extract + LLM anonymisation + chunk + store)
+//     runs in an Upstash Workflow in the background.
+//   - This hook polls /api/upload-job/:id/status every 2s while the
+//     workflow runs; terminal status ('ready' or 'failed') stops polling
+//     and fires onSuccess / populates the error state.
 
-import { useEffect, useMemo, useRef, useState, useTransition } from "react";
-import {
-  type UploadPriorPortfolioResult,
-  uploadPortfolioAction,
-} from "../../actions";
-
-export type UploadPriorPortfolioForm = ReturnType<
-  typeof useUploadPortfolioForm
->;
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { uploadPortfolioAction } from "../../actions";
 
 export type PortfolioRichting = "instructeur" | "leercoach" | "pvb_beoordelaar";
 
@@ -50,6 +51,37 @@ export type CoverageScope =
   | { type: "full_profiel" }
   | { type: "kerntaken"; kerntaakCodes: string[] };
 
+/**
+ * Client-side view of the upload's progression. Maps one-to-one to
+ * upload_job.status server-side but adds an implicit "idle" state for
+ * the form before anything has been submitted, and a "failed_submit"
+ * state for the narrow window where the action itself throws before
+ * ever creating a job row. Consumers render the matching UI for each.
+ */
+export type UploadState =
+  | { kind: "idle" }
+  | {
+      kind: "pending" | "processing";
+      jobId: string;
+    }
+  | {
+      kind: "ready";
+      jobId: string;
+      sourceId: string;
+    }
+  | {
+      kind: "failed";
+      jobId: string | null;
+      errorMessage: string;
+    };
+
+export type UploadSuccessCtx = {
+  jobId: string;
+  sourceId: string;
+  niveauRang: number | null;
+  label: string;
+};
+
 export type UseUploadPriorPortfolioFormOptions = {
   /** Open state — controls the "seed preselectedFile" effect timing. */
   open: boolean;
@@ -66,13 +98,21 @@ export type UseUploadPriorPortfolioFormOptions = {
   defaultProfielId?: string | null;
   /** Seed the file input from a drag-drop event on a parent component. */
   preselectedFile?: File | null;
-  /** Called after a successful upload, with the server result. */
-  onSuccess?: (ctx: {
-    result: Extract<UploadPriorPortfolioResult, { ok: true }>;
-    niveauRang: number | null;
-    label: string;
-  }) => void;
+  /**
+   * Called when the async workflow completes successfully. Receives
+   * the sourceId so callers can deep-link or revalidate. Not called
+   * on failure — consumers can read `state.kind === "failed"` from
+   * the hook's return.
+   */
+  onSuccess?: (ctx: UploadSuccessCtx) => void;
 };
+
+// Polling cadence for the workflow status endpoint. 2s is fast enough
+// that the UI feels responsive for short jobs (<15s) and slow enough
+// that a 5-minute worst-case job only hits the endpoint ~150 times.
+// The endpoint reads a single indexed row; cost is negligible either
+// way.
+const POLL_INTERVAL_MS = 2000;
 
 export function useUploadPortfolioForm({
   open,
@@ -88,9 +128,15 @@ export function useUploadPortfolioForm({
   const [coverage, setCoverage] = useState<CoverageScope>({
     type: "full_profiel",
   });
-  const [result, setResult] = useState<UploadPriorPortfolioResult | null>(null);
+  // New: opt-in consent for using the anonymised version to improve
+  // the model for other kandidaten. Default OFF — explicit opt-in only.
+  const [consentShared, setConsentShared] = useState(false);
+  const [state, setState] = useState<UploadState>({ kind: "idle" });
   const [isPending, startTransition] = useTransition();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // Stable reference so the polling effect's cleanup cancels the
+  // correct in-flight fetch when the hook unmounts mid-request.
+  const pollAbortRef = useRef<AbortController | null>(null);
 
   // Seed React state from a preselected file (drop-zone path). The
   // native <input type="file"> is hidden in the fields component, so
@@ -125,16 +171,19 @@ export function useUploadPortfolioForm({
     setCoverage({ type: "full_profiel" });
   }, [profielId]);
 
-  function reset() {
+  const reset = useCallback(() => {
     setFile(null);
     setLabel("");
     setProfielId(defaultProfielId ?? "");
     setCoverage({ type: "full_profiel" });
-    setResult(null);
+    setConsentShared(false);
+    setState({ kind: "idle" });
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
-  }
+    pollAbortRef.current?.abort();
+    pollAbortRef.current = null;
+  }, [defaultProfielId]);
 
   function toggleKerntaak(code: string, checked: boolean) {
     setCoverage((prev) => {
@@ -147,37 +196,114 @@ export function useUploadPortfolioForm({
     });
   }
 
+  // Poll the workflow's status endpoint while the job is in flight.
+  // Effect hook re-fires whenever `state.kind` transitions into a
+  // polling state; cleanup aborts the in-flight fetch + stops the
+  // timer chain if the consumer closes the dialog.
+  useEffect(() => {
+    if (state.kind !== "pending" && state.kind !== "processing") {
+      return;
+    }
+    const jobId = state.jobId;
+    const abort = new AbortController();
+    pollAbortRef.current = abort;
+
+    let cancelled = false;
+    const poll = async () => {
+      if (cancelled) return;
+      try {
+        const res = await fetch(`/api/upload-job/${jobId}/status`, {
+          signal: abort.signal,
+          cache: "no-store",
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const body = (await res.json()) as
+          | { status: "pending" | "processing" }
+          | { status: "ready"; sourceId: string }
+          | { status: "failed"; errorMessage: string };
+
+        if (cancelled) return;
+        switch (body.status) {
+          case "pending":
+          case "processing":
+            setState({ kind: body.status, jobId });
+            setTimeout(poll, POLL_INTERVAL_MS);
+            break;
+          case "ready":
+            setState({ kind: "ready", jobId, sourceId: body.sourceId });
+            onSuccess?.({
+              jobId,
+              sourceId: body.sourceId,
+              niveauRang: selectedProfiel?.niveauRang ?? null,
+              label: label.trim(),
+            });
+            break;
+          case "failed":
+            setState({
+              kind: "failed",
+              jobId,
+              errorMessage: body.errorMessage,
+            });
+            break;
+        }
+      } catch (err) {
+        // AbortError fires on cleanup — silent.
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        if (cancelled) return;
+        setState({
+          kind: "failed",
+          jobId,
+          errorMessage:
+            err instanceof Error
+              ? `Status ophalen mislukt: ${err.message}`
+              : "Status ophalen mislukt.",
+        });
+      }
+    };
+    // First poll fires immediately — the action's return races ahead
+    // of the first workflow step, so the first poll usually sees
+    // status='pending' or 'processing' right away, which renders the
+    // right UI. No initial delay.
+    void poll();
+
+    return () => {
+      cancelled = true;
+      abort.abort();
+    };
+    // selectedProfiel + label are captured for the onSuccess callback
+    // only; re-running the effect on every label keystroke would
+    // cancel+restart polling mid-job. Intentionally omitted from deps.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: see above
+  }, [state.kind, state.kind === "pending" || state.kind === "processing" ? state.jobId : null, onSuccess]);
+
   function submit() {
     if (!file || !selectedProfiel) return;
-    // Client-side coverage validation: if the user switched to
-    // "kerntaken" but selected zero, block submit. Server validates
-    // again.
     if (coverage.type === "kerntaken" && coverage.kerntaakCodes.length === 0)
       return;
 
-    setResult(null);
+    setState({ kind: "idle" });
     const formData = new FormData();
     formData.append("file", file);
     formData.append("handle", handle);
     formData.append("profielId", selectedProfiel.id);
     formData.append("coverage", JSON.stringify(coverage));
+    formData.append("consentShared", consentShared ? "true" : "false");
     if (label.trim()) formData.append("label", label.trim());
 
     startTransition(async () => {
       const r = await uploadPortfolioAction(formData);
-      setResult(r);
       if (r.ok) {
-        const effectiveNiveau = selectedProfiel.niveauRang;
-        // Brief pause so the success banner is visible before callers
-        // tear down (e.g. close the dialog + send a chat message).
-        setTimeout(() => {
-          onSuccess?.({
-            result: r,
-            niveauRang: effectiveNiveau,
-            label: label.trim(),
-          });
-          reset();
-        }, 700);
+        // Kick polling. Transitions isPending off instantly; the
+        // polling effect takes over rendering state from here.
+        setState({ kind: "pending", jobId: r.jobId });
+      } else {
+        // The action itself rejected (validation, Storage upload
+        // failure, etc.). No jobId to poll — show the error inline.
+        setState({
+          kind: "failed",
+          jobId: null,
+          errorMessage: r.reason,
+        });
       }
     });
   }
@@ -186,25 +312,35 @@ export function useUploadPortfolioForm({
     coverage.type === "full_profiel" ||
     (coverage.type === "kerntaken" && coverage.kerntaakCodes.length > 0);
   const canSubmit =
-    file !== null && selectedProfiel !== null && coverageComplete && !isPending;
+    file !== null &&
+    selectedProfiel !== null &&
+    coverageComplete &&
+    !isPending &&
+    // Don't let the user submit while a previous upload is still in
+    // flight — reset first, or close + reopen the dialog.
+    state.kind !== "pending" &&
+    state.kind !== "processing";
 
   return {
-    // state
+    // form state
     file,
     label,
     profielId,
     coverage,
-    result,
+    consentShared,
     isPending,
     canSubmit,
     selectedProfiel,
     profielen,
+    // lifecycle state
+    state,
     // setters (single field each; presentational components wire these
     // to their inputs directly)
     setFile,
     setLabel,
     setProfielId,
     setCoverage,
+    setConsentShared,
     toggleKerntaak,
     // refs
     fileInputRef,
@@ -213,3 +349,5 @@ export function useUploadPortfolioForm({
     reset,
   };
 }
+
+export type UploadPriorPortfolioForm = ReturnType<typeof useUploadPortfolioForm>;

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/useUploadPortfolioForm.ts
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/useUploadPortfolioForm.ts
@@ -147,6 +147,17 @@ export type UseUploadPriorPortfolioFormOptions = {
 // way.
 const POLL_INTERVAL_MS = 2000;
 
+// Client-side hard ceiling on how long we'll keep the user in the
+// "Verwerken…" state. Comfortably above the realistic worst case for
+// a portfolio ingest (30-60s typical, up to ~4 minutes for a very
+// large PDF), but short enough to give a silently stalled workflow
+// a definite UX exit (bugbot finding: without a ceiling, a lost
+// QStash webhook would keep the user polling forever with no escape).
+// The workflow itself has step-level retries from Upstash, so by the
+// time we hit this we're firmly in "something is actually broken"
+// territory — surface a failure so the user can retry.
+const POLL_TIMEOUT_MS = 10 * 60 * 1000;
+
 export function useUploadPortfolioForm({
   open,
   handle,
@@ -171,6 +182,11 @@ export function useUploadPortfolioForm({
   //     polling says it failed. UI can offer "retry" specifically.
   const [jobId, setJobId] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  // Flipped by a setTimeout when polling exceeds POLL_TIMEOUT_MS —
+  // gives the user an escape hatch from a silently-stalled workflow
+  // (bugbot finding). Nulling jobId on reset/re-submit clears the
+  // timer via the effect cleanup.
+  const [pollTimedOut, setPollTimedOut] = useState(false);
   const [isPending, startTransition] = useTransition();
   const fileInputRef = useRef<HTMLInputElement>(null);
   // Snapshot of the form values that were actually submitted. Freezes
@@ -216,6 +232,20 @@ export function useUploadPortfolioForm({
     setCoverage({ type: "full_profiel" });
   }, [profielId]);
 
+  // Start a watchdog the moment a jobId is set. If the workflow
+  // finishes (statusData flips to 'ready'/'failed') the useSWR cache
+  // returns a terminal state first and the state machine renders the
+  // result — this timer fires only in the pathological case where
+  // the workflow has gone dark. Cleanup on jobId change (reset /
+  // re-submit) clears the pending timer.
+  useEffect(() => {
+    if (!jobId) return;
+    const timer = setTimeout(() => {
+      setPollTimedOut(true);
+    }, POLL_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [jobId]);
+
   const reset = useCallback(() => {
     setFile(null);
     setLabel("");
@@ -224,6 +254,7 @@ export function useUploadPortfolioForm({
     setConsentShared(false);
     setJobId(null);
     setSubmitError(null);
+    setPollTimedOut(false);
     submittedSnapshotRef.current = null;
     // Re-enable polling for the next submission — a previous error
     // on this form shouldn't permanently disable the poll.
@@ -269,7 +300,9 @@ export function useUploadPortfolioForm({
   // interval function returns 0, stopping the poll.
   const pollDisabledRef = useRef(false);
   const { data: statusData, error: statusError } = useSWR<StatusResponse>(
-    jobId ? `/api/upload-job/${jobId}/status` : null,
+    // Key goes null once the watchdog trips so SWR stops polling
+    // even if the refreshInterval below is somehow still running.
+    jobId && !pollTimedOut ? `/api/upload-job/${jobId}/status` : null,
     fetchUploadJobStatus as (url: string) => Promise<StatusResponse>,
     {
       refreshInterval: (latest) => {
@@ -308,6 +341,14 @@ export function useUploadPortfolioForm({
       return { kind: "failed", jobId: null, errorMessage: submitError };
     }
     if (!jobId) return { kind: "idle" };
+    if (pollTimedOut) {
+      return {
+        kind: "failed",
+        jobId,
+        errorMessage:
+          "Verwerken duurt ongewoon lang. De achtergrond­taak is mogelijk nog bezig, maar je kunt dit venster sluiten en later in je portfolio’s kijken.",
+      };
+    }
     if (statusError) {
       return {
         kind: "failed",
@@ -378,6 +419,7 @@ export function useUploadPortfolioForm({
     // Reset any previous failure so re-submits don't show stale state.
     setSubmitError(null);
     setJobId(null);
+    setPollTimedOut(false);
     // Re-enable polling — a previous job's error must not permanently
     // disable the fresh submission we're about to fire.
     pollDisabledRef.current = false;

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/useUploadPortfolioForm.ts
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/useUploadPortfolioForm.ts
@@ -173,6 +173,15 @@ export function useUploadPortfolioForm({
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // Snapshot of the form values that were actually submitted. Freezes
+  // the values `onSuccess` hands to the parent so they can't drift if
+  // UI state is mutated between submit and the 'ready' transition
+  // (bugbot finding — the ready-effect closed over live `selectedProfiel`
+  // + `label`, so any edit during polling would poison the callback).
+  const submittedSnapshotRef = useRef<{
+    niveauRang: number | null;
+    label: string;
+  } | null>(null);
 
   // Seed React state from a preselected file (drop-zone path). The
   // native <input type="file"> is hidden in the fields component, so
@@ -215,6 +224,7 @@ export function useUploadPortfolioForm({
     setConsentShared(false);
     setJobId(null);
     setSubmitError(null);
+    submittedSnapshotRef.current = null;
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
@@ -319,16 +329,20 @@ export function useUploadPortfolioForm({
   const readySourceId = state.kind === "ready" ? state.sourceId : null;
   useEffect(() => {
     if (!readySourceId || !jobId) return;
+    // Read from the submit-time snapshot, not the current form state —
+    // see `submittedSnapshotRef`. Falls back to live values only if the
+    // snapshot is missing (shouldn't happen; submit() always sets it).
+    const snapshot = submittedSnapshotRef.current;
     onSuccess?.({
       jobId,
       sourceId: readySourceId,
-      niveauRang: selectedProfiel?.niveauRang ?? null,
-      label: label.trim(),
+      niveauRang: snapshot?.niveauRang ?? selectedProfiel?.niveauRang ?? null,
+      label: snapshot?.label ?? label.trim(),
     });
-    // selectedProfiel + label + jobId are captured at the transition
-    // render; they're stable during polling (form isn't re-editable
-    // after submit), so omitting them from deps is correct — we only
-    // want this to fire on the ready transition.
+    // Intentionally fire only on the 'ready' transition. The snapshot
+    // ref makes the other values deterministic, so we don't need them
+    // in deps; we specifically don't want this to re-fire if the user
+    // edits label/profielId after the job is ready.
     // biome-ignore lint/correctness/useExhaustiveDependencies: see comment
   }, [readySourceId]);
 
@@ -340,6 +354,17 @@ export function useUploadPortfolioForm({
     // Reset any previous failure so re-submits don't show stale state.
     setSubmitError(null);
     setJobId(null);
+
+    // Freeze the values we'll hand to onSuccess when the job completes.
+    // Fields are disabled during polling (see `isWorkflowRunning`), but
+    // this ref makes that a belt-and-braces contract — even if a future
+    // caller forgets to respect the disabled state, the callback
+    // receives the submitted values, not whatever's in state when the
+    // job happens to flip to 'ready'.
+    submittedSnapshotRef.current = {
+      niveauRang: selectedProfiel.niveauRang,
+      label: label.trim(),
+    };
 
     const formData = new FormData();
     formData.append("file", file);
@@ -365,15 +390,18 @@ export function useUploadPortfolioForm({
   const coverageComplete =
     coverage.type === "full_profiel" ||
     (coverage.type === "kerntaken" && coverage.kerntaakCodes.length > 0);
+  // True while *anything* async is happening — the useTransition flag
+  // for the server action, OR the SWR-driven polling of a running job.
+  // Consumers use this to disable inputs + close affordances so the
+  // form values match what we actually sent to the server (bugbot
+  // finding: fields remained editable during the 30-60s polling phase).
+  const isWorkflowRunning =
+    isPending || state.kind === "pending" || state.kind === "processing";
   const canSubmit =
     file !== null &&
     selectedProfiel !== null &&
     coverageComplete &&
-    !isPending &&
-    // Don't let the user submit while a previous upload is still in
-    // flight — reset first, or close + reopen the dialog.
-    state.kind !== "pending" &&
-    state.kind !== "processing";
+    !isWorkflowRunning;
 
   return {
     // form state
@@ -383,6 +411,7 @@ export function useUploadPortfolioForm({
     coverage,
     consentShared,
     isPending,
+    isWorkflowRunning,
     canSubmit,
     selectedProfiel,
     profielen,

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/useUploadPortfolioForm.ts
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/upload/useUploadPortfolioForm.ts
@@ -24,11 +24,18 @@
 //   - submit() returns fast (~1s) with a jobId from the upload action.
 //     The heavy work (PDF extract + LLM anonymisation + chunk + store)
 //     runs in an Upstash Workflow in the background.
-//   - This hook polls /api/upload-job/:id/status every 2s while the
-//     workflow runs; terminal status ('ready' or 'failed') stops polling
-//     and fires onSuccess / populates the error state.
+//   - SWR drives the status polling. The key flips from null → the
+//     status URL the instant jobId is set, and `refreshInterval`
+//     returns 2000 until the row reaches a terminal status, at which
+//     point it returns 0 and SWR stops fetching. UI state is derived
+//     purely from SWR's cache + submitError — no setState-in-effect
+//     shenanigans, no AbortController plumbing, no setTimeout chains.
+//     When the dialog unmounts, SWR's own cleanup cancels in-flight
+//     requests.
 
 import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
+import useSWR from "swr";
+import { jsonFetcher } from "~/lib/swr";
 import { uploadPortfolioAction } from "../../actions";
 
 export type PortfolioRichting = "instructeur" | "leercoach" | "pvb_beoordelaar";
@@ -131,12 +138,15 @@ export function useUploadPortfolioForm({
   // New: opt-in consent for using the anonymised version to improve
   // the model for other kandidaten. Default OFF — explicit opt-in only.
   const [consentShared, setConsentShared] = useState(false);
-  const [state, setState] = useState<UploadState>({ kind: "idle" });
+  // Two separate failure surfaces so we can distinguish:
+  //   - submitError: the action itself rejected (validation, Storage
+  //     upload failure) BEFORE creating a job. No jobId to poll.
+  //   - jobId + SWR error / job.status='failed': the job exists and
+  //     polling says it failed. UI can offer "retry" specifically.
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const fileInputRef = useRef<HTMLInputElement>(null);
-  // Stable reference so the polling effect's cleanup cancels the
-  // correct in-flight fetch when the hook unmounts mid-request.
-  const pollAbortRef = useRef<AbortController | null>(null);
 
   // Seed React state from a preselected file (drop-zone path). The
   // native <input type="file"> is hidden in the fields component, so
@@ -177,12 +187,13 @@ export function useUploadPortfolioForm({
     setProfielId(defaultProfielId ?? "");
     setCoverage({ type: "full_profiel" });
     setConsentShared(false);
-    setState({ kind: "idle" });
+    setJobId(null);
+    setSubmitError(null);
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
-    pollAbortRef.current?.abort();
-    pollAbortRef.current = null;
+    // SWR's polling stops automatically when its key goes null (the
+    // jobId reset above). No manual cleanup needed.
   }, [defaultProfielId]);
 
   function toggleKerntaak(code: string, checked: boolean) {
@@ -196,92 +207,104 @@ export function useUploadPortfolioForm({
     });
   }
 
-  // Poll the workflow's status endpoint while the job is in flight.
-  // Effect hook re-fires whenever `state.kind` transitions into a
-  // polling state; cleanup aborts the in-flight fetch + stops the
-  // timer chain if the consumer closes the dialog.
-  useEffect(() => {
-    if (state.kind !== "pending" && state.kind !== "processing") {
-      return;
+  // SWR drives the polling. When jobId is null the key is null → no
+  // fetch. When jobId is set, SWR polls on the returned interval
+  // function; once status hits a terminal state (ready/failed) the
+  // interval goes to 0 and SWR stops polling. Unmount / dialog close
+  // stops it too (SWR handles its own cleanup — no AbortController
+  // plumbing, no setTimeout chain).
+  type StatusResponse =
+    | { status: "pending" | "processing" }
+    | { status: "ready"; sourceId: string }
+    | { status: "failed"; errorMessage: string };
+
+  const { data: statusData, error: statusError } = useSWR<StatusResponse>(
+    jobId ? `/api/upload-job/${jobId}/status` : null,
+    jsonFetcher,
+    {
+      refreshInterval: (latest) =>
+        !latest || latest.status === "pending" || latest.status === "processing"
+          ? POLL_INTERVAL_MS
+          : 0,
+      // Status is a monotonic state machine — re-fetching on focus
+      // gains nothing and just adds noise.
+      revalidateOnFocus: false,
+      // SWR's built-in error retry would mask terminal failures
+      // behind extra fetches; we want to surface them immediately.
+      shouldRetryOnError: false,
+    },
+  );
+
+  // Derive the UI state machine from the three independent signals:
+  //   - submitError: action threw before a job was created
+  //   - jobId + statusData/statusError: async job exists and we're
+  //     polling its status
+  // This replaces the old setState-in-effect pattern — now state is
+  // purely derived, which means it can never drift from the source
+  // of truth (SWR's cache) and there's no manual reconciliation
+  // needed on every poll tick.
+  const state: UploadState = (() => {
+    if (submitError) {
+      return { kind: "failed", jobId: null, errorMessage: submitError };
     }
-    const jobId = state.jobId;
-    const abort = new AbortController();
-    pollAbortRef.current = abort;
+    if (!jobId) return { kind: "idle" };
+    if (statusError) {
+      return {
+        kind: "failed",
+        jobId,
+        errorMessage:
+          statusError instanceof Error
+            ? `Status ophalen mislukt: ${statusError.message}`
+            : "Status ophalen mislukt.",
+      };
+    }
+    if (!statusData) {
+      // jobId is set but the first poll hasn't returned yet. Treat
+      // as 'pending' so the UI already shows the spinner.
+      return { kind: "pending", jobId };
+    }
+    switch (statusData.status) {
+      case "pending":
+      case "processing":
+        return { kind: statusData.status, jobId };
+      case "ready":
+        return { kind: "ready", jobId, sourceId: statusData.sourceId };
+      case "failed":
+        return { kind: "failed", jobId, errorMessage: statusData.errorMessage };
+    }
+  })();
 
-    let cancelled = false;
-    const poll = async () => {
-      if (cancelled) return;
-      try {
-        const res = await fetch(`/api/upload-job/${jobId}/status`, {
-          signal: abort.signal,
-          cache: "no-store",
-        });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const body = (await res.json()) as
-          | { status: "pending" | "processing" }
-          | { status: "ready"; sourceId: string }
-          | { status: "failed"; errorMessage: string };
-
-        if (cancelled) return;
-        switch (body.status) {
-          case "pending":
-          case "processing":
-            setState({ kind: body.status, jobId });
-            setTimeout(poll, POLL_INTERVAL_MS);
-            break;
-          case "ready":
-            setState({ kind: "ready", jobId, sourceId: body.sourceId });
-            onSuccess?.({
-              jobId,
-              sourceId: body.sourceId,
-              niveauRang: selectedProfiel?.niveauRang ?? null,
-              label: label.trim(),
-            });
-            break;
-          case "failed":
-            setState({
-              kind: "failed",
-              jobId,
-              errorMessage: body.errorMessage,
-            });
-            break;
-        }
-      } catch (err) {
-        // AbortError fires on cleanup — silent.
-        if (err instanceof DOMException && err.name === "AbortError") return;
-        if (cancelled) return;
-        setState({
-          kind: "failed",
-          jobId,
-          errorMessage:
-            err instanceof Error
-              ? `Status ophalen mislukt: ${err.message}`
-              : "Status ophalen mislukt.",
-        });
-      }
-    };
-    // First poll fires immediately — the action's return races ahead
-    // of the first workflow step, so the first poll usually sees
-    // status='pending' or 'processing' right away, which renders the
-    // right UI. No initial delay.
-    void poll();
-
-    return () => {
-      cancelled = true;
-      abort.abort();
-    };
-    // selectedProfiel + label are captured for the onSuccess callback
-    // only; re-running the effect on every label keystroke would
-    // cancel+restart polling mid-job. Intentionally omitted from deps.
-    // biome-ignore lint/correctness/useExhaustiveDependencies: see above
-  }, [state.kind, state.kind === "pending" || state.kind === "processing" ? state.jobId : null, onSuccess]);
+  // Notify parent on terminal success. The effect fires exactly when
+  // the derived state transitions into 'ready' (source id is
+  // immutable per job, so the dep list never re-fires mid-session).
+  // This is a legitimate "sync to external system" useEffect —
+  // notifying the parent of a state change, not orchestrating the
+  // fetch itself.
+  const readySourceId = state.kind === "ready" ? state.sourceId : null;
+  useEffect(() => {
+    if (!readySourceId || !jobId) return;
+    onSuccess?.({
+      jobId,
+      sourceId: readySourceId,
+      niveauRang: selectedProfiel?.niveauRang ?? null,
+      label: label.trim(),
+    });
+    // selectedProfiel + label + jobId are captured at the transition
+    // render; they're stable during polling (form isn't re-editable
+    // after submit), so omitting them from deps is correct — we only
+    // want this to fire on the ready transition.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: see comment
+  }, [readySourceId]);
 
   function submit() {
     if (!file || !selectedProfiel) return;
     if (coverage.type === "kerntaken" && coverage.kerntaakCodes.length === 0)
       return;
 
-    setState({ kind: "idle" });
+    // Reset any previous failure so re-submits don't show stale state.
+    setSubmitError(null);
+    setJobId(null);
+
     const formData = new FormData();
     formData.append("file", file);
     formData.append("handle", handle);
@@ -293,17 +316,12 @@ export function useUploadPortfolioForm({
     startTransition(async () => {
       const r = await uploadPortfolioAction(formData);
       if (r.ok) {
-        // Kick polling. Transitions isPending off instantly; the
-        // polling effect takes over rendering state from here.
-        setState({ kind: "pending", jobId: r.jobId });
+        // Setting jobId flips SWR's key from null → a real URL, which
+        // triggers the first fetch and the refreshInterval function.
+        // From here the derived `state` takes over driving the UI.
+        setJobId(r.jobId);
       } else {
-        // The action itself rejected (validation, Storage upload
-        // failure, etc.). No jobId to poll — show the error inline.
-        setState({
-          kind: "failed",
-          jobId: null,
-          errorMessage: r.reason,
-        });
+        setSubmitError(r.reason);
       }
     });
   }

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/actions.ts
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/actions.ts
@@ -239,6 +239,12 @@ export async function uploadPortfolioAction(
         niveauRang: resolved.niveauRang,
         coverage,
         consentShared,
+        // Handle is stashed here so the workflow's mark-ready +
+        // failure paths can revalidate the user's portfolio/leercoach
+        // pages when the async pipeline finishes (bugbot finding: the
+        // old sync flow did this at the end of ingest, the async flow
+        // lost it).
+        handle,
       },
     });
     jobId = created.jobId;

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/actions.ts
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/actions.ts
@@ -277,12 +277,28 @@ export async function uploadPortfolioAction(
     });
   } catch (err) {
     console.error("Failed to trigger ingest-portfolio workflow", err);
-    await Leercoach.UploadJob.updateStatus({
-      jobId,
-      status: "failed",
-      errorMessage:
-        err instanceof Error ? err.message : "Workflow trigger failed",
-    });
+    // Defensive inner try: if the DB is also having a bad day, the
+    // updateStatus throw would propagate out of this server action
+    // unhandled — the client's startTransition callback doesn't
+    // catch, so the user would see nothing and the job row would
+    // stay stuck on its pre-catch state with no workflow running
+    // (bugbot finding). Logging + continuing keeps the `ok:true`
+    // return path intact; the polling UI will see either 'failed'
+    // (if the updateStatus succeeded) or 'pending' → eventual
+    // timeout (if it didn't) — either way the user gets feedback.
+    try {
+      await Leercoach.UploadJob.updateStatus({
+        jobId,
+        status: "failed",
+        errorMessage:
+          err instanceof Error ? err.message : "Workflow trigger failed",
+      });
+    } catch (markErr) {
+      console.error(
+        `Failed to mark upload_job ${jobId} as failed after workflow trigger failure`,
+        markErr,
+      );
+    }
   }
 
   if (handle) {

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/actions.ts
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { AiCorpus } from "@nawadi/core";
+import { AiCorpus, Leercoach } from "@nawadi/core";
 import { revalidatePath } from "next/cache";
 import {
   getUserOrThrow,
@@ -8,8 +8,12 @@ import {
   listKssNiveaus,
 } from "~/lib/nwd";
 import {
+  deletePortfolioOriginal,
+  uploadPortfolioOriginal,
+} from "~/lib/portfolio-storage";
+import { triggerIngestPortfolio } from "~/lib/workflow-client";
+import {
   type CoverageScope,
-  ingestPortfolio,
   type PortfolioRichting,
 } from "./_lib/portfolio-pipeline";
 
@@ -104,25 +108,38 @@ const MAX_UPLOAD_BYTES = 15 * 1024 * 1024;
 export type UploadPriorPortfolioResult =
   | {
       ok: true;
-      sourceId: string;
-      chunkCount: number;
-      pageCount: number;
-      alreadyIngested: boolean;
+      /**
+       * Handle the client polls for completion. See
+       * /api/upload-job/[id]/status.
+       */
+      jobId: string;
+      /**
+       * Always "pending" on success — the actual work runs async in
+       * the Upstash Workflow. Included for clarity at the call site.
+       */
+      status: "pending";
     }
   | { ok: false; reason: string };
 
 /**
- * Accept a portfolio PDF upload, run it through the extract + anonymize
- * + ingest pipeline, and return a summary for the UI.
+ * Accept a portfolio PDF upload. Stashes the raw bytes in Supabase
+ * Storage, creates an upload_job row for status tracking, and fires
+ * an Upstash Workflow that runs the extract + anonymise + ingest
+ * pipeline durably in the background.
  *
- * A kwalificatieprofiel is required: it already encodes richting +
- * niveau. Coverage (whole profiel vs. specific kerntaken) is optional
- * metadata — default is the whole profiel.
+ * Returns fast (~1s) with a jobId the client uses to poll status.
+ * Previous behaviour ran the entire pipeline inside the action — the
+ * LLM anonymisation step regularly exceeded Vercel's 30s timeout and
+ * tore down unrelated server actions on the same route. See
+ * apps/web/src/app/api/workflow/ingest-portfolio/route.ts for the
+ * new pipeline shape.
  *
- * Revalidates both the portfolios management page AND the leercoach
- * session list for this handle so existing tabs reflect the new data.
- * The pipeline is idempotent (source_hash dedup) so re-uploading the
- * same PDF returns the existing row without touching anything.
+ * The original PDF is preserved in the `portfolio-uploads` bucket
+ * indefinitely — users retain access to their raw upload via a
+ * signed-URL flow (follow-up UI). The anonymised version is what
+ * gets chunked + stored in ai_corpus; `consentShared=true` at upload
+ * time marks it as opt_in_shared so we can use it to improve the
+ * model for other kandidaten.
  */
 export async function uploadPortfolioAction(
   formData: FormData,
@@ -170,59 +187,130 @@ export async function uploadPortfolioAction(
       ? labelRaw.trim()
       : file.name.replace(/\.pdf$/i, "");
 
+  // Opt-in consent for using the anonymised version to improve the
+  // digital leercoach model for other kandidaten. Default off —
+  // user's original + anonymised version are user_only unless they
+  // explicitly tick the box.
+  const consentRaw = formData.get("consentShared");
+  const consentShared = consentRaw === "true" || consentRaw === "on";
+
   const handleRaw = formData.get("handle");
   const handle = typeof handleRaw === "string" ? handleRaw : null;
 
   const arrayBuffer = await file.arrayBuffer();
   const bytes = new Uint8Array(arrayBuffer);
 
+  // Step 1: stash the raw bytes durably. No deletion after ingest —
+  // we preserve originals for the user's own retrieval.
+  let blobPath: string;
   try {
-    const result = await ingestPortfolio({
+    const stashed = await uploadPortfolioOriginal({
       userId: user.authUserId,
-      pdfBytes: bytes,
-      profielId,
-      richting: resolved.richting,
-      niveauRang: resolved.niveauRang,
-      coverage,
-      label,
+      bytes,
+      filename: file.name,
     });
-    if (handle) {
-      revalidatePath(`/profiel/${handle}/portfolios`);
-      revalidatePath(`/profiel/${handle}/leercoach`);
-      revalidatePath(`/profiel/${handle}`);
-    }
-    return {
-      ok: true,
-      sourceId: result.sourceId,
-      chunkCount: result.chunkCount,
-      pageCount: result.pageCount,
-      alreadyIngested: result.alreadyIngested,
-    };
+    blobPath = stashed.path;
   } catch (err) {
-    console.error("Portfolio ingest failed", err);
+    console.error("Portfolio Storage upload failed", err);
     return {
       ok: false,
       reason:
         err instanceof Error
-          ? `Verwerken mislukt: ${err.message}`
-          : "Verwerken mislukt.",
+          ? `Uploaden mislukt: ${err.message}`
+          : "Uploaden mislukt.",
     };
   }
+
+  // Step 2: create the upload_job row. This is the pollable handle
+  // the client uses to track completion.
+  const { jobId } = await Leercoach.UploadJob.create({
+    userId: user.authUserId,
+    kind: "portfolio",
+    blobPath,
+    label,
+    metadata: {
+      profielId,
+      richting: resolved.richting,
+      niveauRang: resolved.niveauRang,
+      coverage,
+      consentShared,
+    },
+  });
+
+  // Step 3: fire the workflow. On failure (QStash outage), flip the
+  // job to 'failed' so the UI can surface it. We still return ok:true
+  // with jobId so the client lands on the polling UI which then shows
+  // the error — better than a jarring inline error after the upload
+  // already "happened".
+  try {
+    const { workflowRunId } = await triggerIngestPortfolio(jobId);
+    await Leercoach.UploadJob.updateStatus({
+      jobId,
+      status: "pending",
+      workflowRunId,
+    });
+  } catch (err) {
+    console.error("Failed to trigger ingest-portfolio workflow", err);
+    await Leercoach.UploadJob.updateStatus({
+      jobId,
+      status: "failed",
+      errorMessage:
+        err instanceof Error ? err.message : "Workflow trigger failed",
+    });
+  }
+
+  if (handle) {
+    revalidatePath(`/profiel/${handle}/portfolios`);
+  }
+
+  return { ok: true, jobId, status: "pending" };
 }
 
 /**
- * Soft-delete (revoke) a portfolio source. userId scoping in the core
- * helper prevents cross-user revocations.
+ * Soft-delete (revoke) a portfolio source AND delete the original
+ * PDF from Supabase Storage. userId scoping in the core helper
+ * prevents cross-user revocations.
+ *
+ * Why both: the user's right to erasure (GDPR) covers both the
+ * anonymised-but-retrievable source row AND the raw bytes. Leaving
+ * the Storage object behind after revoke would be a compliance gap.
+ * Storage delete is best-effort (idempotent, swallows "not found");
+ * the source revoke is the authoritative user-visible action.
  */
 export async function revokePortfolioAction(input: {
   sourceId: string;
   handle: string;
 }): Promise<void> {
   const user = await getUserOrThrow();
+
+  // Look up the source first to grab its originalStoragePath before
+  // revoking. We want the Storage delete to happen only when the DB
+  // operation would succeed.
+  const source = await AiCorpus.getUserPriorSourceById({
+    userId: user.authUserId,
+    sourceId: input.sourceId,
+  });
+
   await AiCorpus.revokeUserPriorSource({
     userId: user.authUserId,
     sourceId: input.sourceId,
   });
+
+  // Best-effort cleanup of the raw bytes. A Storage failure doesn't
+  // roll back the revoke — a stale blob on its own is inert (nothing
+  // references it now that the source row is revoked), and the
+  // follow-up Storage lifecycle / cleanup can pick it up.
+  if (source?.originalStoragePath) {
+    try {
+      await deletePortfolioOriginal(source.originalStoragePath);
+    } catch (err) {
+      console.error(
+        `[revokePortfolio] failed to delete Storage blob for source=${input.sourceId}`,
+        err,
+      );
+    }
+  }
+
   revalidatePath(`/profiel/${input.handle}/portfolios`);
   revalidatePath(`/profiel/${input.handle}/leercoach`);
 }

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/actions.ts
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/actions.ts
@@ -269,23 +269,23 @@ export async function uploadPortfolioAction(
   // the error — better than a jarring inline error after the upload
   // already "happened".
   //
-  // Two distinct try-blocks on purpose (bugbot finding): a shared
-  // catch would treat "trigger succeeded, updateStatus failed" as
-  // "workflow failed", flipping the row to 'failed' even though
-  // QStash is actively processing the job. The workflow would then
-  // write 'ready' at its own pace, but by then the client's SWR
-  // polling has already seen 'failed' and stopped — the user sees a
-  // false-failure banner for an upload that actually succeeded.
-  let workflowRunId: string | null = null;
+  // We deliberately do NOT write `status`/`workflowRunId` from here
+  // on success. The workflow runs asynchronously, and by the time an
+  // action-side updateStatus call executes the workflow may already
+  // have advanced to 'processing' (or even 'ready' for a very fast
+  // job). Overwriting with status='pending' would regress the row,
+  // the client's SWR poll would keep seeing 'pending', and the
+  // upload would appear stuck forever (bugbot finding). The workflow
+  // writes its own runId in its `mark-processing` step via
+  // `context.workflowRunId`, eliminating the race entirely.
   try {
-    const triggered = await triggerIngestPortfolio(jobId);
-    workflowRunId = triggered.workflowRunId;
+    await triggerIngestPortfolio(jobId);
   } catch (err) {
     console.error("Failed to trigger ingest-portfolio workflow", err);
     // Trigger genuinely failed — no workflow is running — so marking
     // the row as 'failed' is the correct outcome. Inner try around
     // updateStatus so a DB hiccup on the mark-failed path doesn't
-    // propagate unhandled (bugbot finding).
+    // propagate unhandled.
     try {
       await Leercoach.UploadJob.updateStatus({
         jobId,
@@ -296,25 +296,6 @@ export async function uploadPortfolioAction(
     } catch (markErr) {
       console.error(
         `Failed to mark upload_job ${jobId} as failed after workflow trigger failure`,
-        markErr,
-      );
-    }
-  }
-
-  // Trigger succeeded — record the workflowRunId for debugging + flip
-  // the row to 'pending' so the UI moves out of its creation state.
-  // A failure here must NOT touch the row's status: the workflow is
-  // already in flight and will write 'ready'/'failed' on its own.
-  if (workflowRunId !== null) {
-    try {
-      await Leercoach.UploadJob.updateStatus({
-        jobId,
-        status: "pending",
-        workflowRunId,
-      });
-    } catch (markErr) {
-      console.error(
-        `Failed to record workflowRunId for upload_job ${jobId}; workflow is running but the row still shows no runId.`,
         markErr,
       );
     }

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/actions.ts
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/actions.ts
@@ -268,24 +268,24 @@ export async function uploadPortfolioAction(
   // with jobId so the client lands on the polling UI which then shows
   // the error — better than a jarring inline error after the upload
   // already "happened".
+  //
+  // Two distinct try-blocks on purpose (bugbot finding): a shared
+  // catch would treat "trigger succeeded, updateStatus failed" as
+  // "workflow failed", flipping the row to 'failed' even though
+  // QStash is actively processing the job. The workflow would then
+  // write 'ready' at its own pace, but by then the client's SWR
+  // polling has already seen 'failed' and stopped — the user sees a
+  // false-failure banner for an upload that actually succeeded.
+  let workflowRunId: string | null = null;
   try {
-    const { workflowRunId } = await triggerIngestPortfolio(jobId);
-    await Leercoach.UploadJob.updateStatus({
-      jobId,
-      status: "pending",
-      workflowRunId,
-    });
+    const triggered = await triggerIngestPortfolio(jobId);
+    workflowRunId = triggered.workflowRunId;
   } catch (err) {
     console.error("Failed to trigger ingest-portfolio workflow", err);
-    // Defensive inner try: if the DB is also having a bad day, the
-    // updateStatus throw would propagate out of this server action
-    // unhandled — the client's startTransition callback doesn't
-    // catch, so the user would see nothing and the job row would
-    // stay stuck on its pre-catch state with no workflow running
-    // (bugbot finding). Logging + continuing keeps the `ok:true`
-    // return path intact; the polling UI will see either 'failed'
-    // (if the updateStatus succeeded) or 'pending' → eventual
-    // timeout (if it didn't) — either way the user gets feedback.
+    // Trigger genuinely failed — no workflow is running — so marking
+    // the row as 'failed' is the correct outcome. Inner try around
+    // updateStatus so a DB hiccup on the mark-failed path doesn't
+    // propagate unhandled (bugbot finding).
     try {
       await Leercoach.UploadJob.updateStatus({
         jobId,
@@ -296,6 +296,25 @@ export async function uploadPortfolioAction(
     } catch (markErr) {
       console.error(
         `Failed to mark upload_job ${jobId} as failed after workflow trigger failure`,
+        markErr,
+      );
+    }
+  }
+
+  // Trigger succeeded — record the workflowRunId for debugging + flip
+  // the row to 'pending' so the UI moves out of its creation state.
+  // A failure here must NOT touch the row's status: the workflow is
+  // already in flight and will write 'ready'/'failed' on its own.
+  if (workflowRunId !== null) {
+    try {
+      await Leercoach.UploadJob.updateStatus({
+        jobId,
+        status: "pending",
+        workflowRunId,
+      });
+    } catch (markErr) {
+      console.error(
+        `Failed to record workflowRunId for upload_job ${jobId}; workflow is running but the row still shows no runId.`,
         markErr,
       );
     }

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/actions.ts
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/actions.ts
@@ -222,20 +222,46 @@ export async function uploadPortfolioAction(
   }
 
   // Step 2: create the upload_job row. This is the pollable handle
-  // the client uses to track completion.
-  const { jobId } = await Leercoach.UploadJob.create({
-    userId: user.authUserId,
-    kind: "portfolio",
-    blobPath,
-    label,
-    metadata: {
-      profielId,
-      richting: resolved.richting,
-      niveauRang: resolved.niveauRang,
-      coverage,
-      consentShared,
-    },
-  });
+  // the client uses to track completion. If the insert fails, we
+  // must clean up the blob we just uploaded — otherwise the Storage
+  // bucket accumulates orphans that no job row references and no
+  // revoke flow can reach (bugbot finding).
+  let jobId: string;
+  try {
+    const created = await Leercoach.UploadJob.create({
+      userId: user.authUserId,
+      kind: "portfolio",
+      blobPath,
+      label,
+      metadata: {
+        profielId,
+        richting: resolved.richting,
+        niveauRang: resolved.niveauRang,
+        coverage,
+        consentShared,
+      },
+    });
+    jobId = created.jobId;
+  } catch (err) {
+    console.error("Portfolio upload_job create failed", err);
+    // Best-effort cleanup — we don't want a cleanup failure to mask
+    // the original error from the user, so swallow any throw here.
+    try {
+      await deletePortfolioOriginal(blobPath);
+    } catch (cleanupErr) {
+      console.error(
+        `Failed to clean up orphaned Storage blob at ${blobPath}`,
+        cleanupErr,
+      );
+    }
+    return {
+      ok: false,
+      reason:
+        err instanceof Error
+          ? `Uploaden mislukt: ${err.message}`
+          : "Uploaden mislukt.",
+    };
+  }
 
   // Step 3: fire the workflow. On failure (QStash outage), flip the
   // job to 'failed' so the UI can surface it. We still return ok:true

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/actions.ts
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/actions.ts
@@ -269,14 +269,19 @@ export async function uploadPortfolioAction(
     };
   }
 
-  // Step 3: fire the workflow. On failure (QStash outage), flip the
-  // job to 'failed' so the UI can surface it. We still return ok:true
-  // with jobId so the client lands on the polling UI which then shows
-  // the error — better than a jarring inline error after the upload
-  // already "happened".
+  // Step 3: fire the workflow. On failure (QStash outage), no workflow
+  // is running, so there's nothing for the client to poll — we return
+  // `{ ok: false }` so the submit() path sets submitError and the
+  // "failed" banner shows immediately. The row is best-effort marked
+  // as 'failed' and the Storage blob cleaned up so we don't leave
+  // orphan state; but if those cleanup calls ALSO fail, the client
+  // still gets actionable inline feedback (bugbot finding — returning
+  // ok:true here relied on the row flipping to 'failed' and the
+  // client's SWR polling picking it up, which silently degraded into
+  // a 10-minute spinner if the mark-failed write ALSO failed).
   //
-  // We deliberately do NOT write `status`/`workflowRunId` from here
-  // on success. The workflow runs asynchronously, and by the time an
+  // We deliberately do NOT write `status`/`workflowRunId` on trigger
+  // success. The workflow runs asynchronously, and by the time an
   // action-side updateStatus call executes the workflow may already
   // have advanced to 'processing' (or even 'ready' for a very fast
   // job). Overwriting with status='pending' would regress the row,
@@ -288,10 +293,9 @@ export async function uploadPortfolioAction(
     await triggerIngestPortfolio(jobId);
   } catch (err) {
     console.error("Failed to trigger ingest-portfolio workflow", err);
-    // Trigger genuinely failed — no workflow is running — so marking
-    // the row as 'failed' is the correct outcome. Inner try around
-    // updateStatus so a DB hiccup on the mark-failed path doesn't
-    // propagate unhandled.
+    // Best-effort mark the row 'failed' so ops + any later revisit
+    // sees the real terminal state. Don't let a DB hiccup here mask
+    // the user-visible error.
     try {
       await Leercoach.UploadJob.updateStatus({
         jobId,
@@ -305,6 +309,23 @@ export async function uploadPortfolioAction(
         markErr,
       );
     }
+    // Best-effort blob cleanup — the row is dead, so the bytes are
+    // unreachable and should not linger in Storage.
+    try {
+      await deletePortfolioOriginal(blobPath);
+    } catch (cleanupErr) {
+      console.error(
+        `Failed to clean up Storage blob at ${blobPath} after trigger failure`,
+        cleanupErr,
+      );
+    }
+    return {
+      ok: false,
+      reason:
+        err instanceof Error
+          ? `Uploaden mislukt: ${err.message}`
+          : "Uploaden mislukt — workflow kon niet starten.",
+    };
   }
 
   if (handle) {

--- a/apps/web/src/app/api/upload-job/[id]/status/route.ts
+++ b/apps/web/src/app/api/upload-job/[id]/status/route.ts
@@ -1,0 +1,77 @@
+import { Leercoach } from "@nawadi/core";
+import { NextResponse } from "next/server";
+import { createClient } from "~/lib/supabase/server";
+
+// Pollable status endpoint for upload jobs. The PortfolioUploadDialog
+// hits this every ~2s after submitting an upload, stops once the
+// status resolves to 'ready' or 'failed'.
+//
+// Shape kept narrow on purpose — we only expose what the client
+// actually needs to render state. Internal fields like
+// workflow_run_id stay on the job row for ops debugging.
+
+type StatusBody =
+  | {
+      status: "pending" | "processing";
+    }
+  | {
+      status: "ready";
+      sourceId: string;
+    }
+  | {
+      status: "failed";
+      errorMessage: string;
+    };
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id: jobId } = await ctx.params;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Niet ingelogd." }, { status: 401 });
+  }
+
+  const job = await Leercoach.UploadJob.getById({
+    jobId,
+    userId: user.id,
+  });
+  if (!job) {
+    return NextResponse.json(
+      { error: "Upload-job niet gevonden." },
+      { status: 404 },
+    );
+  }
+
+  let body: StatusBody;
+  switch (job.status) {
+    case "pending":
+    case "processing":
+      body = { status: job.status };
+      break;
+    case "ready":
+      // sourceId is set by the final workflow step in lockstep with
+      // status='ready', so this should always be present — but fall
+      // back safely if something raced.
+      body = {
+        status: "ready",
+        sourceId: job.sourceId ?? "",
+      };
+      break;
+    case "failed":
+      body = {
+        status: "failed",
+        errorMessage:
+          job.errorMessage ??
+          "Verwerken mislukt. Probeer opnieuw of neem contact op met ondersteuning.",
+      };
+      break;
+  }
+
+  return NextResponse.json(body);
+}

--- a/apps/web/src/app/api/upload-job/[id]/status/route.ts
+++ b/apps/web/src/app/api/upload-job/[id]/status/route.ts
@@ -56,12 +56,25 @@ export async function GET(
       break;
     case "ready":
       // sourceId is set by the final workflow step in lockstep with
-      // status='ready', so this should always be present — but fall
-      // back safely if something raced.
-      body = {
-        status: "ready",
-        sourceId: job.sourceId ?? "",
-      };
+      // status='ready', so this should always be present. If it's
+      // missing, something's wrong upstream (schema drift, partial
+      // write, rollback mid-commit) — surface it as a failure rather
+      // than returning an empty string. Returning "" here was tripping
+      // the client's `!readySourceId` guard, dropping onSuccess
+      // silently and leaving the dialog stuck on "Klaar." with no
+      // auto-dismiss (bugbot finding).
+      if (!job.sourceId) {
+        body = {
+          status: "failed",
+          errorMessage:
+            "Verwerking is afgerond, maar de verwijzing naar het document ontbreekt. Probeer opnieuw of neem contact op met ondersteuning.",
+        };
+      } else {
+        body = {
+          status: "ready",
+          sourceId: job.sourceId,
+        };
+      }
       break;
     case "failed":
       body = {

--- a/apps/web/src/app/api/workflow/ingest-portfolio/route.ts
+++ b/apps/web/src/app/api/workflow/ingest-portfolio/route.ts
@@ -28,12 +28,14 @@ import {
 //
 // Pipeline shape (mirrors the old synchronous ingestPortfolio):
 //
-//   1. mark-processing  — flip upload_job.status to 'processing'
-//   2. extract          — fetch bytes from Storage, run unpdf
-//   3. anonymise        — LLM scrub of names/locations/verenigingen
-//   4. ingest           — dedup, chunk, upsert into ai_corpus; link
+//   1. load-job         — fetch upload_job row, detect replay of a
+//                          completed run, short-circuit if so
+//   2. mark-processing  — flip upload_job.status to 'processing'
+//   3. extract          — fetch bytes from Storage, run unpdf
+//   4. anonymise        — LLM scrub of names/locations/verenigingen
+//   5. ingest           — dedup, chunk, upsert into ai_corpus; link
 //                          source.original_storage_path to the blob
-//   5. mark-ready       — flip upload_job.status to 'ready', set
+//   6. mark-ready       — flip upload_job.status to 'ready', set
 //                          upload_job.sourceId
 //
 // Retries: each step is retried automatically by @upstash/workflow
@@ -71,36 +73,43 @@ export const { POST } = serve<Payload>(
   async (context) => {
     const { jobId } = context.requestPayload;
 
-    // Step 1: mark processing. Also validates that the job exists
-    // before we spend compute on it. Returns the job metadata so the
-    // next steps don't need to re-query.
-    const job = await context.run("mark-processing", async () => {
+    // Step 1: load job and detect replay. Validates the job exists
+    // before we spend compute on it. Returns an `alreadyReady` flag
+    // so a replay of a completed job short-circuits below without
+    // throwing — the previous implementation threw to signal replay,
+    // which tripped the workflow's `failureFunction` and corrupted
+    // the job's status from 'ready' back to 'failed' (bugbot finding).
+    const job = await context.run("load-job", async () => {
       const found = await Leercoach.UploadJob.getByIdAsWorkflow({ jobId });
       if (!found) {
         throw new Error(
           `upload_job ${jobId} not found — aborting workflow.`,
         );
       }
-      if (found.status === "ready") {
-        // Replay of a completed job. Short-circuit by throwing a
-        // distinguishable error the runtime-done short-circuit catches
-        // below. Simpler than a special return type that threads all
-        // the way through subsequent steps.
-        throw new Error("ALREADY_READY");
-      }
-      await Leercoach.UploadJob.updateStatus({
-        jobId,
-        status: "processing",
-      });
       return {
+        alreadyReady: found.status === "ready",
         userId: found.userId,
         blobPath: found.blobPath,
         label: found.label,
         metadata: found.metadata,
       };
     });
+    // Replay short-circuit: the job is already marked ready in the DB,
+    // so there is nothing left to do. Returning here leaves the row
+    // untouched (no flip back to 'failed' via failureFunction).
+    if (job.alreadyReady) return;
 
-    // Step 2: fetch bytes + extract text. unpdf runs in Node
+    // Step 2: mark processing. Separated from load-job so the load
+    // step's return value is purely informational and the state
+    // mutation lives in its own replayable unit.
+    await context.run("mark-processing", async () => {
+      await Leercoach.UploadJob.updateStatus({
+        jobId,
+        status: "processing",
+      });
+    });
+
+    // Step 3: fetch bytes + extract text. unpdf runs in Node
     // serverless cleanly — no canvas / DOMMatrix quirks — but we
     // still isolate it in its own step because it can run several
     // seconds for large PDFs and we want clean retry semantics if
@@ -111,7 +120,7 @@ export const { POST } = serve<Payload>(
       return { rawText, pageCount, charCount };
     });
 
-    // Step 3: LLM anonymisation. This is the long pole — regularly
+    // Step 4: LLM anonymisation. This is the long pole — regularly
     // 30-60s for a real portfolio. Having it in its own step means a
     // retry on provider flakiness doesn't re-run extract, and the
     // full-blown timeout ceiling applies per-step, not to the whole
@@ -125,7 +134,7 @@ export const { POST } = serve<Payload>(
       },
     );
 
-    // Step 4: chunk + upsert into ai_corpus. Same logic as the old
+    // Step 5: chunk + upsert into ai_corpus. Same logic as the old
     // inline ingestPortfolio, just running in a durable context.
     // source.original_storage_path records the raw blob so we can
     // offer the user a "download my original" affordance later.
@@ -191,7 +200,7 @@ export const { POST } = serve<Payload>(
       return { sourceId: result.sourceId };
     });
 
-    // Step 5: mark job as ready + wire the sourceId so the status
+    // Step 6: mark job as ready + wire the sourceId so the status
     // endpoint can return it. Separate step so a bug in the ingest
     // step's DB write doesn't conflate with the UI-facing "done"
     // signal — the upload_job's status change is the atomic commit
@@ -213,6 +222,21 @@ export const { POST } = serve<Payload>(
       const payload = context.requestPayload as Payload | undefined;
       if (!payload?.jobId) return;
       try {
+        // Defensive re-read: even though the main handler now
+        // short-circuits on a replay instead of throwing, we still
+        // guard against any future path that could fire this
+        // callback for a job the DB already marks 'ready' (e.g. a
+        // late callback racing a successful run). Flipping 'ready'
+        // → 'failed' would corrupt a known-good result.
+        const current = await Leercoach.UploadJob.getByIdAsWorkflow({
+          jobId: payload.jobId,
+        });
+        if (current?.status === "ready") {
+          console.warn(
+            `[workflow/ingest-portfolio] failureFunction fired for already-ready job ${payload.jobId}; skipping status flip.`,
+          );
+          return;
+        }
         await Leercoach.UploadJob.updateStatus({
           jobId: payload.jobId,
           status: "failed",

--- a/apps/web/src/app/api/workflow/ingest-portfolio/route.ts
+++ b/apps/web/src/app/api/workflow/ingest-portfolio/route.ts
@@ -1,11 +1,36 @@
 import { AiCorpus, Leercoach } from "@nawadi/core";
 import { serve } from "@upstash/workflow/nextjs";
+import { revalidatePath } from "next/cache";
 import { createHash } from "node:crypto";
 import { anonymizeText } from "~/app/(dashboard)/(account)/profiel/[handle]/portfolios/_lib/portfolio-pipeline";
 import { extractPdfText, splitIntoChunks } from "~/app/(dashboard)/(account)/profiel/[handle]/_lib/extract";
 import {
   downloadPortfolioOriginal,
 } from "~/lib/portfolio-storage";
+
+// Revalidate the pages that render portfolio data for a given user.
+// Called from the workflow's terminal steps (mark-ready + failure
+// path) so the UI picks up the new portfolio or the failure state
+// the next time the user navigates. Matches the path set the old
+// synchronous ingestPortfolio used to revalidate — we lost those
+// calls when the action stopped waiting for the pipeline, so the
+// workflow takes ownership of them now (bugbot finding).
+function revalidatePortfolioPathsFor(handle: string | null): void {
+  if (!handle) return;
+  try {
+    revalidatePath(`/profiel/${handle}/portfolios`);
+    revalidatePath(`/profiel/${handle}/leercoach`);
+    revalidatePath(`/profiel/${handle}`);
+  } catch (err) {
+    // revalidatePath can throw when called outside a request context
+    // under certain edge cases; don't let that corrupt an otherwise
+    // successful workflow run.
+    console.warn(
+      "[workflow/ingest-portfolio] revalidatePath threw; continuing.",
+      err,
+    );
+  }
+}
 
 // Durable portfolio-ingest pipeline.
 //
@@ -217,6 +242,9 @@ export const { POST } = serve<Payload>(
         status: "ready",
         sourceId: ingested.sourceId,
       });
+      const metadata = (job.metadata as Record<string, unknown>) ?? {};
+      const handle = typeof metadata.handle === "string" ? metadata.handle : null;
+      revalidatePortfolioPathsFor(handle);
     });
   },
   {
@@ -251,6 +279,13 @@ export const { POST } = serve<Payload>(
               ? failResponse.slice(0, 2000)
               : `Workflow failed with status ${failStatus}`,
         });
+        // Revalidate the user's pages so the failure state replaces
+        // any stale "still processing" cached render.
+        const metadata =
+          (current?.metadata as Record<string, unknown>) ?? {};
+        const handle =
+          typeof metadata.handle === "string" ? metadata.handle : null;
+        revalidatePortfolioPathsFor(handle);
       } catch (markErr) {
         console.error(
           `[workflow/ingest-portfolio] failureFunction markFailed threw (jobId=${payload.jobId})`,

--- a/apps/web/src/app/api/workflow/ingest-portfolio/route.ts
+++ b/apps/web/src/app/api/workflow/ingest-portfolio/route.ts
@@ -1,0 +1,232 @@
+import { AiCorpus, Leercoach } from "@nawadi/core";
+import { serve } from "@upstash/workflow/nextjs";
+import { createHash } from "node:crypto";
+import { anonymizeText } from "~/app/(dashboard)/(account)/profiel/[handle]/portfolios/_lib/portfolio-pipeline";
+import { extractPdfText, splitIntoChunks } from "~/app/(dashboard)/(account)/profiel/[handle]/_lib/extract";
+import {
+  downloadPortfolioOriginal,
+} from "~/lib/portfolio-storage";
+
+// Durable portfolio-ingest pipeline.
+//
+// Trigger: uploadPortfolioAction (server action) calls
+// workflow.trigger() with `{ jobId }` after stashing the raw PDF
+// bytes in Supabase Storage + creating the upload_job row.
+//
+// Why Upstash Workflow + upload_job vs. doing the work inline in the
+// action:
+//
+//   - The LLM anonymisation step regularly runs 30-60s on a real
+//     portfolio. Vercel's serverless timeout (30s default, 300s max)
+//     forces us to either bloat maxDuration or break the work up.
+//   - Break-the-work-up isn't safe without durability: a lambda
+//     cold-start, network blip, or deploy mid-job drops all progress.
+//   - Upstash Workflow gives us durable state machine for free:
+//     each 'step' below becomes an isolated HTTP callback; step
+//     outputs are persisted in QStash's event log; retries + skew
+//     protection are automatic.
+//
+// Pipeline shape (mirrors the old synchronous ingestPortfolio):
+//
+//   1. mark-processing  — flip upload_job.status to 'processing'
+//   2. extract          — fetch bytes from Storage, run unpdf
+//   3. anonymise        — LLM scrub of names/locations/verenigingen
+//   4. ingest           — dedup, chunk, upsert into ai_corpus; link
+//                          source.original_storage_path to the blob
+//   5. mark-ready       — flip upload_job.status to 'ready', set
+//                          upload_job.sourceId
+//
+// Retries: each step is retried automatically by @upstash/workflow
+// on transient failure. If a step's retries exhaust, the workflow
+// fails permanently and our failureFunction flips upload_job to
+// 'failed' with the error message — the UI's polling hook then
+// surfaces a human-readable error to the user.
+//
+// Idempotency: steps re-read upload_job by id at the start. A replay
+// of an already-completed job short-circuits (status check) rather
+// than double-inserting into ai_corpus.
+
+type Payload = {
+  jobId: string;
+};
+
+type ExtractOutput = {
+  rawText: string;
+  pageCount: number;
+  charCount: number;
+};
+
+type AnonymiseOutput = {
+  anonymizedText: string;
+  redactedEntities: Awaited<
+    ReturnType<typeof anonymizeText>
+  >["redactedEntities"];
+};
+
+type IngestOutput = {
+  sourceId: string;
+};
+
+export const { POST } = serve<Payload>(
+  async (context) => {
+    const { jobId } = context.requestPayload;
+
+    // Step 1: mark processing. Also validates that the job exists
+    // before we spend compute on it. Returns the job metadata so the
+    // next steps don't need to re-query.
+    const job = await context.run("mark-processing", async () => {
+      const found = await Leercoach.UploadJob.getByIdAsWorkflow({ jobId });
+      if (!found) {
+        throw new Error(
+          `upload_job ${jobId} not found — aborting workflow.`,
+        );
+      }
+      if (found.status === "ready") {
+        // Replay of a completed job. Short-circuit by throwing a
+        // distinguishable error the runtime-done short-circuit catches
+        // below. Simpler than a special return type that threads all
+        // the way through subsequent steps.
+        throw new Error("ALREADY_READY");
+      }
+      await Leercoach.UploadJob.updateStatus({
+        jobId,
+        status: "processing",
+      });
+      return {
+        userId: found.userId,
+        blobPath: found.blobPath,
+        label: found.label,
+        metadata: found.metadata,
+      };
+    });
+
+    // Step 2: fetch bytes + extract text. unpdf runs in Node
+    // serverless cleanly — no canvas / DOMMatrix quirks — but we
+    // still isolate it in its own step because it can run several
+    // seconds for large PDFs and we want clean retry semantics if
+    // Storage hiccups.
+    const extracted = await context.run<ExtractOutput>("extract", async () => {
+      const bytes = await downloadPortfolioOriginal(job.blobPath);
+      const { rawText, pageCount, charCount } = await extractPdfText(bytes);
+      return { rawText, pageCount, charCount };
+    });
+
+    // Step 3: LLM anonymisation. This is the long pole — regularly
+    // 30-60s for a real portfolio. Having it in its own step means a
+    // retry on provider flakiness doesn't re-run extract, and the
+    // full-blown timeout ceiling applies per-step, not to the whole
+    // workflow.
+    const anonymised = await context.run<AnonymiseOutput>(
+      "anonymise",
+      async () => {
+        return await anonymizeText(extracted.rawText, {
+          userId: job.userId,
+        });
+      },
+    );
+
+    // Step 4: chunk + upsert into ai_corpus. Same logic as the old
+    // inline ingestPortfolio, just running in a durable context.
+    // source.original_storage_path records the raw blob so we can
+    // offer the user a "download my original" affordance later.
+    const ingested = await context.run<IngestOutput>("ingest", async () => {
+      const metadata = job.metadata as Record<string, unknown>;
+      const profielId =
+        typeof metadata.profielId === "string" ? metadata.profielId : null;
+      const richting =
+        typeof metadata.richting === "string"
+          ? (metadata.richting as
+              | "instructeur"
+              | "leercoach"
+              | "pvb_beoordelaar")
+          : null;
+      const niveauRang =
+        typeof metadata.niveauRang === "number" ? metadata.niveauRang : null;
+      const coverage =
+        metadata.coverage && typeof metadata.coverage === "object"
+          ? (metadata.coverage as Record<string, unknown>)
+          : null;
+      const consentShared = metadata.consentShared === true;
+
+      const chunks = splitIntoChunks(anonymised.anonymizedText);
+      const sourceHash = createHash("sha256")
+        .update(anonymised.anonymizedText)
+        .digest("hex");
+      const sourceIdentifier = `user:${job.userId}:${sourceHash.slice(0, 12)}`;
+
+      const result = await AiCorpus.upsertSourceWithChunks({
+        source: {
+          domain: "pvb_portfolio",
+          sourceIdentifier,
+          sourceHash,
+          content: anonymised.anonymizedText,
+          // user_only by default; opt_in_shared when the user ticks
+          // the "help improve our models" checkbox at upload.
+          consentLevel: consentShared ? "opt_in_shared" : "user_only",
+          contributedByUserId: job.userId,
+          profielId,
+          richting,
+          niveauRang,
+          chatId: null,
+          originalStoragePath: job.blobPath,
+          metadata: {
+            label: job.label,
+            coverage,
+            redactedEntities: anonymised.redactedEntities,
+            pageCount: extracted.pageCount,
+            uploadedAt: new Date().toISOString(),
+          },
+          charCount: anonymised.anonymizedText.length,
+          pageCount: extracted.pageCount,
+        },
+        chunks: chunks.map((c) => ({
+          content: c.content,
+          wordCount: c.wordCount,
+          qualityScore: null,
+          criteriumId: null,
+          werkprocesId: null,
+          metadata: {},
+        })),
+      });
+      return { sourceId: result.sourceId };
+    });
+
+    // Step 5: mark job as ready + wire the sourceId so the status
+    // endpoint can return it. Separate step so a bug in the ingest
+    // step's DB write doesn't conflate with the UI-facing "done"
+    // signal — the upload_job's status change is the atomic commit
+    // point for "this upload succeeded".
+    await context.run("mark-ready", async () => {
+      await Leercoach.UploadJob.updateStatus({
+        jobId,
+        status: "ready",
+        sourceId: ingested.sourceId,
+      });
+    });
+  },
+  {
+    // When a step exhausts its retries, this handler fires once and
+    // marks the job as failed so the client's status polling can
+    // surface a human-readable error. No throw inside — any throw
+    // would put us back in retry hell.
+    failureFunction: async ({ failStatus, failResponse, context }) => {
+      const payload = context.requestPayload as Payload | undefined;
+      if (!payload?.jobId) return;
+      try {
+        await Leercoach.UploadJob.updateStatus({
+          jobId: payload.jobId,
+          status: "failed",
+          errorMessage:
+            typeof failResponse === "string"
+              ? failResponse.slice(0, 2000)
+              : `Workflow failed with status ${failStatus}`,
+        });
+      } catch (markErr) {
+        console.error(
+          `[workflow/ingest-portfolio] failureFunction markFailed threw (jobId=${payload.jobId})`,
+          markErr,
+        );
+      }
+    },
+  },
+);

--- a/apps/web/src/app/api/workflow/ingest-portfolio/route.ts
+++ b/apps/web/src/app/api/workflow/ingest-portfolio/route.ts
@@ -99,13 +99,19 @@ export const { POST } = serve<Payload>(
     // untouched (no flip back to 'failed' via failureFunction).
     if (job.alreadyReady) return;
 
-    // Step 2: mark processing. Separated from load-job so the load
-    // step's return value is purely informational and the state
-    // mutation lives in its own replayable unit.
+    // Step 2: mark processing + record our own workflowRunId. The
+    // server action used to write the runId from its side right after
+    // `triggerIngestPortfolio`, but that raced with this very step —
+    // a slow action / fast workflow would regress 'processing' back
+    // to 'pending', and the client's SWR poll would chase a status
+    // the workflow had already moved past. Writing it here, in
+    // lockstep with the 'processing' transition, eliminates the race
+    // (bugbot finding).
     await context.run("mark-processing", async () => {
       await Leercoach.UploadJob.updateStatus({
         jobId,
         status: "processing",
+        workflowRunId: context.workflowRunId,
       });
     });
 

--- a/apps/web/src/lib/portfolio-storage.ts
+++ b/apps/web/src/lib/portfolio-storage.ts
@@ -1,0 +1,159 @@
+import "server-only";
+import { createHash } from "node:crypto";
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import { invariant } from "~/utils/invariant";
+
+// Helpers around the `portfolio-uploads` Supabase Storage bucket.
+//
+// Two concerns:
+//
+//   1. **Writing originals at upload time** — the action reads the
+//      request's bytes, hashes them for dedup, and stashes them in
+//      the bucket under `{userId}/{hash}.pdf`. This path is durable:
+//      kept on disk so the user can retrieve their original later,
+//      NOT deleted after anonymisation.
+//
+//   2. **Reading originals inside the workflow** — the extract step
+//      needs the raw bytes; it fetches by path. This runs on the
+//      server, not in the user's session, so we use the service-role
+//      client that bypasses RLS. Users only ever hit the bucket via
+//      the signed-URL retrieval flow (future) or the action's write.
+//
+// The bucket is **private** — no public reads. All user-facing
+// access goes through signed URLs minted server-side with short
+// expiries. For now we only write + workflow-read; signed-URL
+// retrieval is a follow-up UI.
+
+export const PORTFOLIO_UPLOADS_BUCKET = "portfolio-uploads";
+
+/**
+ * Service-role Supabase client for server-side bucket operations
+ * that need to bypass RLS. Separate from the per-request `createClient`
+ * used in server actions — that one runs under the user's JWT and
+ * respects RLS. Used here because:
+ *
+ *   - The workflow route runs without a Supabase session (QStash
+ *     calls our webhook, no user cookies). Must use service-role.
+ *   - The write path in the action happens under the user's session
+ *     too, but we prefer a consistent server-side client for the
+ *     whole Storage surface. RLS on the bucket enforces write-scope
+ *     via the policy we set in Supabase (writes only under
+ *     `{auth.uid()}/*`); the service-role client respects that
+ *     policy's semantics at write time by passing explicit `userId`.
+ */
+function getServiceClient() {
+  invariant(process.env.NEXT_PUBLIC_SUPABASE_URL);
+  invariant(process.env.SUPABASE_SERVICE_ROLE_KEY);
+  return createSupabaseClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    },
+  );
+}
+
+/**
+ * Upload the raw bytes of a portfolio PDF and return the durable
+ * storage path. Hashes the content so repeat uploads by the same
+ * user dedup to the same object — a second upload of identical
+ * bytes is a no-op (Supabase's upsert semantic).
+ *
+ * Path shape: `{userId}/{sha256[0..16]}.pdf`
+ *
+ * The short hash prefix keeps paths readable in dashboards while
+ * giving ~2^64 collision space per user — comfortable for any
+ * individual user's upload history.
+ */
+export async function uploadPortfolioOriginal(input: {
+  userId: string;
+  bytes: Uint8Array;
+  filename?: string;
+}): Promise<{ path: string; hash: string }> {
+  const hash = createHash("sha256").update(input.bytes).digest("hex");
+  // Preserve the extension from filename when supplied; default to
+  // .pdf since the upload flow only accepts PDFs for portfolios.
+  const ext = input.filename?.match(/\.([a-zA-Z0-9]+)$/)?.[1]?.toLowerCase() ??
+    "pdf";
+  const path = `${input.userId}/${hash.slice(0, 16)}.${ext}`;
+
+  const supabase = getServiceClient();
+  const { error } = await supabase.storage
+    .from(PORTFOLIO_UPLOADS_BUCKET)
+    .upload(path, input.bytes, {
+      contentType: "application/pdf",
+      upsert: true, // Idempotent re-upload: same hash → same path → overwrite (no-op).
+    });
+
+  if (error) {
+    throw new Error(`Failed to upload portfolio to Storage: ${error.message}`);
+  }
+
+  return { path, hash };
+}
+
+/**
+ * Fetch the raw bytes of an uploaded portfolio by its storage path.
+ * Called from inside the workflow's extract step, which runs without
+ * a Supabase session, so we use the service-role client.
+ */
+export async function downloadPortfolioOriginal(
+  path: string,
+): Promise<Uint8Array> {
+  const supabase = getServiceClient();
+  const { data, error } = await supabase.storage
+    .from(PORTFOLIO_UPLOADS_BUCKET)
+    .download(path);
+  if (error) {
+    throw new Error(
+      `Failed to download portfolio from Storage (path=${path}): ${error.message}`,
+    );
+  }
+  const ab = await data.arrayBuffer();
+  return new Uint8Array(ab);
+}
+
+/**
+ * Mint a signed URL for the user to download their own original.
+ * Short-lived (5 minutes) — the user clicks → browser downloads →
+ * URL expires. Not used in this PR but wired up now so the eventual
+ * "Download origineel" button is a one-line addition.
+ */
+export async function signPortfolioDownloadUrl(
+  path: string,
+  expiresInSeconds = 300,
+): Promise<string> {
+  const supabase = getServiceClient();
+  const { data, error } = await supabase.storage
+    .from(PORTFOLIO_UPLOADS_BUCKET)
+    .createSignedUrl(path, expiresInSeconds);
+  if (error || !data) {
+    throw new Error(
+      `Failed to sign download URL (path=${path}): ${error?.message ?? "unknown"}`,
+    );
+  }
+  return data.signedUrl;
+}
+
+/**
+ * Delete the original from Storage. Called by the revoke flow so the
+ * user's right to erasure (GDPR) is honoured end-to-end: revoking
+ * removes both the searchable anonymised chunks AND the raw bytes.
+ * Idempotent — missing object is treated as success.
+ */
+export async function deletePortfolioOriginal(path: string): Promise<void> {
+  const supabase = getServiceClient();
+  const { error } = await supabase.storage
+    .from(PORTFOLIO_UPLOADS_BUCKET)
+    .remove([path]);
+  // Supabase returns an error object if the key doesn't exist — which
+  // for revoke is fine. Only re-throw on unexpected failure modes.
+  if (error && !/not found/i.test(error.message)) {
+    throw new Error(
+      `Failed to delete portfolio from Storage (path=${path}): ${error.message}`,
+    );
+  }
+}

--- a/apps/web/src/lib/portfolio-storage.ts
+++ b/apps/web/src/lib/portfolio-storage.ts
@@ -117,28 +117,6 @@ export async function downloadPortfolioOriginal(
 }
 
 /**
- * Mint a signed URL for the user to download their own original.
- * Short-lived (5 minutes) — the user clicks → browser downloads →
- * URL expires. Not used in this PR but wired up now so the eventual
- * "Download origineel" button is a one-line addition.
- */
-export async function signPortfolioDownloadUrl(
-  path: string,
-  expiresInSeconds = 300,
-): Promise<string> {
-  const supabase = getServiceClient();
-  const { data, error } = await supabase.storage
-    .from(PORTFOLIO_UPLOADS_BUCKET)
-    .createSignedUrl(path, expiresInSeconds);
-  if (error || !data) {
-    throw new Error(
-      `Failed to sign download URL (path=${path}): ${error?.message ?? "unknown"}`,
-    );
-  }
-  return data.signedUrl;
-}
-
-/**
  * Delete the original from Storage. Called by the revoke flow so the
  * user's right to erasure (GDPR) is honoured end-to-end: revoking
  * removes both the searchable anonymised chunks AND the raw bytes.

--- a/apps/web/src/lib/workflow-client.ts
+++ b/apps/web/src/lib/workflow-client.ts
@@ -1,0 +1,72 @@
+import "server-only";
+import { Client } from "@upstash/workflow";
+import { BASE_URL } from "~/constants";
+
+// Thin wrapper around @upstash/workflow's Client for triggering
+// workflows from server actions.
+//
+// Env vars expected (see .env.example):
+//   - QSTASH_TOKEN                  — API token (dev CLI or prod)
+//   - QSTASH_URL                    — base URL of the QStash server
+//                                     (http://127.0.0.1:8080 in dev,
+//                                      https://qstash.upstash.io in prod)
+//   - QSTASH_CURRENT_SIGNING_KEY    — verifies incoming webhook payloads
+//   - QSTASH_NEXT_SIGNING_KEY       — key rotation handover
+//
+// The SDK auto-reads QSTASH_TOKEN + QSTASH_URL when you omit them at
+// construction; we pass them explicitly so the code is self-documenting
+// at the grep level.
+
+function getClient(): Client {
+  const token = process.env.QSTASH_TOKEN;
+  if (!token) {
+    throw new Error(
+      "QSTASH_TOKEN is required to trigger workflows. Run `pnpm dev:qstash` " +
+        "in a sidecar terminal for local dev, or set the prod token in " +
+        "Vercel env.",
+    );
+  }
+  return new Client({
+    token,
+    baseUrl: process.env.QSTASH_URL,
+  });
+}
+
+/**
+ * Trigger the portfolio-ingest workflow with the given jobId. The
+ * workflow route at `/api/workflow/ingest-portfolio` picks up the
+ * payload, loads the upload_job row, and runs the 5-step pipeline.
+ *
+ * Returns the QStash workflow run id — we stash it on the upload_job
+ * row so ops can deep-link into Upstash's console for debugging.
+ *
+ * Failure of this trigger call is rare (QStash outage) but surfaces
+ * as a thrown error the caller must handle — the upload_job row
+ * already exists at this point, and the action flips its status to
+ * 'failed' on error so the UI shows a retry affordance.
+ */
+export async function triggerIngestPortfolio(
+  jobId: string,
+): Promise<{ workflowRunId: string }> {
+  const client = getClient();
+  const webhookUrl = new URL(
+    "/api/workflow/ingest-portfolio",
+    BASE_URL,
+  ).toString();
+
+  const result = await client.trigger({
+    url: webhookUrl,
+    body: { jobId },
+    // Retry count for the initial invocation. Step-level retries are
+    // handled by the workflow SDK itself — this is only the "first
+    // call to the webhook failed" retry.
+    retries: 3,
+  });
+
+  // SDK returns either a single workflowRunId or an array when
+  // multiple headers collapse. Normalise to the first id.
+  const workflowRunId = Array.isArray(result.workflowRunId)
+    ? (result.workflowRunId[0] ?? "")
+    : result.workflowRunId;
+  return { workflowRunId };
+}

--- a/apps/web/src/lib/workflow-client.ts
+++ b/apps/web/src/lib/workflow-client.ts
@@ -35,26 +35,28 @@ function getClient(): Client {
 /**
  * Trigger the portfolio-ingest workflow with the given jobId. The
  * workflow route at `/api/workflow/ingest-portfolio` picks up the
- * payload, loads the upload_job row, and runs the 5-step pipeline.
+ * payload, loads the upload_job row, and runs the 6-step pipeline.
  *
- * Returns the QStash workflow run id — we stash it on the upload_job
- * row so ops can deep-link into Upstash's console for debugging.
+ * The workflow writes its own `workflowRunId` onto the upload_job
+ * row from within its `mark-processing` step (via
+ * `context.workflowRunId`). The caller intentionally does not stash
+ * the runId from the trigger response itself — an action-side write
+ * would race the workflow's state machine and could regress a
+ * 'processing'/'ready' row back to 'pending'.
  *
  * Failure of this trigger call is rare (QStash outage) but surfaces
  * as a thrown error the caller must handle — the upload_job row
  * already exists at this point, and the action flips its status to
  * 'failed' on error so the UI shows a retry affordance.
  */
-export async function triggerIngestPortfolio(
-  jobId: string,
-): Promise<{ workflowRunId: string }> {
+export async function triggerIngestPortfolio(jobId: string): Promise<void> {
   const client = getClient();
   const webhookUrl = new URL(
     "/api/workflow/ingest-portfolio",
     BASE_URL,
   ).toString();
 
-  const result = await client.trigger({
+  await client.trigger({
     url: webhookUrl,
     body: { jobId },
     // Retry count for the initial invocation. Step-level retries are
@@ -62,11 +64,4 @@ export async function triggerIngestPortfolio(
     // call to the webhook failed" retry.
     retries: 3,
   });
-
-  // SDK returns either a single workflowRunId or an array when
-  // multiple headers collapse. Normalise to the first id.
-  const workflowRunId = Array.isArray(result.workflowRunId)
-    ? (result.workflowRunId[0] ?? "")
-    : result.workflowRunId;
-  return { workflowRunId };
 }

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -61,6 +61,7 @@ words:
   - Polyvalk
   - pvbs
   - qrcode
+  - qstash
   - qwkkmc
   - redocly
   - rehype

--- a/packages/core/src/models/ai-corpus/index.ts
+++ b/packages/core/src/models/ai-corpus/index.ts
@@ -62,6 +62,12 @@ export const upsertSourceWithChunksInput = z.object({
     // chat_id is required when domain === "artefact" (caller enforces).
     // Leave null for every other domain.
     chatId: uuidSchema.nullable(),
+    /**
+     * Path in Supabase Storage to the original un-anonymised file.
+     * Null for text-only sources + legacy rows that predate durable
+     * ingest. Used by the "download my original" flow.
+     */
+    originalStoragePath: z.string().nullable().default(null),
     metadata: z.record(z.unknown()).default({}),
     charCount: z.number().int().nonnegative(),
     pageCount: z.number().int().nullable(),
@@ -147,6 +153,7 @@ export const upsertSourceWithChunks = wrapCommand(
             richting: input.source.richting,
             niveauRang: input.source.niveauRang,
             chatId: input.source.chatId,
+            originalStoragePath: input.source.originalStoragePath,
             metadata: input.source.metadata,
             charCount: input.source.charCount,
             pageCount: input.source.pageCount,
@@ -535,6 +542,63 @@ export const getUserPriorChunks = wrapQuery(
       };
     });
   }),
+);
+
+// ---- Read: single prior source, user-scoped ----
+//
+// Rare path — used by the revoke flow so it can look up the Storage
+// blob path before deleting the row. Returns null for rows owned by
+// another user to prevent cross-user probing.
+
+export const getUserPriorSourceByIdInput = z.object({
+  userId: uuidSchema,
+  sourceId: uuidSchema,
+});
+
+export const getUserPriorSourceByIdOutput = z
+  .object({
+    sourceId: uuidSchema,
+    sourceIdentifier: z.string(),
+    charCount: z.number().int(),
+    originalStoragePath: z.string().nullable(),
+    revokedAt: z.string().nullable(),
+  })
+  .nullable();
+
+export const getUserPriorSourceById = wrapQuery(
+  "aiCorpus.source.getUserPriorById",
+  withZod(
+    getUserPriorSourceByIdInput,
+    getUserPriorSourceByIdOutput,
+    async (input) => {
+      const query = useQuery();
+      const row = await query
+        .select({
+          id: s.source.id,
+          sourceIdentifier: s.source.sourceIdentifier,
+          charCount: s.source.charCount,
+          originalStoragePath: s.source.originalStoragePath,
+          revokedAt: s.source.revokedAt,
+        })
+        .from(s.source)
+        .where(
+          and(
+            eq(s.source.id, input.sourceId),
+            eq(s.source.contributedByUserId, input.userId),
+          ),
+        )
+        .limit(1)
+        .then((r) => r[0]);
+      if (!row) return null;
+      return {
+        sourceId: row.id,
+        sourceIdentifier: row.sourceIdentifier,
+        charCount: row.charCount,
+        originalStoragePath: row.originalStoragePath,
+        revokedAt: row.revokedAt,
+      };
+    },
+  ),
 );
 
 export const revokeUserPriorSourceInput = z.object({

--- a/packages/core/src/models/leercoach/index.ts
+++ b/packages/core/src/models/leercoach/index.ts
@@ -13,4 +13,5 @@ export * as Chat from "./chat.js";
 export { leercoachChatScopeSchema } from "./chat.js";
 export * as Message from "./message.js";
 export * as Portfolio from "./portfolio.js";
+export * as UploadJob from "./upload-job.js";
 export { leercoachPortfolioScopeSchema } from "./portfolio.js";

--- a/packages/core/src/models/leercoach/upload-job.ts
+++ b/packages/core/src/models/leercoach/upload-job.ts
@@ -1,5 +1,5 @@
 import { schema as s } from "@nawadi/db";
-import { and, desc, eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { useQuery, withTransaction } from "../../contexts/index.js";
 import {
@@ -228,44 +228,3 @@ export const updateStatus = wrapCommand(
   }),
 );
 
-// ---- List recent jobs for a user ----
-//
-// Nice-to-have for a "my uploads" dashboard; not wired into the UI
-// yet. Included here so the surface is complete when the time comes.
-
-export const listUploadJobsByUserIdInput = z.object({
-  userId: uuidSchema,
-  limit: z.number().int().min(1).max(100).default(20),
-});
-
-export const listByUserId = wrapQuery(
-  "leercoach.uploadJob.listByUserId",
-  withZod(
-    listUploadJobsByUserIdInput,
-    z.array(getUploadJobByIdOutput.unwrap()),
-    async (input) => {
-      const query = useQuery();
-      const rows = await query
-        .select()
-        .from(s.leercoachUploadJob)
-        .where(eq(s.leercoachUploadJob.userId, input.userId))
-        .orderBy(desc(s.leercoachUploadJob.createdAt))
-        .limit(input.limit);
-      return rows.map((row) => ({
-        jobId: row.id,
-        userId: row.userId,
-        kind: row.kind,
-        status: row.status,
-        blobPath: row.blobPath,
-        label: row.label,
-        metadata: row.metadata,
-        workflowRunId: row.workflowRunId,
-        sourceId: row.sourceId,
-        errorMessage: row.errorMessage,
-        createdAt: row.createdAt,
-        updatedAt: row.updatedAt,
-        completedAt: row.completedAt,
-      }));
-    },
-  ),
-);

--- a/packages/core/src/models/leercoach/upload-job.ts
+++ b/packages/core/src/models/leercoach/upload-job.ts
@@ -1,0 +1,271 @@
+import { schema as s } from "@nawadi/db";
+import { and, desc, eq } from "drizzle-orm";
+import { z } from "zod";
+import { useQuery, withTransaction } from "../../contexts/index.js";
+import {
+  uuidSchema,
+  withZod,
+  wrapCommand,
+  wrapQuery,
+} from "../../utils/index.js";
+
+// Tracks the lifecycle of a durable ingest run (portfolio upload
+// today; artefact upload when we migrate it). The row is the client's
+// pollable handle on async processing: they poll by id, we return the
+// current status + (on success) the resulting ai_corpus.source id.
+
+export const uploadJobKindSchema = z.enum(["portfolio"]);
+export type UploadJobKind = z.infer<typeof uploadJobKindSchema>;
+
+export const uploadJobStatusSchema = z.enum([
+  "pending",
+  "processing",
+  "ready",
+  "failed",
+]);
+export type UploadJobStatus = z.infer<typeof uploadJobStatusSchema>;
+
+// ---- Create ----
+//
+// Called by the upload server action the moment bytes are in Supabase
+// Storage. The workflow trigger fires right after; the returned id is
+// what the client uses to poll status + what the workflow route
+// receives as its input payload.
+
+export const createUploadJobInput = z.object({
+  userId: uuidSchema,
+  kind: uploadJobKindSchema,
+  blobPath: z.string().min(1),
+  label: z.string().default(""),
+  /**
+   * Opaque bag of form inputs (profielId, scope, consent, etc.).
+   * Typed loosely so the upload form can evolve without a schema
+   * migration per field; the workflow route validates shape at read.
+   */
+  metadata: z.record(z.string(), z.unknown()).default({}),
+});
+
+export const createUploadJobOutput = z.object({
+  jobId: uuidSchema,
+});
+
+export const create = wrapCommand(
+  "leercoach.uploadJob.create",
+  withZod(createUploadJobInput, createUploadJobOutput, async (input) => {
+    return withTransaction(async (tx) => {
+      const inserted = await tx
+        .insert(s.leercoachUploadJob)
+        .values({
+          userId: input.userId,
+          kind: input.kind,
+          blobPath: input.blobPath,
+          label: input.label,
+          metadata: input.metadata,
+        })
+        .returning({ id: s.leercoachUploadJob.id })
+        .then((r) => r[0]);
+      if (!inserted) {
+        throw new Error("Insert leercoach.upload_job returned no rows");
+      }
+      return { jobId: inserted.id };
+    });
+  }),
+);
+
+// ---- Read: single job, user-scoped ----
+
+export const getUploadJobByIdInput = z.object({
+  jobId: uuidSchema,
+  userId: uuidSchema,
+});
+
+export const getUploadJobByIdOutput = z
+  .object({
+    jobId: uuidSchema,
+    userId: uuidSchema,
+    kind: uploadJobKindSchema,
+    status: uploadJobStatusSchema,
+    blobPath: z.string(),
+    label: z.string(),
+    metadata: z.record(z.string(), z.unknown()),
+    workflowRunId: z.string().nullable(),
+    sourceId: uuidSchema.nullable(),
+    errorMessage: z.string().nullable(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+    completedAt: z.string().nullable(),
+  })
+  .nullable();
+
+/**
+ * Fetch one upload job, scoped to the requesting user. Returns null
+ * when the job doesn't exist OR belongs to a different user — never
+ * throws on mismatch so callers can't probe existence across users.
+ */
+export const getById = wrapQuery(
+  "leercoach.uploadJob.getById",
+  withZod(getUploadJobByIdInput, getUploadJobByIdOutput, async (input) => {
+    const query = useQuery();
+    const row = await query
+      .select()
+      .from(s.leercoachUploadJob)
+      .where(
+        and(
+          eq(s.leercoachUploadJob.id, input.jobId),
+          eq(s.leercoachUploadJob.userId, input.userId),
+        ),
+      )
+      .limit(1)
+      .then((r) => r[0]);
+
+    if (!row) return null;
+    return {
+      jobId: row.id,
+      userId: row.userId,
+      kind: row.kind,
+      status: row.status,
+      blobPath: row.blobPath,
+      label: row.label,
+      metadata: row.metadata,
+      workflowRunId: row.workflowRunId,
+      sourceId: row.sourceId,
+      errorMessage: row.errorMessage,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      completedAt: row.completedAt,
+    };
+  }),
+);
+
+// ---- Read: by id, no user scoping ----
+//
+// The workflow route runs in an unauthenticated context — QStash
+// calls our webhook with a signed payload containing the jobId, and
+// we need to load the job to drive the pipeline. No userId filter
+// here, but the webhook is gated by QStash's signing-key verification
+// upstream, so the call itself is authenticated as "this queue only".
+export const getByIdAsWorkflow = wrapQuery(
+  "leercoach.uploadJob.getByIdAsWorkflow",
+  withZod(
+    z.object({ jobId: uuidSchema }),
+    getUploadJobByIdOutput,
+    async (input) => {
+      const query = useQuery();
+      const row = await query
+        .select()
+        .from(s.leercoachUploadJob)
+        .where(eq(s.leercoachUploadJob.id, input.jobId))
+        .limit(1)
+        .then((r) => r[0]);
+      if (!row) return null;
+      return {
+        jobId: row.id,
+        userId: row.userId,
+        kind: row.kind,
+        status: row.status,
+        blobPath: row.blobPath,
+        label: row.label,
+        metadata: row.metadata,
+        workflowRunId: row.workflowRunId,
+        sourceId: row.sourceId,
+        errorMessage: row.errorMessage,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        completedAt: row.completedAt,
+      };
+    },
+  ),
+);
+
+// ---- Update status + workflow-run bookkeeping ----
+//
+// Called from inside the workflow route at every meaningful
+// transition: step 1 → "processing", final step → "ready" (+ sourceId),
+// any step failure → "failed" (+ errorMessage). Writes are small and
+// non-transactional by design — workflow steps are idempotent, so a
+// redo of the same transition is a no-op.
+
+export const updateUploadJobStatusInput = z.object({
+  jobId: uuidSchema,
+  status: uploadJobStatusSchema,
+  workflowRunId: z.string().optional(),
+  sourceId: uuidSchema.optional(),
+  errorMessage: z.string().max(2000).optional(),
+});
+
+export const updateStatus = wrapCommand(
+  "leercoach.uploadJob.updateStatus",
+  withZod(updateUploadJobStatusInput, z.void(), async (input) => {
+    return withTransaction(async (tx) => {
+      const patch: {
+        status: typeof input.status;
+        updatedAt: string;
+        workflowRunId?: string;
+        sourceId?: string;
+        errorMessage?: string | null;
+        completedAt?: string;
+      } = {
+        status: input.status,
+        updatedAt: new Date().toISOString(),
+      };
+      if (input.workflowRunId !== undefined) {
+        patch.workflowRunId = input.workflowRunId;
+      }
+      if (input.sourceId !== undefined) patch.sourceId = input.sourceId;
+      // Clear previous error on success; set it on failure.
+      if (input.status === "failed") {
+        patch.errorMessage = input.errorMessage ?? null;
+      } else if (input.status === "ready") {
+        patch.errorMessage = null;
+        patch.completedAt = new Date().toISOString();
+      }
+
+      await tx
+        .update(s.leercoachUploadJob)
+        .set(patch)
+        .where(eq(s.leercoachUploadJob.id, input.jobId));
+    });
+  }),
+);
+
+// ---- List recent jobs for a user ----
+//
+// Nice-to-have for a "my uploads" dashboard; not wired into the UI
+// yet. Included here so the surface is complete when the time comes.
+
+export const listUploadJobsByUserIdInput = z.object({
+  userId: uuidSchema,
+  limit: z.number().int().min(1).max(100).default(20),
+});
+
+export const listByUserId = wrapQuery(
+  "leercoach.uploadJob.listByUserId",
+  withZod(
+    listUploadJobsByUserIdInput,
+    z.array(getUploadJobByIdOutput.unwrap()),
+    async (input) => {
+      const query = useQuery();
+      const rows = await query
+        .select()
+        .from(s.leercoachUploadJob)
+        .where(eq(s.leercoachUploadJob.userId, input.userId))
+        .orderBy(desc(s.leercoachUploadJob.createdAt))
+        .limit(input.limit);
+      return rows.map((row) => ({
+        jobId: row.id,
+        userId: row.userId,
+        kind: row.kind,
+        status: row.status,
+        blobPath: row.blobPath,
+        label: row.label,
+        metadata: row.metadata,
+        workflowRunId: row.workflowRunId,
+        sourceId: row.sourceId,
+        errorMessage: row.errorMessage,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        completedAt: row.completedAt,
+      }));
+    },
+  ),
+);

--- a/packages/db/migrations/0036_uneven_amphibian.sql
+++ b/packages/db/migrations/0036_uneven_amphibian.sql
@@ -1,0 +1,21 @@
+CREATE TYPE "leercoach"."upload_job_kind" AS ENUM('portfolio');
+CREATE TYPE "leercoach"."upload_job_status" AS ENUM('pending', 'processing', 'ready', 'failed');
+CREATE TABLE "leercoach"."upload_job" (
+	"id" uuid PRIMARY KEY DEFAULT extensions.uuid_generate_v4() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"kind" "leercoach"."upload_job_kind" NOT NULL,
+	"status" "leercoach"."upload_job_status" DEFAULT 'pending' NOT NULL,
+	"blob_path" text NOT NULL,
+	"label" text DEFAULT '' NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"workflow_run_id" text,
+	"source_id" uuid,
+	"error_message" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"completed_at" timestamp with time zone
+);
+
+ALTER TABLE "ai_corpus"."source" ADD COLUMN "original_storage_path" text;
+CREATE INDEX "upload_job_user_created_idx" ON "leercoach"."upload_job" USING btree ("user_id","created_at" DESC NULLS LAST);
+CREATE INDEX "upload_job_status_idx" ON "leercoach"."upload_job" USING btree ("status");

--- a/packages/db/migrations/meta/0036_snapshot.json
+++ b/packages/db/migrations/meta/0036_snapshot.json
@@ -1,0 +1,7941 @@
+{
+  "id": "4aa7a36d-44a4-4304-a517-1f4465554e89",
+  "prevId": "7bd9d6c6-8b95-4be0-af07-a61fc5a02950",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "ai_corpus.chunk": {
+      "name": "chunk",
+      "schema": "ai_corpus",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "criterium_id": {
+          "name": "criterium_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "werkproces_id": {
+          "name": "werkproces_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chunk_criterium_quality_idx": {
+          "name": "chunk_criterium_quality_idx",
+          "columns": [
+            {
+              "expression": "criterium_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quality_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chunk_source_idx": {
+          "name": "chunk_source_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chunk_source_id_source_id_fk": {
+          "name": "chunk_source_id_source_id_fk",
+          "tableFrom": "chunk",
+          "tableTo": "source",
+          "schemaTo": "ai_corpus",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chunk_criterium_id_beoordelingscriterium_id_fk": {
+          "name": "chunk_criterium_id_beoordelingscriterium_id_fk",
+          "tableFrom": "chunk",
+          "tableTo": "beoordelingscriterium",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "criterium_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chunk_werkproces_id_werkproces_id_fk": {
+          "name": "chunk_werkproces_id_werkproces_id_fk",
+          "tableFrom": "chunk",
+          "tableTo": "werkproces",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "werkproces_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ai_corpus.outline_template": {
+      "name": "outline_template",
+      "schema": "ai_corpus",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "profiel_id": {
+          "name": "profiel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sections": {
+          "name": "sections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "outline_template_profiel_version_unique": {
+          "name": "outline_template_profiel_version_unique",
+          "columns": [
+            {
+              "expression": "profiel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outline_template_profiel_id_kwalificatieprofiel_id_fk": {
+          "name": "outline_template_profiel_id_kwalificatieprofiel_id_fk",
+          "tableFrom": "outline_template",
+          "tableTo": "kwalificatieprofiel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "profiel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ai_corpus.source": {
+      "name": "source",
+      "schema": "ai_corpus",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "domain": {
+          "name": "domain",
+          "type": "domain",
+          "typeSchema": "ai_corpus",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_identifier": {
+          "name": "source_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_level": {
+          "name": "consent_level",
+          "type": "consent_level",
+          "typeSchema": "ai_corpus",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contributed_by_user_id": {
+          "name": "contributed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profiel_id": {
+          "name": "profiel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "richting": {
+          "name": "richting",
+          "type": "richting",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "niveau_rang": {
+          "name": "niveau_rang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "char_count": {
+          "name": "char_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_storage_path": {
+          "name": "original_storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "source_domain_hash_unique": {
+          "name": "source_domain_hash_unique",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_chat_created_idx": {
+          "name": "source_chat_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_profiel_id_kwalificatieprofiel_id_fk": {
+          "name": "source_profiel_id_kwalificatieprofiel_id_fk",
+          "tableFrom": "source",
+          "tableTo": "kwalificatieprofiel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "profiel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_chat_id_chat_id_fk": {
+          "name": "source_chat_id_chat_id_fk",
+          "tableFrom": "source",
+          "tableTo": "chat",
+          "schemaTo": "leercoach",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.token": {
+      "name": "token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partial_key": {
+          "name": "partial_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "token_hashed_key_index": {
+          "name": "token_hashed_key_index",
+          "columns": [
+            {
+              "expression": "hashed_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "token_user_id_fk": {
+          "name": "token_user_id_fk",
+          "tableFrom": "token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "auth_user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.token_usage": {
+      "name": "token_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "token_usage_token_id_used_at_index": {
+          "name": "token_usage_token_id_used_at_index",
+          "columns": [
+            {
+              "expression": "token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "used_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "token_usage_token_id_fk": {
+          "name": "token_usage_token_id_fk",
+          "tableFrom": "token_usage",
+          "tableTo": "token",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leercoach.chat": {
+      "name": "chat",
+      "schema": "leercoach",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profiel_id": {
+          "name": "profiel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructie_groep_id": {
+          "name": "instructie_groep_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "chat_phase",
+          "typeSchema": "leercoach",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verkennen'"
+        },
+        "active_stream_id": {
+          "name": "active_stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portfolio_id": {
+          "name": "portfolio_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "chat_user_created_idx": {
+          "name": "chat_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_profiel_idx": {
+          "name": "chat_profiel_idx",
+          "columns": [
+            {
+              "expression": "profiel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_profiel_id_kwalificatieprofiel_id_fk": {
+          "name": "chat_profiel_id_kwalificatieprofiel_id_fk",
+          "tableFrom": "chat",
+          "tableTo": "kwalificatieprofiel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "profiel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "chat_instructie_groep_id_instructie_groep_id_fk": {
+          "name": "chat_instructie_groep_id_instructie_groep_id_fk",
+          "tableFrom": "chat",
+          "tableTo": "instructie_groep",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "instructie_groep_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leercoach.message": {
+      "name": "message",
+      "schema": "leercoach",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "compacted_into_id": {
+          "name": "compacted_into_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compaction_metadata": {
+          "name": "compaction_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "message_chat_created_idx": {
+          "name": "message_chat_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_active_chat_created_idx": {
+          "name": "message_active_chat_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"leercoach\".\"message\".\"compacted_into_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_chat_id_chat_id_fk": {
+          "name": "message_chat_id_chat_id_fk",
+          "tableFrom": "message",
+          "tableTo": "chat",
+          "schemaTo": "leercoach",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leercoach.portfolio": {
+      "name": "portfolio",
+      "schema": "leercoach",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profiel_id": {
+          "name": "profiel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructie_groep_id": {
+          "name": "instructie_groep_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "portfolio_user_created_idx": {
+          "name": "portfolio_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "portfolio_user_profiel_groep_idx": {
+          "name": "portfolio_user_profiel_groep_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profiel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instructie_groep_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "portfolio_instructie_groep_id_instructie_groep_id_fk": {
+          "name": "portfolio_instructie_groep_id_instructie_groep_id_fk",
+          "tableFrom": "portfolio",
+          "tableTo": "instructie_groep",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "instructie_groep_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leercoach.portfolio_version": {
+      "name": "portfolio_version",
+      "schema": "leercoach",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "portfolio_id": {
+          "name": "portfolio_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "portfolio_version_created_by",
+          "typeSchema": "leercoach",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_message_id": {
+          "name": "created_by_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_note": {
+          "name": "change_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "portfolio_version_portfolio_created_idx": {
+          "name": "portfolio_version_portfolio_created_idx",
+          "columns": [
+            {
+              "expression": "portfolio_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "portfolio_version_portfolio_hash_unique": {
+          "name": "portfolio_version_portfolio_hash_unique",
+          "columns": [
+            {
+              "expression": "portfolio_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "portfolio_version_portfolio_id_portfolio_id_fk": {
+          "name": "portfolio_version_portfolio_id_portfolio_id_fk",
+          "tableFrom": "portfolio_version",
+          "tableTo": "portfolio",
+          "schemaTo": "leercoach",
+          "columnsFrom": [
+            "portfolio_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "portfolio_version_parent_version_id_portfolio_version_id_fk": {
+          "name": "portfolio_version_parent_version_id_portfolio_version_id_fk",
+          "tableFrom": "portfolio_version",
+          "tableTo": "portfolio_version",
+          "schemaTo": "leercoach",
+          "columnsFrom": [
+            "parent_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leercoach.upload_job": {
+      "name": "upload_job",
+      "schema": "leercoach",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "upload_job_kind",
+          "typeSchema": "leercoach",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "upload_job_status",
+          "typeSchema": "leercoach",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "blob_path": {
+          "name": "blob_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "upload_job_user_created_idx": {
+          "name": "upload_job_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upload_job_status_idx": {
+          "name": "upload_job_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cohort_allocation_role": {
+      "name": "cohort_allocation_role",
+      "schema": "",
+      "columns": {
+        "cohort_allocation_id": {
+          "name": "cohort_allocation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cohort_allocation_role_allocation_id_fk": {
+          "name": "cohort_allocation_role_allocation_id_fk",
+          "tableFrom": "cohort_allocation_role",
+          "tableTo": "cohort_allocation",
+          "columnsFrom": [
+            "cohort_allocation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_role_role_id_fk": {
+          "name": "user_role_role_id_fk",
+          "tableFrom": "cohort_allocation_role",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "cohort_allocation_role_cohort_allocation_id_role_id_pk": {
+          "name": "cohort_allocation_role_cohort_allocation_id_role_id_pk",
+          "columns": [
+            "cohort_allocation_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_role": {
+      "name": "person_role",
+      "schema": "",
+      "columns": {
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "person_role_person_id_fk": {
+          "name": "person_role_person_id_fk",
+          "tableFrom": "person_role",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_role_role_id_fk": {
+          "name": "user_role_role_id_fk",
+          "tableFrom": "person_role",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "person_role_person_id_role_id_pk": {
+          "name": "person_role_person_id_role_id_pk",
+          "columns": [
+            "person_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.privilege": {
+      "name": "privilege",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "privilege_handle_index": {
+          "name": "privilege_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "role_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "role_handle_index": {
+          "name": "role_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_location_id_fk": {
+          "name": "role_location_id_fk",
+          "tableFrom": "role",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_privilege": {
+      "name": "role_privilege",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privilege_id": {
+          "name": "privilege_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_privilege_role_id_fk": {
+          "name": "role_privilege_role_id_fk",
+          "tableFrom": "role_privilege",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "role_privilege_privilege_id_fk": {
+          "name": "role_privilege_privilege_id_fk",
+          "tableFrom": "role_privilege",
+          "tableTo": "privilege",
+          "columnsFrom": [
+            "privilege_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_privilege_pk": {
+          "name": "role_privilege_pk",
+          "columns": [
+            "role_id",
+            "privilege_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.token_privilege": {
+      "name": "token_privilege",
+      "schema": "",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privilege_id": {
+          "name": "privilege_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "token_privilege_token_id_fk": {
+          "name": "token_privilege_token_id_fk",
+          "tableFrom": "token_privilege",
+          "tableTo": "token",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "token_privilege_privilege_id_fk": {
+          "name": "token_privilege_privilege_id_fk",
+          "tableFrom": "token_privilege",
+          "tableTo": "privilege",
+          "columnsFrom": [
+            "privilege_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "token_privilege_pk": {
+          "name": "token_privilege_pk",
+          "columns": [
+            "token_id",
+            "privilege_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certificate": {
+      "name": "certificate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_curriculum_id": {
+          "name": "student_curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort_allocation_id": {
+          "name": "cohort_allocation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visible_from": {
+          "name": "visible_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "certificate_unq_handle": {
+          "name": "certificate_unq_handle",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_idx_location": {
+          "name": "certificate_idx_location",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_idx_issued_at": {
+          "name": "certificate_idx_issued_at",
+          "columns": [
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_idx_visible_from": {
+          "name": "certificate_idx_visible_from",
+          "columns": [
+            {
+              "expression": "visible_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_idx_deleted_at": {
+          "name": "certificate_idx_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_idx_location_issued_at": {
+          "name": "certificate_idx_location_issued_at",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_idx_handle_search": {
+          "name": "certificate_idx_handle_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', \"handle\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "certificate_student_curriculum_link_id_fk": {
+          "name": "certificate_student_curriculum_link_id_fk",
+          "tableFrom": "certificate",
+          "tableTo": "student_curriculum",
+          "columnsFrom": [
+            "student_curriculum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "certificate_location_id_fk": {
+          "name": "certificate_location_id_fk",
+          "tableFrom": "certificate",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "certificate_cohort_allocation_id_fk": {
+          "name": "certificate_cohort_allocation_id_fk",
+          "tableFrom": "certificate",
+          "tableTo": "cohort_allocation",
+          "columnsFrom": [
+            "cohort_allocation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_certificate": {
+      "name": "external_certificate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuing_authority": {
+          "name": "issuing_authority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuing_location": {
+          "name": "issuing_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awarded_at": {
+          "name": "awarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_comments": {
+          "name": "additional_comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "external_certificate_media_id_media_id_fk": {
+          "name": "external_certificate_media_id_media_id_fk",
+          "tableFrom": "external_certificate",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "external_certificate_person_id_fk": {
+          "name": "external_certificate_person_id_fk",
+          "tableFrom": "external_certificate",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "external_certificate_location_id_fk": {
+          "name": "external_certificate_location_id_fk",
+          "tableFrom": "external_certificate",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_completed_competency": {
+      "name": "student_completed_competency",
+      "schema": "",
+      "columns": {
+        "student_curriculum_id": {
+          "name": "student_curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "curriculum_module_competency_id": {
+          "name": "curriculum_module_competency_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "certificate_id": {
+          "name": "certificate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "student_completed_competency_student_curriculum_link_id_fk": {
+          "name": "student_completed_competency_student_curriculum_link_id_fk",
+          "tableFrom": "student_completed_competency",
+          "tableTo": "student_curriculum",
+          "columnsFrom": [
+            "student_curriculum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "curriculum_competency_competency_id_fk": {
+          "name": "curriculum_competency_competency_id_fk",
+          "tableFrom": "student_completed_competency",
+          "tableTo": "curriculum_competency",
+          "columnsFrom": [
+            "curriculum_module_competency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_completed_competency_certificate_id_fk": {
+          "name": "student_completed_competency_certificate_id_fk",
+          "tableFrom": "student_completed_competency",
+          "tableTo": "certificate",
+          "columnsFrom": [
+            "certificate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "student_completed_competency_pk": {
+          "name": "student_completed_competency_pk",
+          "columns": [
+            "student_curriculum_id",
+            "curriculum_module_competency_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_curriculum": {
+      "name": "student_curriculum",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "curriculum_id": {
+          "name": "curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_type_id": {
+          "name": "gear_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "student_curriculum_unq_identity_gear_curriculum": {
+          "name": "student_curriculum_unq_identity_gear_curriculum",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "curriculum_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gear_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "student_curriculum_idx_person": {
+          "name": "student_curriculum_idx_person",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_curriculum_link_curriculum_id_gear_type_id_fk": {
+          "name": "student_curriculum_link_curriculum_id_gear_type_id_fk",
+          "tableFrom": "student_curriculum",
+          "tableTo": "curriculum_gear_link",
+          "columnsFrom": [
+            "curriculum_id",
+            "gear_type_id"
+          ],
+          "columnsTo": [
+            "curriculum_id",
+            "gear_type_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_curriculum_link_curriculum_id_fk": {
+          "name": "student_curriculum_link_curriculum_id_fk",
+          "tableFrom": "student_curriculum",
+          "tableTo": "curriculum",
+          "columnsFrom": [
+            "curriculum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_curriculum_link_gear_type_id_fk": {
+          "name": "student_curriculum_link_gear_type_id_fk",
+          "tableFrom": "student_curriculum",
+          "tableTo": "gear_type",
+          "columnsFrom": [
+            "gear_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_curriculum_link_person_id_fk": {
+          "name": "student_curriculum_link_person_id_fk",
+          "tableFrom": "student_curriculum",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cohort": {
+      "name": "cohort",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_start_time": {
+          "name": "access_start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_end_time": {
+          "name": "access_end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "certificates_visible_from": {
+          "name": "certificates_visible_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cohort_handle_location_id_index": {
+          "name": "cohort_handle_location_id_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cohort_location_id_fk": {
+          "name": "cohort_location_id_fk",
+          "tableFrom": "cohort",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cohort_allocation": {
+      "name": "cohort_allocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "cohort_id": {
+          "name": "cohort_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_curriculum_id": {
+          "name": "student_curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructor_id": {
+          "name": "instructor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "progress_visible_up_until": {
+          "name": "progress_visible_up_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cohort_allocation_cohort_id_actor_id_student_curriculum_id_index": {
+          "name": "cohort_allocation_cohort_id_actor_id_student_curriculum_id_index",
+          "columns": [
+            {
+              "expression": "cohort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_curriculum_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cohort_allocation\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cohort_allocation_cohort_id_tags_index": {
+          "name": "cohort_allocation_cohort_id_tags_index",
+          "columns": [
+            {
+              "expression": "cohort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cohort_allocation_cohort_id_fk": {
+          "name": "cohort_allocation_cohort_id_fk",
+          "tableFrom": "cohort_allocation",
+          "tableTo": "cohort",
+          "columnsFrom": [
+            "cohort_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cohort_allocation_actor_id_fk": {
+          "name": "cohort_allocation_actor_id_fk",
+          "tableFrom": "cohort_allocation",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cohort_allocation_student_curriculum_id_fk": {
+          "name": "cohort_allocation_student_curriculum_id_fk",
+          "tableFrom": "cohort_allocation",
+          "tableTo": "student_curriculum",
+          "columnsFrom": [
+            "student_curriculum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cohort_allocation_instructor_id_fk": {
+          "name": "cohort_allocation_instructor_id_fk",
+          "tableFrom": "cohort_allocation",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "instructor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category": {
+      "name": "category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "parent_category_id": {
+          "name": "parent_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "category_handle_index": {
+          "name": "category_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "category_parent_category_id_fk": {
+          "name": "category_parent_category_id_fk",
+          "tableFrom": "category",
+          "tableTo": "category",
+          "columnsFrom": [
+            "parent_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competency": {
+      "name": "competency",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "competency_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "competency_handle_index": {
+          "name": "competency_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course": {
+      "name": "course",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discipline_id": {
+          "name": "discipline_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "course_handle_index": {
+          "name": "course_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_discipline_id_fk": {
+          "name": "course_discipline_id_fk",
+          "tableFrom": "course",
+          "tableTo": "discipline",
+          "columnsFrom": [
+            "discipline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_category": {
+      "name": "course_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "course_category_category_id_course_id_index": {
+          "name": "course_category_category_id_course_id_index",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_category_course_id_fk": {
+          "name": "course_category_course_id_fk",
+          "tableFrom": "course_category",
+          "tableTo": "course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "course_category_category_id_fk": {
+          "name": "course_category_category_id_fk",
+          "tableFrom": "course_category",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.degree": {
+      "name": "degree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rang": {
+          "name": "rang",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "degree_handle_index": {
+          "name": "degree_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "degree_rang_index": {
+          "name": "degree_rang_index",
+          "columns": [
+            {
+              "expression": "rang",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discipline": {
+      "name": "discipline",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "discipline_handle_index": {
+          "name": "discipline_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gear_type": {
+      "name": "gear_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gear_type_handle_index": {
+          "name": "gear_type_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.module": {
+      "name": "module",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "module_handle_index": {
+          "name": "module_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.program": {
+      "name": "program",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degree_id": {
+          "name": "degree_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "program_handle_index": {
+          "name": "program_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "program_course_id_fk": {
+          "name": "program_course_id_fk",
+          "tableFrom": "program",
+          "tableTo": "course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_degree_id_fk": {
+          "name": "program_degree_id_fk",
+          "tableFrom": "program",
+          "tableTo": "degree",
+          "columnsFrom": [
+            "degree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curriculum": {
+      "name": "curriculum",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "curriculum_program_id_revision_index": {
+          "name": "curriculum_program_id_revision_index",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curriculum_program_id_fk": {
+          "name": "curriculum_program_id_fk",
+          "tableFrom": "curriculum",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curriculum_competency": {
+      "name": "curriculum_competency",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "curriculum_id": {
+          "name": "curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competency_id": {
+          "name": "competency_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement": {
+          "name": "requirement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "curriculum_competency_unq_set": {
+          "name": "curriculum_competency_unq_set",
+          "columns": [
+            {
+              "expression": "curriculum_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "module_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curriculum_competency_curriculum_module_id_fk": {
+          "name": "curriculum_competency_curriculum_module_id_fk",
+          "tableFrom": "curriculum_competency",
+          "tableTo": "curriculum_module",
+          "columnsFrom": [
+            "curriculum_id",
+            "module_id"
+          ],
+          "columnsTo": [
+            "curriculum_id",
+            "module_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "curriculum_competency_competency_id_fk": {
+          "name": "curriculum_competency_competency_id_fk",
+          "tableFrom": "curriculum_competency",
+          "tableTo": "competency",
+          "columnsFrom": [
+            "competency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curriculum_gear_link": {
+      "name": "curriculum_gear_link",
+      "schema": "",
+      "columns": {
+        "curriculum_id": {
+          "name": "curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_type_id": {
+          "name": "gear_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "curriculum_gear_link_curriculum_id_fk": {
+          "name": "curriculum_gear_link_curriculum_id_fk",
+          "tableFrom": "curriculum_gear_link",
+          "tableTo": "curriculum",
+          "columnsFrom": [
+            "curriculum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "curriculum_gear_link_gear_type_id_fk": {
+          "name": "curriculum_gear_link_gear_type_id_fk",
+          "tableFrom": "curriculum_gear_link",
+          "tableTo": "gear_type",
+          "columnsFrom": [
+            "gear_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curriculum_gear_link_curriculum_id_gear_type_id_pk": {
+          "name": "curriculum_gear_link_curriculum_id_gear_type_id_pk",
+          "columns": [
+            "curriculum_id",
+            "gear_type_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curriculum_module": {
+      "name": "curriculum_module",
+      "schema": "",
+      "columns": {
+        "curriculum_id": {
+          "name": "curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "curriculum_module_curriculum_id_module_id_index": {
+          "name": "curriculum_module_curriculum_id_module_id_index",
+          "columns": [
+            {
+              "expression": "curriculum_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "module_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curriculum_module_curriculum_id_fk": {
+          "name": "curriculum_module_curriculum_id_fk",
+          "tableFrom": "curriculum_module",
+          "tableTo": "curriculum",
+          "columnsFrom": [
+            "curriculum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "curriculum_module_module_id_fk": {
+          "name": "curriculum_module_module_id_fk",
+          "tableFrom": "curriculum_module",
+          "tableTo": "module",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curriculum_module_curriculum_id_module_id_pk": {
+          "name": "curriculum_module_curriculum_id_module_id_pk",
+          "columns": [
+            "curriculum_id",
+            "module_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.instructie_groep": {
+      "name": "instructie_groep",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "richting": {
+          "name": "richting",
+          "type": "richting",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.instructie_groep_cursus": {
+      "name": "instructie_groep_cursus",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "instructie_groep_id": {
+          "name": "instructie_groep_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "instructie_groep_cursus_instructie_groep_id_course_id_index": {
+          "name": "instructie_groep_cursus_instructie_groep_id_course_id_index",
+          "columns": [
+            {
+              "expression": "instructie_groep_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instructie_groep_cursus_instructie_groep_id_instructie_groep_id_fk": {
+          "name": "instructie_groep_cursus_instructie_groep_id_instructie_groep_id_fk",
+          "tableFrom": "instructie_groep_cursus",
+          "tableTo": "instructie_groep",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "instructie_groep_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instructie_groep_cursus_course_id_course_id_fk": {
+          "name": "instructie_groep_cursus_course_id_course_id_fk",
+          "tableFrom": "instructie_groep_cursus",
+          "tableTo": "course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.persoon_kwalificatie": {
+      "name": "persoon_kwalificatie",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "direct_behaalde_pvb_onderdeel_id": {
+          "name": "direct_behaalde_pvb_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "afgeleide_pvb_onderdeel_id": {
+          "name": "afgeleide_pvb_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_onderdeel_id": {
+          "name": "kerntaak_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verkregen_reden": {
+          "name": "verkregen_reden",
+          "type": "kwalificatie_verkregen_reden",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'onbekend'"
+        },
+        "toegevoegd_op": {
+          "name": "toegevoegd_op",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toegevoegd_door": {
+          "name": "toegevoegd_door",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "unique_person_course_kerntaak_onderdeel": {
+          "name": "unique_person_course_kerntaak_onderdeel",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kerntaak_onderdeel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "persoon_kwalificatie_direct_behaalde_pvb_onderdeel_id_kerntaak_onderdeel_id_pvb_onderdeel_id_kerntaak_onderdeel_id_fk": {
+          "name": "persoon_kwalificatie_direct_behaalde_pvb_onderdeel_id_kerntaak_onderdeel_id_pvb_onderdeel_id_kerntaak_onderdeel_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "tableTo": "pvb_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "direct_behaalde_pvb_onderdeel_id",
+            "kerntaak_onderdeel_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_onderdeel_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persoon_kwalificatie_afgeleide_pvb_onderdeel_id_kerntaak_onderdeel_id_pvb_onderdeel_id_kerntaak_onderdeel_id_fk": {
+          "name": "persoon_kwalificatie_afgeleide_pvb_onderdeel_id_kerntaak_onderdeel_id_pvb_onderdeel_id_kerntaak_onderdeel_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "tableTo": "pvb_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "afgeleide_pvb_onderdeel_id",
+            "kerntaak_onderdeel_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_onderdeel_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persoon_kwalificatie_kerntaak_onderdeel_id_kerntaak_onderdeel_id_fk": {
+          "name": "persoon_kwalificatie_kerntaak_onderdeel_id_kerntaak_onderdeel_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "tableTo": "kerntaak_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_onderdeel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persoon_kwalificatie_course_id_course_id_fk": {
+          "name": "persoon_kwalificatie_course_id_course_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "tableTo": "course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persoon_kwalificatie_toegevoegd_door_actor_id_fk": {
+          "name": "persoon_kwalificatie_toegevoegd_door_actor_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "toegevoegd_door"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persoon_kwalificatie_person_id_person_id_fk": {
+          "name": "persoon_kwalificatie_person_id_person_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verkregen_reden_pvb_behaald_constraint": {
+          "name": "verkregen_reden_pvb_behaald_constraint",
+          "value": "(\"kss\".\"persoon_kwalificatie\".\"verkregen_reden\" != 'pvb_behaald') OR (\"kss\".\"persoon_kwalificatie\".\"direct_behaalde_pvb_onderdeel_id\" IS NOT NULL AND \"kss\".\"persoon_kwalificatie\".\"afgeleide_pvb_onderdeel_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "kss.pvb_aanvraag": {
+      "name": "pvb_aanvraag",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kandidaat_id": {
+          "name": "kandidaat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locatie_id": {
+          "name": "locatie_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "pvb_aanvraag_type",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_aanvraag_kandidaat_id_person_id_fk": {
+          "name": "pvb_aanvraag_kandidaat_id_person_id_fk",
+          "tableFrom": "pvb_aanvraag",
+          "tableTo": "person",
+          "columnsFrom": [
+            "kandidaat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_aanvraag_locatie_id_location_id_fk": {
+          "name": "pvb_aanvraag_locatie_id_location_id_fk",
+          "tableFrom": "pvb_aanvraag",
+          "tableTo": "location",
+          "columnsFrom": [
+            "locatie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pvb_aanvraag_handle_unique": {
+          "name": "pvb_aanvraag_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_aanvraag_course": {
+      "name": "pvb_aanvraag_course",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructie_groep_id": {
+          "name": "instructie_groep_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_main_course": {
+          "name": "is_main_course",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pvb_aanvraag_course_pvb_aanvraag_id_instructie_groep_id_index": {
+          "name": "pvb_aanvraag_course_pvb_aanvraag_id_instructie_groep_id_index",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instructie_groep_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kss\".\"pvb_aanvraag_course\".\"is_main_course\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pvb_aanvraag_course_pvb_aanvraag_id_instructie_groep_id_course_id_index": {
+          "name": "pvb_aanvraag_course_pvb_aanvraag_id_instructie_groep_id_course_id_index",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instructie_groep_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pvb_aanvraag_course_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_aanvraag_course_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_aanvraag_course",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_aanvraag_course_course_id_course_id_fk": {
+          "name": "pvb_aanvraag_course_course_id_course_id_fk",
+          "tableFrom": "pvb_aanvraag_course",
+          "tableTo": "course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_aanvraag_course_instructie_groep_id_instructie_groep_id_fk": {
+          "name": "pvb_aanvraag_course_instructie_groep_id_instructie_groep_id_fk",
+          "tableFrom": "pvb_aanvraag_course",
+          "tableTo": "instructie_groep",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "instructie_groep_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_aanvraag_status": {
+      "name": "pvb_aanvraag_status",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "aanvraag_status",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aangemaakt_op": {
+          "name": "aangemaakt_op",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "aangemaakt_door": {
+          "name": "aangemaakt_door",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reden": {
+          "name": "reden",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_aanvraag_status_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_aanvraag_status_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_aanvraag_status",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_aanvraag_status_aangemaakt_door_actor_id_fk": {
+          "name": "pvb_aanvraag_status_aangemaakt_door_actor_id_fk",
+          "tableFrom": "pvb_aanvraag_status",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "aangemaakt_door"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_beoordelaar_beschikbaarheid": {
+      "name": "pvb_beoordelaar_beschikbaarheid",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beoordelaar_id": {
+          "name": "beoordelaar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pvb_voorstel_datum_id": {
+          "name": "pvb_voorstel_datum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_beoordelaar_beschikbaarheid_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_beoordelaar_beschikbaarheid_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_beoordelaar_beschikbaarheid",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_beoordelaar_beschikbaarheid_beoordelaar_id_person_id_fk": {
+          "name": "pvb_beoordelaar_beschikbaarheid_beoordelaar_id_person_id_fk",
+          "tableFrom": "pvb_beoordelaar_beschikbaarheid",
+          "tableTo": "person",
+          "columnsFrom": [
+            "beoordelaar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_beoordelaar_beschikbaarheid_pvb_voorstel_datum_id_pvb_aanvraag_id_pvb_voorstel_datum_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_beoordelaar_beschikbaarheid_pvb_voorstel_datum_id_pvb_aanvraag_id_pvb_voorstel_datum_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_beoordelaar_beschikbaarheid",
+          "tableTo": "pvb_voorstel_datum",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_voorstel_datum_id",
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id",
+            "pvb_aanvraag_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_beoordelaar_beschikbaarheid_status": {
+      "name": "pvb_beoordelaar_beschikbaarheid_status",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_beoordelaar_beschikbaarheid_id": {
+          "name": "pvb_beoordelaar_beschikbaarheid_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "beoordelaar_beschikbaarheidsstatus",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aangemaakt_op": {
+          "name": "aangemaakt_op",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "aangemaakt_door": {
+          "name": "aangemaakt_door",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reden": {
+          "name": "reden",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_beoordelaar_beschikbaarheid_status_pvb_beoordelaar_beschikbaarheid_id_pvb_beoordelaar_beschikbaarheid_id_fk": {
+          "name": "pvb_beoordelaar_beschikbaarheid_status_pvb_beoordelaar_beschikbaarheid_id_pvb_beoordelaar_beschikbaarheid_id_fk",
+          "tableFrom": "pvb_beoordelaar_beschikbaarheid_status",
+          "tableTo": "pvb_beoordelaar_beschikbaarheid",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_beoordelaar_beschikbaarheid_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_beoordelaar_beschikbaarheid_status_aangemaakt_door_actor_id_fk": {
+          "name": "pvb_beoordelaar_beschikbaarheid_status_aangemaakt_door_actor_id_fk",
+          "tableFrom": "pvb_beoordelaar_beschikbaarheid_status",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "aangemaakt_door"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_beoordelaar_onderdeel_beschikbaarheid": {
+      "name": "pvb_beoordelaar_onderdeel_beschikbaarheid",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_beoordelaar_beschikbaarheid_id": {
+          "name": "pvb_beoordelaar_beschikbaarheid_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pvb_onderdeel_id": {
+          "name": "pvb_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_beoordelaar_onderdeel_beschikbaarheid_pvb_beoordelaar_beschikbaarheid_id_pvb_beoordelaar_beschikbaarheid_id_fk": {
+          "name": "pvb_beoordelaar_onderdeel_beschikbaarheid_pvb_beoordelaar_beschikbaarheid_id_pvb_beoordelaar_beschikbaarheid_id_fk",
+          "tableFrom": "pvb_beoordelaar_onderdeel_beschikbaarheid",
+          "tableTo": "pvb_beoordelaar_beschikbaarheid",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_beoordelaar_beschikbaarheid_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_beoordelaar_onderdeel_beschikbaarheid_pvb_onderdeel_id_pvb_onderdeel_id_fk": {
+          "name": "pvb_beoordelaar_onderdeel_beschikbaarheid_pvb_onderdeel_id_pvb_onderdeel_id_fk",
+          "tableFrom": "pvb_beoordelaar_onderdeel_beschikbaarheid",
+          "tableTo": "pvb_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_onderdeel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_gebeurtenis": {
+      "name": "pvb_gebeurtenis",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pvb_onderdeel_id": {
+          "name": "pvb_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gebeurtenis_type": {
+          "name": "gebeurtenis_type",
+          "type": "pvb_gebeurtenis_type",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aangemaakt_op": {
+          "name": "aangemaakt_op",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "aangemaakt_door": {
+          "name": "aangemaakt_door",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reden": {
+          "name": "reden",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_gebeurtenis_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_gebeurtenis_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_gebeurtenis",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_gebeurtenis_pvb_onderdeel_id_pvb_onderdeel_id_fk": {
+          "name": "pvb_gebeurtenis_pvb_onderdeel_id_pvb_onderdeel_id_fk",
+          "tableFrom": "pvb_gebeurtenis",
+          "tableTo": "pvb_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_onderdeel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_gebeurtenis_aangemaakt_door_actor_id_fk": {
+          "name": "pvb_gebeurtenis_aangemaakt_door_actor_id_fk",
+          "tableFrom": "pvb_gebeurtenis",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "aangemaakt_door"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_leercoach_toestemming": {
+      "name": "pvb_leercoach_toestemming",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leercoach_id": {
+          "name": "leercoach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "leercoach_toestemming_status",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aangemaakt_op": {
+          "name": "aangemaakt_op",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "aangemaakt_door": {
+          "name": "aangemaakt_door",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reden": {
+          "name": "reden",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pvb_leercoach_toestemming_recent_idx": {
+          "name": "pvb_leercoach_toestemming_recent_idx",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "leercoach_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "aangemaakt_op",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pvb_leercoach_toestemming_status_idx": {
+          "name": "pvb_leercoach_toestemming_status_idx",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "leercoach_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pvb_leercoach_toestemming_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_leercoach_toestemming_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_leercoach_toestemming",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_leercoach_toestemming_leercoach_id_person_id_fk": {
+          "name": "pvb_leercoach_toestemming_leercoach_id_person_id_fk",
+          "tableFrom": "pvb_leercoach_toestemming",
+          "tableTo": "person",
+          "columnsFrom": [
+            "leercoach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_leercoach_toestemming_aangemaakt_door_actor_id_fk": {
+          "name": "pvb_leercoach_toestemming_aangemaakt_door_actor_id_fk",
+          "tableFrom": "pvb_leercoach_toestemming",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "aangemaakt_door"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_onderdeel": {
+      "name": "pvb_onderdeel",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_onderdeel_id": {
+          "name": "kerntaak_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beoordelaar_id": {
+          "name": "beoordelaar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_datum_tijd": {
+          "name": "start_datum_tijd",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uitslag": {
+          "name": "uitslag",
+          "type": "pvb_onderdeel_uitslag",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'nog_niet_bekend'"
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pvb_onderdeel_aanvraag_id_kerntaak_onderdeel_id_beoordelaar_id_unique": {
+          "name": "pvb_onderdeel_aanvraag_id_kerntaak_onderdeel_id_beoordelaar_id_unique",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kerntaak_onderdeel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "beoordelaar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pvb_onderdeel_aanvraag_id_kerntaak_onderdeel_id_unique": {
+          "name": "pvb_onderdeel_aanvraag_id_kerntaak_onderdeel_id_unique",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kerntaak_onderdeel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pvb_onderdeel_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_onderdeel_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_onderdeel",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_onderdeel_kerntaak_onderdeel_id_kerntaak_id_kerntaak_onderdeel_id_kerntaak_id_fk": {
+          "name": "pvb_onderdeel_kerntaak_onderdeel_id_kerntaak_id_kerntaak_onderdeel_id_kerntaak_id_fk",
+          "tableFrom": "pvb_onderdeel",
+          "tableTo": "kerntaak_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_onderdeel_id",
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_onderdeel_kerntaak_id_kerntaak_id_fk": {
+          "name": "pvb_onderdeel_kerntaak_id_kerntaak_id_fk",
+          "tableFrom": "pvb_onderdeel",
+          "tableTo": "kerntaak",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_onderdeel_beoordelaar_id_person_id_fk": {
+          "name": "pvb_onderdeel_beoordelaar_id_person_id_fk",
+          "tableFrom": "pvb_onderdeel",
+          "tableTo": "person",
+          "columnsFrom": [
+            "beoordelaar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pvb_onderdeel_id_kerntaak_onderdeel_id_unique": {
+          "name": "pvb_onderdeel_id_kerntaak_onderdeel_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "kerntaak_onderdeel_id"
+          ]
+        },
+        "pvb_onderdeel_id_kerntaak_onderdeel_id_beoordelaar_id_unique": {
+          "name": "pvb_onderdeel_id_kerntaak_onderdeel_id_beoordelaar_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "kerntaak_onderdeel_id",
+            "beoordelaar_id"
+          ]
+        },
+        "pvb_onderdeel_id_kerntaak_id_unique": {
+          "name": "pvb_onderdeel_id_kerntaak_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "kerntaak_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_onderdeel_beoordelingscriterium": {
+      "name": "pvb_onderdeel_beoordelingscriterium",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_onderdeel_id": {
+          "name": "pvb_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beoordelingscriterium_id": {
+          "name": "beoordelingscriterium_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "behaald": {
+          "name": "behaald",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_onderdeel_beoordelingscriterium_pvb_onderdeel_id_kerntaak_id_pvb_onderdeel_id_kerntaak_id_fk": {
+          "name": "pvb_onderdeel_beoordelingscriterium_pvb_onderdeel_id_kerntaak_id_pvb_onderdeel_id_kerntaak_id_fk",
+          "tableFrom": "pvb_onderdeel_beoordelingscriterium",
+          "tableTo": "pvb_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_onderdeel_id",
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_onderdeel_beoordelingscriterium_beoordelingscriterium_id_kerntaak_id_beoordelingscriterium_id_kerntaak_id_fk": {
+          "name": "pvb_onderdeel_beoordelingscriterium_beoordelingscriterium_id_kerntaak_id_beoordelingscriterium_id_kerntaak_id_fk",
+          "tableFrom": "pvb_onderdeel_beoordelingscriterium",
+          "tableTo": "beoordelingscriterium",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "beoordelingscriterium_id",
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_onderdeel_beoordelingscriterium_kerntaak_id_kerntaak_id_fk": {
+          "name": "pvb_onderdeel_beoordelingscriterium_kerntaak_id_kerntaak_id_fk",
+          "tableFrom": "pvb_onderdeel_beoordelingscriterium",
+          "tableTo": "kerntaak",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pvb_onderdeel_beoordelingscriterium_pvb_onderdeel_id_beoordelingscriterium_id_unique": {
+          "name": "pvb_onderdeel_beoordelingscriterium_pvb_onderdeel_id_beoordelingscriterium_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pvb_onderdeel_id",
+            "beoordelingscriterium_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_voorstel_datum": {
+      "name": "pvb_voorstel_datum",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_na": {
+          "name": "start_na",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eind_voor": {
+          "name": "eind_voor",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voorkeur": {
+          "name": "voorkeur",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_voorstel_datum_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_voorstel_datum_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_voorstel_datum",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pvb_voorstel_datum_id_pvb_aanvraag_id_unique": {
+          "name": "pvb_voorstel_datum_id_pvb_aanvraag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "pvb_aanvraag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.beoordelingscriterium": {
+      "name": "beoordelingscriterium",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "werkproces_id": {
+          "name": "werkproces_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rang": {
+          "name": "rang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "omschrijving": {
+          "name": "omschrijving",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "beoordelingscriterium_werkproces_id_kerntaak_id_werkproces_id_kerntaak_id_fk": {
+          "name": "beoordelingscriterium_werkproces_id_kerntaak_id_werkproces_id_kerntaak_id_fk",
+          "tableFrom": "beoordelingscriterium",
+          "tableTo": "werkproces",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "werkproces_id",
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "beoordelingscriterium_kerntaak_id_kerntaak_id_fk": {
+          "name": "beoordelingscriterium_kerntaak_id_kerntaak_id_fk",
+          "tableFrom": "beoordelingscriterium",
+          "tableTo": "kerntaak",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "beoordelingscriterium_id_kerntaak_id_unique": {
+          "name": "beoordelingscriterium_id_kerntaak_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "kerntaak_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.kerntaak": {
+      "name": "kerntaak",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "titel": {
+          "name": "titel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kwalificatieprofiel_id": {
+          "name": "kwalificatieprofiel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "kerntaakType",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rang": {
+          "name": "rang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kerntaak_kwalificatieprofiel_id_kwalificatieprofiel_id_fk": {
+          "name": "kerntaak_kwalificatieprofiel_id_kwalificatieprofiel_id_fk",
+          "tableFrom": "kerntaak",
+          "tableTo": "kwalificatieprofiel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kwalificatieprofiel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.kerntaak_onderdeel": {
+      "name": "kerntaak_onderdeel",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beoordelingsType": {
+          "name": "beoordelingsType",
+          "type": "kerntaakOnderdeelType",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kerntaak_onderdeel_kerntaak_id_kerntaak_id_fk": {
+          "name": "kerntaak_onderdeel_kerntaak_id_kerntaak_id_fk",
+          "tableFrom": "kerntaak_onderdeel",
+          "tableTo": "kerntaak",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kerntaak_onderdeel_id_kerntaak_id_unique": {
+          "name": "kerntaak_onderdeel_id_kerntaak_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "kerntaak_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.kwalificatieprofiel": {
+      "name": "kwalificatieprofiel",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "titel": {
+          "name": "titel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "richting": {
+          "name": "richting",
+          "type": "richting",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "niveau_id": {
+          "name": "niveau_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kwalificatieprofiel_niveau_id_niveau_id_fk": {
+          "name": "kwalificatieprofiel_niveau_id_niveau_id_fk",
+          "tableFrom": "kwalificatieprofiel",
+          "tableTo": "niveau",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "niveau_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.niveau": {
+      "name": "niveau",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "rang": {
+          "name": "rang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.werkproces": {
+      "name": "werkproces",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "titel": {
+          "name": "titel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resultaat": {
+          "name": "resultaat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rang": {
+          "name": "rang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "werkproces_kerntaak_id_kerntaak_id_fk": {
+          "name": "werkproces_kerntaak_id_kerntaak_id_fk",
+          "tableFrom": "werkproces",
+          "tableTo": "kerntaak",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "werkproces_id_kerntaak_id_unique": {
+          "name": "werkproces_id_kerntaak_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "kerntaak_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.werkproces_kerntaak_onderdeel": {
+      "name": "werkproces_kerntaak_onderdeel",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "werkproces_id": {
+          "name": "werkproces_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_onderdeel_id": {
+          "name": "kerntaak_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "werkproces_kerntaak_onderdeel_werkproces_id_kerntaak_id_werkproces_id_kerntaak_id_fk": {
+          "name": "werkproces_kerntaak_onderdeel_werkproces_id_kerntaak_id_werkproces_id_kerntaak_id_fk",
+          "tableFrom": "werkproces_kerntaak_onderdeel",
+          "tableTo": "werkproces",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "werkproces_id",
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "werkproces_kerntaak_onderdeel_kerntaak_onderdeel_id_kerntaak_id_kerntaak_onderdeel_id_kerntaak_id_fk": {
+          "name": "werkproces_kerntaak_onderdeel_kerntaak_onderdeel_id_kerntaak_id_kerntaak_onderdeel_id_kerntaak_id_fk",
+          "tableFrom": "werkproces_kerntaak_onderdeel",
+          "tableTo": "kerntaak_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_onderdeel_id",
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "werkproces_kerntaak_onderdeel_werkproces_id_kerntaak_onderdeel_id_unique": {
+          "name": "werkproces_kerntaak_onderdeel_werkproces_id_kerntaak_onderdeel_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "werkproces_id",
+            "kerntaak_onderdeel_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location": {
+      "name": "location",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "status": {
+          "name": "status",
+          "type": "location_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_media_id": {
+          "name": "logo_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "square_logo_media_id": {
+          "name": "square_logo_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_media_id": {
+          "name": "certificate_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "unique_handle_for_location": {
+          "name": "unique_handle_for_location",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_logo_media_id_media_id_fk": {
+          "name": "location_logo_media_id_media_id_fk",
+          "tableFrom": "location",
+          "tableTo": "media",
+          "columnsFrom": [
+            "logo_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_square_logo_media_id_media_id_fk": {
+          "name": "location_square_logo_media_id_media_id_fk",
+          "tableFrom": "location",
+          "tableTo": "media",
+          "columnsFrom": [
+            "square_logo_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_certificate_media_id_media_id_fk": {
+          "name": "location_certificate_media_id_media_id_fk",
+          "tableFrom": "location",
+          "tableTo": "media",
+          "columnsFrom": [
+            "certificate_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_resource_link": {
+      "name": "location_resource_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_type_id": {
+          "name": "gear_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discipline_id": {
+          "name": "discipline_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "location_gear_type_unique": {
+          "name": "location_gear_type_unique",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gear_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_discipline_unique": {
+          "name": "location_discipline_unique",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discipline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_resource_link_location_id_fk": {
+          "name": "location_resource_link_location_id_fk",
+          "tableFrom": "location_resource_link",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_resource_link_gear_type_id_fk": {
+          "name": "location_resource_link_gear_type_id_fk",
+          "tableFrom": "location_resource_link",
+          "tableTo": "gear_type",
+          "columnsFrom": [
+            "gear_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_resource_link_discipline_id_fk": {
+          "name": "location_resource_link_discipline_id_fk",
+          "tableFrom": "location_resource_link",
+          "tableTo": "discipline",
+          "columnsFrom": [
+            "discipline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "location_resource_link_required_one_resource": {
+          "name": "location_resource_link_required_one_resource",
+          "value": "(\n        (gear_type_id is not null)::int + \n        (discipline_id is not null)::int = 1\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.logbook": {
+      "name": "logbook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departure_port": {
+          "name": "departure_port",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arrival_port": {
+          "name": "arrival_port",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wind_power": {
+          "name": "wind_power",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wind_direction": {
+          "name": "wind_direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boat_type": {
+          "name": "boat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boat_length": {
+          "name": "boat_length",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sailed_nautical_miles": {
+          "name": "sailed_nautical_miles",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sailed_hours_in_dark": {
+          "name": "sailed_hours_in_dark",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_role": {
+          "name": "primary_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crew_names": {
+          "name": "crew_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_comments": {
+          "name": "additional_comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "logbook_person_id_fk": {
+          "name": "logbook_person_id_fk",
+          "tableFrom": "logbook",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "marketing.cashback": {
+      "name": "cashback",
+      "schema": "marketing",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "applicant_full_name": {
+          "name": "applicant_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_email": {
+          "name": "applicant_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_iban": {
+          "name": "applicant_iban",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_full_name": {
+          "name": "student_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_media_id": {
+          "name": "verification_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_location": {
+          "name": "verification_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booking_location_id": {
+          "name": "booking_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booking_number": {
+          "name": "booking_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cashback_verification_media_id_media_id_fk": {
+          "name": "cashback_verification_media_id_media_id_fk",
+          "tableFrom": "cashback",
+          "tableTo": "media",
+          "columnsFrom": [
+            "verification_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cashback_booking_location_id_location_id_fk": {
+          "name": "cashback_booking_location_id_location_id_fk",
+          "tableFrom": "cashback",
+          "tableTo": "location",
+          "columnsFrom": [
+            "booking_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "media_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_idx_name_search": {
+          "name": "media_idx_name_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', COALESCE(\"name\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_object_id_fk": {
+          "name": "media_object_id_fk",
+          "tableFrom": "media",
+          "tableTo": "objects",
+          "schemaTo": "storage",
+          "columnsFrom": [
+            "object_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "media_actor_id_fk": {
+          "name": "media_actor_id_fk",
+          "tableFrom": "media",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "media_location_id_fk": {
+          "name": "media_location_id_fk",
+          "tableFrom": "media",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.country": {
+      "name": "country",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ar": {
+          "name": "ar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bg": {
+          "name": "bg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "cs": {
+          "name": "cs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "da": {
+          "name": "da",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "de": {
+          "name": "de",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "el": {
+          "name": "el",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "en": {
+          "name": "en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "es": {
+          "name": "es",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "et": {
+          "name": "et",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "eu": {
+          "name": "eu",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "fi": {
+          "name": "fi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "fr": {
+          "name": "fr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "hu": {
+          "name": "hu",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "it": {
+          "name": "it",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ja": {
+          "name": "ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ko": {
+          "name": "ko",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "lt": {
+          "name": "lt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "nl": {
+          "name": "nl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "no": {
+          "name": "no",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "pl": {
+          "name": "pl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "pt": {
+          "name": "pt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ro": {
+          "name": "ro",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ru": {
+          "name": "ru",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sk": {
+          "name": "sk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sv": {
+          "name": "sv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "th": {
+          "name": "th",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "uk": {
+          "name": "uk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "zh": {
+          "name": "zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "zh-tw": {
+          "name": "zh-tw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "alpha_2": {
+          "name": "alpha_2",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "alpha_3": {
+          "name": "alpha_3",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "country_alpha_2_is_unique": {
+          "name": "country_alpha_2_is_unique",
+          "columns": [
+            {
+              "expression": "alpha_2",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "country_alpha_3_is_unique": {
+          "name": "country_alpha_3_is_unique",
+          "columns": [
+            {
+              "expression": "alpha_3",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "type": {
+          "name": "type",
+          "type": "feedback_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query": {
+          "name": "query",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "base": {
+          "name": "base",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "inserted_by": {
+          "name": "inserted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_inserted_by_fk": {
+          "name": "feedback_inserted_by_fk",
+          "tableFrom": "feedback",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inserted_by"
+          ],
+          "columnsTo": [
+            "auth_user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_cohort_progress": {
+      "name": "student_cohort_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "cohort_allocation_id": {
+          "name": "cohort_allocation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "curriculum_module_competency_id": {
+          "name": "curriculum_module_competency_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cohort_allocation_id_idx": {
+          "name": "cohort_allocation_id_idx",
+          "columns": [
+            {
+              "expression": "cohort_allocation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "curriculum_module_competency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_cohort_progress_cohort_allocation_id_fk": {
+          "name": "student_cohort_progress_cohort_allocation_id_fk",
+          "tableFrom": "student_cohort_progress",
+          "tableTo": "cohort_allocation",
+          "columnsFrom": [
+            "cohort_allocation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "curriculum_competency_competency_id_fk": {
+          "name": "curriculum_competency_competency_id_fk",
+          "tableFrom": "student_cohort_progress",
+          "tableTo": "curriculum_competency",
+          "columnsFrom": [
+            "curriculum_module_competency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_cohort_progress_created_by_fk": {
+          "name": "student_cohort_progress_created_by_fk",
+          "tableFrom": "student_cohort_progress",
+          "tableTo": "person",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.actor": {
+      "name": "actor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "type": {
+          "name": "type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "actor_person_id_fk": {
+          "name": "actor_person_id_fk",
+          "tableFrom": "actor",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "actor_location_link_location_id_fk": {
+          "name": "actor_location_link_location_id_fk",
+          "tableFrom": "actor",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unq_actor_type_person_location": {
+          "name": "unq_actor_type_person_location",
+          "nullsNotDistinct": true,
+          "columns": [
+            "type",
+            "person_id",
+            "location_id"
+          ]
+        },
+        "unq_actor_location_id_unique": {
+          "name": "unq_actor_location_id_unique",
+          "nullsNotDistinct": true,
+          "columns": [
+            "id",
+            "location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person": {
+      "name": "person",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_name_prefix": {
+          "name": "last_name_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_city": {
+          "name": "birth_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_country": {
+          "name": "birth_country",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "person_unq_handle": {
+          "name": "person_unq_handle",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_idx_handle_search": {
+          "name": "person_idx_handle_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', COALESCE(\"handle\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "person_idx_name_search": {
+          "name": "person_idx_name_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', \n        COALESCE(\"first_name\", '') || ' ' || \n        COALESCE(\"last_name_prefix\", '') || ' ' || \n        COALESCE(\"last_name\", '')\n      )",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "person_idx_user_id": {
+          "name": "person_idx_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_idx_is_primary": {
+          "name": "person_idx_is_primary",
+          "columns": [
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unq_primary_person": {
+          "name": "unq_primary_person",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"person\".\"is_primary\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_birth_country_country_alpha_2_fk": {
+          "name": "person_birth_country_country_alpha_2_fk",
+          "tableFrom": "person",
+          "tableTo": "country",
+          "columnsFrom": [
+            "birth_country"
+          ],
+          "columnsTo": [
+            "alpha_2"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "person_user_id_fk": {
+          "name": "person_user_id_fk",
+          "tableFrom": "person",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "auth_user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_location_link": {
+      "name": "person_location_link",
+      "schema": "",
+      "columns": {
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "person_location_link_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_level": {
+          "name": "permission_level",
+          "type": "permissionRequestStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "person_location_link_person_id_fk": {
+          "name": "person_location_link_person_id_fk",
+          "tableFrom": "person_location_link",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "person_location_link_location_id_fk": {
+          "name": "person_location_link_location_id_fk",
+          "tableFrom": "person_location_link",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "person_location_link_pk": {
+          "name": "person_location_link_pk",
+          "columns": [
+            "person_id",
+            "location_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_idx_email_full_search": {
+          "name": "user_idx_email_full_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', COALESCE(\"email\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "user_idx_email_username_search": {
+          "name": "user_idx_email_username_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', COALESCE(split_part(\"email\"::text, '@', 1), ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "user_idx_email_domain_search": {
+          "name": "user_idx_email_domain_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', COALESCE(split_part(\"email\"::text, '@', 2), ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_auth_user_id_fk": {
+          "name": "user_auth_user_id_fk",
+          "tableFrom": "user",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "auth_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "ai_corpus.consent_level": {
+      "name": "consent_level",
+      "schema": "ai_corpus",
+      "values": [
+        "seed",
+        "opt_in_shared",
+        "user_only"
+      ]
+    },
+    "ai_corpus.domain": {
+      "name": "domain",
+      "schema": "ai_corpus",
+      "values": [
+        "pvb_portfolio",
+        "diplomalijn",
+        "knowledge_center",
+        "artefact"
+      ]
+    },
+    "leercoach.chat_phase": {
+      "name": "chat_phase",
+      "schema": "leercoach",
+      "values": [
+        "verkennen",
+        "ordenen",
+        "concept",
+        "verfijnen"
+      ]
+    },
+    "leercoach.portfolio_version_created_by": {
+      "name": "portfolio_version_created_by",
+      "schema": "leercoach",
+      "values": [
+        "coach",
+        "user",
+        "imported"
+      ]
+    },
+    "leercoach.upload_job_kind": {
+      "name": "upload_job_kind",
+      "schema": "leercoach",
+      "values": [
+        "portfolio"
+      ]
+    },
+    "leercoach.upload_job_status": {
+      "name": "upload_job_status",
+      "schema": "leercoach",
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.role_type": {
+      "name": "role_type",
+      "schema": "public",
+      "values": [
+        "organization",
+        "location",
+        "cohort"
+      ]
+    },
+    "public.competency_type": {
+      "name": "competency_type",
+      "schema": "public",
+      "values": [
+        "knowledge",
+        "skill"
+      ]
+    },
+    "public.kwalificatie_verkregen_reden": {
+      "name": "kwalificatie_verkregen_reden",
+      "schema": "public",
+      "values": [
+        "pvb_behaald",
+        "pvb_instructiegroep_basis",
+        "onbekend"
+      ]
+    },
+    "kss.aanvraag_status": {
+      "name": "aanvraag_status",
+      "schema": "kss",
+      "values": [
+        "concept",
+        "wacht_op_voorwaarden",
+        "gereed_voor_beoordeling",
+        "in_beoordeling",
+        "afgerond",
+        "ingetrokken",
+        "afgebroken"
+      ]
+    },
+    "kss.beoordelaar_beschikbaarheidsstatus": {
+      "name": "beoordelaar_beschikbaarheidsstatus",
+      "schema": "kss",
+      "values": [
+        "geinteresseerd",
+        "toegewezen",
+        "afgewezen_door_beoordelaar",
+        "afgewezen_door_secretariaat",
+        "afgewezen_door_vaarlocatie",
+        "ingetrokken"
+      ]
+    },
+    "kss.leercoach_toestemming_status": {
+      "name": "leercoach_toestemming_status",
+      "schema": "kss",
+      "values": [
+        "gevraagd",
+        "gegeven",
+        "geweigerd",
+        "herroepen"
+      ]
+    },
+    "kss.pvb_aanvraag_type": {
+      "name": "pvb_aanvraag_type",
+      "schema": "kss",
+      "values": [
+        "intern",
+        "extern"
+      ]
+    },
+    "kss.pvb_gebeurtenis_type": {
+      "name": "pvb_gebeurtenis_type",
+      "schema": "kss",
+      "values": [
+        "aanvraag_ingediend",
+        "leercoach_toestemming_gevraagd",
+        "leercoach_toestemming_gegeven",
+        "leercoach_toestemming_geweigerd",
+        "voorwaarden_voltooid",
+        "beoordeling_gestart",
+        "beoordeling_afgerond",
+        "aanvraag_ingetrokken",
+        "onderdeel_toegevoegd",
+        "onderdeel_beoordelaar_gewijzigd",
+        "onderdeel_uitslag_gewijzigd",
+        "onderdeel_startdatum_gewijzigd"
+      ]
+    },
+    "kss.pvb_onderdeel_uitslag": {
+      "name": "pvb_onderdeel_uitslag",
+      "schema": "kss",
+      "values": [
+        "behaald",
+        "niet_behaald",
+        "nog_niet_bekend"
+      ]
+    },
+    "kss.kerntaakOnderdeelType": {
+      "name": "kerntaakOnderdeelType",
+      "schema": "kss",
+      "values": [
+        "portfolio",
+        "praktijk"
+      ]
+    },
+    "kss.kerntaakType": {
+      "name": "kerntaakType",
+      "schema": "kss",
+      "values": [
+        "verplicht",
+        "facultatief"
+      ]
+    },
+    "kss.richting": {
+      "name": "richting",
+      "schema": "kss",
+      "values": [
+        "instructeur",
+        "leercoach",
+        "pvb_beoordelaar"
+      ]
+    },
+    "public.location_status": {
+      "name": "location_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "hidden",
+        "archived"
+      ]
+    },
+    "public.media_status": {
+      "name": "media_status",
+      "schema": "public",
+      "values": [
+        "failed",
+        "processing",
+        "ready",
+        "uploaded",
+        "corrupt"
+      ]
+    },
+    "public.media_type": {
+      "name": "media_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "file"
+      ]
+    },
+    "public.feedback_type": {
+      "name": "feedback_type",
+      "schema": "public",
+      "values": [
+        "bug",
+        "product-feedback",
+        "program-feedback",
+        "question",
+        "other"
+      ]
+    },
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": [
+        "student",
+        "instructor",
+        "location_admin",
+        "system",
+        "pvb_beoordelaar",
+        "secretariaat"
+      ]
+    },
+    "public.permissionRequestStatus": {
+      "name": "permissionRequestStatus",
+      "schema": "public",
+      "values": [
+        "none",
+        "requested",
+        "permission_granted"
+      ]
+    },
+    "public.person_location_link_status": {
+      "name": "person_location_link_status",
+      "schema": "public",
+      "values": [
+        "linked",
+        "revoked",
+        "removed"
+      ]
+    }
+  },
+  "schemas": {
+    "ai_corpus": "ai_corpus",
+    "leercoach": "leercoach",
+    "kss": "kss",
+    "marketing": "marketing"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1776787945892,
       "tag": "0035_opposite_tiger_shark",
       "breakpoints": false
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1776803414976,
+      "tag": "0036_uneven_amphibian",
+      "breakpoints": false
     }
   ]
 }

--- a/packages/db/src/schema/ai_corpus/source.ts
+++ b/packages/db/src/schema/ai_corpus/source.ts
@@ -60,6 +60,14 @@ export const source = aiCorpusSchema.table(
       .notNull(),
     charCount: integer("char_count").notNull(),
     pageCount: integer("page_count"),
+    // Path in Supabase Storage to the original, un-anonymised file
+    // (null for text-only sources + legacy rows from before durable
+    // ingest landed). Stored so the uploader can always retrieve
+    // their original — the anonymised `content` above is what we
+    // search/ingest, but the user retains ownership of the raw bytes.
+    // Shape: "portfolio-uploads/{userId}/{hash}.pdf". ACL: private,
+    // signed-URL access only.
+    originalStoragePath: text("original_storage_path"),
     createdAt: timestamp("created_at", { withTimezone: true, mode: "string" })
       .defaultNow()
       .notNull(),

--- a/packages/db/src/schema/leercoach/index.ts
+++ b/packages/db/src/schema/leercoach/index.ts
@@ -9,3 +9,8 @@ export {
   portfolioVersionCreatedBy,
 } from "./portfolio.js";
 export { leercoachSchema } from "./schema.js";
+export {
+  leercoachUploadJob,
+  uploadJobKind,
+  uploadJobStatus,
+} from "./upload-job.js";

--- a/packages/db/src/schema/leercoach/upload-job.ts
+++ b/packages/db/src/schema/leercoach/upload-job.ts
@@ -1,0 +1,103 @@
+import { sql } from "drizzle-orm";
+import {
+  index,
+  jsonb,
+  text,
+  timestamp,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { leercoachSchema } from "./schema.js";
+
+// Tracks the async lifecycle of a durable ingest job (portfolio upload
+// today, artefact upload later). Created by the upload action the
+// instant the file arrives in Supabase Storage; updated by the Upstash
+// Workflow route as each step completes.
+//
+// The row persists after completion as an audit trail — the status
+// endpoint reads it to tell the client when processing is done, and
+// the "download my original" feature (future) reads `blobPath` to
+// mint a signed URL.
+//
+// Lifecycle:
+//   1. Action inserts row with status='pending', blobPath set to the
+//      just-uploaded Storage path, metadata carrying the form inputs.
+//   2. Action triggers the workflow — this row's id becomes the
+//      workflow's input payload.
+//   3. Workflow step 1 (`extract`) flips status to 'processing'.
+//   4. Workflow step 4 (`done`) flips status to 'ready' and sets
+//      sourceId to the just-created ai_corpus.source row.
+//   5. Any step failure → status='failed' + errorMessage.
+
+export const uploadJobKind = leercoachSchema.enum("upload_job_kind", [
+  "portfolio",
+  // Future: "artefact" when we migrate the chat-inline upload path.
+]);
+
+export const uploadJobStatus = leercoachSchema.enum("upload_job_status", [
+  "pending", // Row created; workflow not yet triggered / just triggered.
+  "processing", // Workflow has picked up the job and is mid-pipeline.
+  "ready", // All steps completed successfully; sourceId is set.
+  "failed", // A step permanently failed; errorMessage is set.
+]);
+
+export const leercoachUploadJob = leercoachSchema.table(
+  "upload_job",
+  {
+    id: uuid("id")
+      .default(sql`extensions.uuid_generate_v4()`)
+      .primaryKey()
+      .notNull(),
+    // Supabase auth.users.id. No FK — auth.users lives in a different
+    // schema we don't own. Validated in the application layer.
+    userId: uuid("user_id").notNull(),
+    kind: uploadJobKind("kind").notNull(),
+    status: uploadJobStatus("status").notNull().default("pending"),
+    // Path in Supabase Storage to the original uploaded file. The
+    // workflow's extract step fetches from here. After completion,
+    // this path is copied into ai_corpus.source.original_storage_path
+    // so the source row becomes the durable reference.
+    blobPath: text("blob_path").notNull(),
+    // Human-facing label provided at upload time (e.g. filename or
+    // user-supplied title). Carried through to the eventual source
+    // row's metadata.
+    label: text("label").notNull().default(""),
+    // Form inputs captured at upload time: profielId, richting,
+    // niveauRang, coverage (scope), consent ("user_only" vs
+    // "opt_in_shared"), etc. Intentionally typed as loose jsonb so we
+    // can evolve the upload form without a schema migration per field.
+    metadata: jsonb("metadata")
+      .$type<Record<string, unknown>>()
+      .default({})
+      .notNull(),
+    // Upstash Workflow run id — returned by client.trigger(), useful
+    // for deep-linking into the Upstash console for debugging. Not
+    // functionally required.
+    workflowRunId: text("workflow_run_id"),
+    // Filled in by the final workflow step. The presence of this id
+    // doubles as the "did the ingest succeed" signal for the status
+    // endpoint (status='ready' → sourceId is non-null).
+    sourceId: uuid("source_id"),
+    // Populated when status='failed'. Keep the raw error message for
+    // ops triage; surface a friendlier version via the status endpoint.
+    errorMessage: text("error_message"),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+    completedAt: timestamp("completed_at", {
+      withTimezone: true,
+      mode: "string",
+    }),
+  },
+  (table) => [
+    // Hot path: a user polling their own pending jobs newest-first.
+    index("upload_job_user_created_idx").on(
+      table.userId,
+      table.createdAt.desc(),
+    ),
+    // Secondary: find jobs by status (ops dashboards, orphan cleanup).
+    index("upload_job_status_idx").on(table.status),
+  ],
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,12 @@ importers:
       '@tremor/react':
         specifier: 3.18.7
         version: 3.18.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@upstash/qstash':
+        specifier: ^2.10.1
+        version: 2.10.1
+      '@upstash/workflow':
+        specifier: ^1.2.0
+        version: 1.2.0(zod@3.25.76)
       '@vercel/otel':
         specifier: 2.1.0
         version: 2.1.0(@opentelemetry/api-logs@0.211.0)(@opentelemetry/api@1.9.0)(@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-logs@0.211.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))
@@ -4788,6 +4794,14 @@ packages:
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
+  '@upstash/qstash@2.10.1':
+    resolution: {integrity: sha512-LsTAPxPk0dFvhlEnRqwObRS94b8mmDHYaBlF3IaONUL+Scq6i9cZraA6936KSUVe+Vq3eNQle3CjOZkStPUFTw==}
+
+  '@upstash/workflow@1.2.0':
+    resolution: {integrity: sha512-91aOAnh5JsWzVajO+isU9BHdzQmWhOY++qSPeZcwEgvGIlhhIjH/IuKnLXLJhm4UIk0ntvY/w9rXUvD7UWDQvw==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
@@ -8491,6 +8505,10 @@ packages:
   netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
+
+  neverthrow@7.2.0:
+    resolution: {integrity: sha512-iGBUfFB7yPczHHtA8dksKTJ9E8TESNTAx1UQWW6TzMF280vo9jdPYpLUXrMN1BCkPdHFdNG3fxOt2CUad8KhAw==}
+    engines: {node: '>=18'}
 
   next-mdx-remote-client@1.0.7:
     resolution: {integrity: sha512-bO15bFa9e33JuxO50OWMyGmW7O7Pbe4qe1AjFiZHfbqYff5ga095pCfRcDBMVUQ6oKXPq/qzdgUbTIiHQZRrPw==}
@@ -15813,6 +15831,17 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  '@upstash/qstash@2.10.1':
+    dependencies:
+      crypto-js: 4.2.0
+      jose: 5.10.0
+      neverthrow: 7.2.0
+
+  '@upstash/workflow@1.2.0(zod@3.25.76)':
+    dependencies:
+      '@upstash/qstash': 2.10.1
+      zod: 3.25.76
+
   '@vercel/oidc@3.2.0': {}
 
   '@vercel/otel@2.1.0(@opentelemetry/api-logs@0.211.0)(@opentelemetry/api@1.9.0)(@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-logs@0.211.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))':
@@ -20408,6 +20437,8 @@ snapshots:
   neotraverse@0.6.18: {}
 
   netmask@2.0.2: {}
+
+  neverthrow@7.2.0: {}
 
   next-mdx-remote-client@1.0.7(@types/react@19.2.10)(acorn@8.11.2)(react-dom@19.2.4(react@19.2.3))(react@19.2.3):
     dependencies:


### PR DESCRIPTION
## Summary

Replaces the synchronous `uploadPortfolioAction → ingestPortfolio` pipeline (which kept timing out at Vercel's 30s ceiling on realistic portfolios) with an async pipeline backed by **Upstash Workflow**. User gets a fast response; the heavy work (PDF extract + LLM anonymise + chunk + store) runs **durably in the background**.

Why Upstash Workflow over a plain queue (Workflow vs QStash-alone): the pipeline has state (output of each step feeds the next), so we get automatic retries per-step, deterministic replay on crash, and typed TS directives instead of hand-rolled HTTP chains.

## Architecture

```
Client
  ↓ POST upload
uploadPortfolioAction (~1s):
  1. Upload bytes → Supabase Storage (portfolio-uploads bucket)
  2. INSERT leercoach.upload_job (status='pending')
  3. client.trigger() workflow webhook
  4. Return { jobId, status: 'pending' }

Upstash Workflow → /api/workflow/ingest-portfolio (5 isolated steps):
  mark-processing → extract → anonymise → ingest → mark-ready

Client polls GET /api/upload-job/[id]/status every 2s
UI shows "verwerken…" until status in {ready, failed}.
```

## User-facing changes

- **New upload dialog section** ("Bewaren en verbeteren"):
  - Tells users we keep their original indefinitely under their account
  - Opt-in checkbox: "Ik geef toestemming dat de geanonimiseerde versie gebruikt wordt om de digitale leercoach voor andere kandidaten te verbeteren" — unchecked → `consent_level=user_only`, checked → `consent_level=opt_in_shared`
- **"verwerken…" state** after submit, with a spinner — replaces the silent spinner-then-timeout
- **Success / failure banners** reflect the workflow's actual outcome, not a 30s race
- **Revoke flow** now deletes the Storage blob too (GDPR-clean erasure)
- **Originals are preserved** in Storage indefinitely (per product decision in this PR's discussion)

## Schema (migration `0036_uneven_amphibian`)

- New `leercoach.upload_job` table: audit + poll surface for async ingest runs
- New enums: `leercoach.upload_job_kind` (`portfolio` — will gain `artefact` later), `leercoach.upload_job_status` (`pending`/`processing`/`ready`/`failed`)
- New column: `ai_corpus.source.original_storage_path` — durable reference to the raw PDF

## Core (`@nawadi/core/models/leercoach`)

- New `Leercoach.UploadJob` namespace: `create`, `getById` (user-scoped), `getByIdAsWorkflow` (unauthed, for the webhook), `updateStatus`, `listByUserId`
- `AiCorpus.getUserPriorSourceById` (new) — revoke flow needs Storage path before deletion
- `AiCorpus.upsertSourceWithChunks` gains `originalStoragePath`

## Infra + env vars

- **Supabase Storage bucket `portfolio-uploads`** (private, RLS scoped per user) — created manually; follow-up migration will codify the RLS policy
- **Service-role Supabase client** for bucket writes/reads inside the workflow (no user session)
- **QStash env vars**: `QSTASH_TOKEN`, `QSTASH_URL`, `QSTASH_CURRENT_SIGNING_KEY`, `QSTASH_NEXT_SIGNING_KEY`
- **`pnpm dev:qstash`** — runs `@upstash/qstash-cli` locally (in-memory QStash on :8080). **No prod Upstash account needed for local dev.**

## Deploy notes

Before merging, set in Vercel prod env:
- [ ] `QSTASH_TOKEN` — from [Upstash console → QStash](https://console.upstash.com/qstash)
- [ ] `QSTASH_CURRENT_SIGNING_KEY` + `QSTASH_NEXT_SIGNING_KEY`
- [ ] `QSTASH_URL` can be omitted in prod (defaults to `https://qstash.upstash.io`)

Prod Supabase Storage:
- [ ] Bucket `portfolio-uploads` exists, private
- [ ] RLS policy: authenticated users can INSERT into `{auth.uid()}/*`

## NOT in this PR (deferred)

- **Artefact upload path** (chat-inline attachments) — same shape applies but needs UX work for in-composer processing-state chips + the coach's `listArtefacten` tool handling in-progress rows. Separate PR.
- **"Download my original" button** on `/profiel/[handle]/portfolios` — Storage helper `signPortfolioDownloadUrl` is wired; UI is a small follow-up.
- **RLS-policy-as-code migration** for `portfolio-uploads` bucket — created manually in Supabase dashboard today.
- **Dead code cleanup**: `portfolio-pipeline.ts`'s old `ingestPortfolio` sits unused after this PR. Delete in a follow-up.

## Test plan

With `pnpm dev:qstash` running in a sidecar terminal:
- [ ] Upload a 5-page PDF portfolio → dialog shows "verwerken…" → resolves to green success in 30-60s → re-opening the portfolios list shows the row
- [ ] Upload the same PDF again → workflow short-circuits (source-hash dedup), status ends 'ready' quickly, no duplicate chunks
- [ ] Upload with the consent checkbox unchecked → inspect `ai_corpus.source.consent_level` → 'user_only'
- [ ] Upload with it checked → 'opt_in_shared'
- [ ] Revoke a portfolio → `ai_corpus.source.revoked_at` is set AND the blob disappears from Supabase Storage
- [ ] Kill the qstash-cli mid-workflow → restart → in-memory state is lost (expected for dev); in prod, the workflow resumes from the last step
- [ ] Make the anonymise step throw (e.g., block AI gateway) → after retries exhaust, status='failed' with the error message; dialog renders red banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core data-ingest and retention paths (new DB tables/columns, async workflow execution, Storage writes/deletes) where failures can strand jobs/blobs or affect user data visibility and consent handling.
> 
> **Overview**
> Moves portfolio ingestion from a synchronous server action to a **durable async workflow**: `uploadPortfolioAction` now uploads the raw PDF to Supabase Storage, creates a `leercoach.upload_job` row, triggers an Upstash Workflow, and the client polls a new `GET /api/upload-job/[id]/status` endpoint until the job is `ready`/`failed`.
> 
> Adds the Upstash workflow webhook at `api/workflow/ingest-portfolio` to run extract → anonymise → chunk → `AiCorpus.upsertSourceWithChunks`, persisting `ai_corpus.source.original_storage_path` and updating `upload_job` status with replay/timeout/failure handling + revalidation.
> 
> Updates the upload UI to reflect the async lifecycle (pending/processing/ready/failed banners, disable inputs during polling, reset/refresh on success), introduces an opt-in consent checkbox for using anonymised data to improve models, and extends revoke to also delete the stored original PDF.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11ce22868b67ce9d941df2b26d5f181237c161cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->