### PR TITLE
fix(leercoach/chat): regenerate user-message id when client sends non-UUID

### DIFF
--- a/apps/web/src/app/api/leercoach/chat/route.ts
+++ b/apps/web/src/app/api/leercoach/chat/route.ts
@@ -52,6 +52,14 @@ export const maxDuration = 60;
 // Model id centralized in ~/lib/ai-models so a single swap flips the
 // whole chat stack. See CHAT_MODEL for the role rationale.
 
+// RFC 4122-style UUID matcher. Used below to validate client-supplied
+// message ids before handing them to Leercoach.Message.save (which
+// enforces uuidSchema via Zod). Clients with cached pre-PR-440 JS
+// bundles still ship nanoid-style "msg_xxx" ids — we mint a fresh
+// UUID server-side rather than 500 on the save.
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 // Body shape produced by the client's DefaultChatTransport. Discriminated
 // on `trigger` — zod-like parsing inline instead of a zod schema so we
 // keep the route dependency-lean.
@@ -181,12 +189,29 @@ export async function POST(req: Request) {
       const idx = messages.findIndex((m) => m.id === body.messageId);
       if (idx !== -1) messages = messages.slice(0, idx);
     }
+    // Defensive id validation. The client's useChat config sets
+    // `generateId: () => crypto.randomUUID()` (PR #440), but clients
+    // with cached pre-fix JS bundles keep shipping nanoid-style ids
+    // like "msg_4h3jk2h4" — which Zod rejects because the message
+    // column is uuid NOT NULL. When we see a non-UUID from the
+    // client, we mint a server-side UUID instead of failing the save.
+    //
+    // The UPSERT semantics on Message.save mean this is still safe
+    // on retry: a second submit with the SAME server-generated UUID
+    // lands as an update, not a duplicate. The trade-off is a slight
+    // drift between the client's in-memory id (msg_xxx) and what's
+    // persisted (UUID-xxx) — on a refresh the client rehydrates
+    // from the DB and the ids realign.
+    const incomingId = body.message.id;
+    const savedMessageId = UUID_RE.test(incomingId)
+      ? incomingId
+      : crypto.randomUUID();
     // Persist the user turn synchronously so a mid-stream refresh
     // still shows what they typed. The save mutation UPSERTs on the
     // id we pass — so a retried submit with the same id is a no-op
     // insert + redundant update, not a duplicate row.
     await Leercoach.Message.save({
-      id: body.message.id,
+      id: savedMessageId,
       chatId: chat.chatId,
       role: "user",
       parts: body.message.parts as Array<{
@@ -194,7 +219,15 @@ export async function POST(req: Request) {
         [k: string]: unknown;
       }>,
     });
-    messages = [...messages, body.message];
+    messages = [
+      ...messages,
+      // Swap the client's id for the server-generated UUID in the
+      // in-memory `messages` array so the model's history view is
+      // consistent with what's in the DB. If we left the nanoid id
+      // here, a subsequent regenerate-message keyed on this id
+      // wouldn't find a matching row.
+      { ...body.message, id: savedMessageId } as UIMessage,
+    ];
   } else {
     // regenerate-message: truncate to the message just before the
     // target (or before the last assistant if no messageId). The


### PR DESCRIPTION
## Summary

Defensive fix for a recurrence of the \`Invalid uuid at path [\"id\"]\` error in prod, even after PR #440 merged.

## Root cause

PR #440 made \`useChat\` generate UUIDs on the client. New clients work. BUT users with **cached pre-fix JS bundles** keep shipping the AI SDK's default nanoid-style ids (\`msg_xxx\`) to the chat POST route. The server passes that id straight to \`Leercoach.Message.save\`, Zod rejects it, request 500s, user can't send messages.

## Fix

Validate the incoming \`body.message.id\` as a UUID server-side; if it fails, mint a fresh one via \`crypto.randomUUID()\` and save with that. Also swap the id in the in-memory \`messages\` array we hand to the model so the streamed context references what's actually persisted.

One regex constant + ~10 lines in the chat POST route.

## Why this matters

We can't force users to hard-refresh. Service workers, HTTP caches, and in-memory SPA state can keep pre-fix bundles alive for hours or days. A server-side guard is the only way to kill the error deterministically.

## Trade-off (minor)

When the server regenerates the id, the client's \`useChat\` state keeps the nanoid id locally while the DB has the UUID. On refresh the client rehydrates from the DB and the ids realign. Mid-session, a subsequent regenerate-message keyed on the nanoid would fall through to the "last message" fallback in the route's regen branch — acceptable degradation compared to the current 500-on-every-submit.

## Test plan

- [ ] Deploy
- [ ] Open chat in a browser that still has the old bundle (dev tools → disable cache OR open incognito with a stale extension cache)
- [ ] Send a message → receive response, no 500
- [ ] Check DB: \`leercoach.message\` row has a valid UUID in the \`id\` column

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes server-side message persistence to rewrite client-provided ids when they are not UUIDs, which can affect how messages are referenced (e.g., regenerate flows) and should be validated against existing clients.
> 
> **Overview**
> Adds server-side validation for client-supplied `UIMessage.id` on `submit-message`; if the id is not a UUID, the route now generates a fresh `crypto.randomUUID()` to avoid `Leercoach.Message.save` failures.
> 
> Also replaces the message id in the in-memory `messages` array with the server-generated UUID so downstream model context and later operations (like `regenerate-message` lookups) align with what was persisted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 080666d4c24d9e2b9ffa75c92eb027ce42580831. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->