### PR TITLE
fix(web): enable PostHog sourcemap upload for readable prod stack traces

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -199,6 +199,17 @@ export default withPostHogConfig(withMDX(nextConfig), {
   host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
   envId: process.env.POSTHOG_ENV_ID,
   sourcemaps: {
-    enabled: false,
+    // Upload sourcemaps at build time so PostHog's Error Tracking
+    // symbolicates stack frames back to real file paths + line
+    // numbers instead of the minified `chunks/_4ca4fe68._.js:158`
+    // references that make prod errors hostile to diagnose.
+    //
+    // `deleteAfterUpload` defaults to true — maps are uploaded to
+    // PostHog then deleted from the deployed bundle, so end users
+    // never fetch them from our domain. If we ever want external
+    // contributors to debug prod via devtools, flip that to false
+    // in a follow-up (low risk given the repo is open source, but
+    // no reason to ship the extra bytes by default).
+    enabled: true,
   },
 });


### PR DESCRIPTION
## Summary

`@posthog/nextjs-config` is already wired in \`next.config.mjs\` but sourcemap upload is explicitly disabled. Flipping it on turns every future error in PostHog from \`chunks/_4ca4fe68._.js:158\` into a real file path + line number.

## Why

Earlier today we hit an \`Invalid uuid at path [\"id\"]\` error in prod. My diagnosis pointed at \`Leercoach.Message.save\` but I couldn't be certain — 100+ other core functions have \`id: uuidSchema\` fields and could throw the same minified trace. Without sourcemaps we're grepping chunk files to guess.

With sourcemaps:
- PostHog Error Tracking shows \`apps/web/src/app/api/leercoach/chat/route.ts:189\` instead of \`chunks/.../_.js:94\`
- Diagnosis time per error: minutes → seconds
- Future regressions (the kind that always hit on the first few days of a major deploy like the leercoach launch) become actionable

## What changes

One field in one file:

\`\`\`diff
   sourcemaps: {
-    enabled: false,
+    enabled: true,
   },
\`\`\`

Everything else (\`deleteAfterUpload\`, upload hooks, API auth) is already defaulted correctly by \`@posthog/nextjs-config\`.

## Safety & cost

- **Sourcemaps not exposed to users**: \`deleteAfterUpload: true\` (the package default) uploads to PostHog then deletes from the deployed bundle. End users never fetch \`.map\` files.
- **Repo is open source anyway**: even if a \`.map\` leaked, nothing new is revealed — source is on GitHub.
- **Build cost**: ~20s per \`next build\` for the upload. Zero runtime cost to users.
- **Env vars**: \`POSTHOG_API_KEY\` + \`POSTHOG_ENV_ID\` already set in Vercel (they're in the turbo.json platform-env warnings from earlier deploys).

## Caveat

Only symbolicates errors from the sourcemap-enabled build onward. Errors already in PostHog's history (including the \`Invalid uuid\` one from this morning) stay minified — we need to wait for the next occurrence post-deploy to see a real trace. That's why I'd merge this first and wait for the error to recur before trusting any diagnostic conclusions.

## Test plan

- [ ] Merge + deploy
- [ ] In PostHog → Error Tracking, confirm recent errors resolve to app paths (e.g. \`apps/web/src/app/.../route.ts:NNN\`)
- [ ] If the \`Invalid uuid\` error fires again → finally see exactly which core function throws → commit to a targeted fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a config-only change that enables build-time sourcemap upload to PostHog; main impact is slightly longer builds and potential exposure if PostHog configuration/credentials are mis-set.
> 
> **Overview**
> Enables PostHog sourcemap upload in `apps/web/next.config.mjs` by setting `sourcemaps.enabled: true`, improving production Error Tracking stack traces from minified chunk references to original source file paths/line numbers.
> 
> Adds inline documentation clarifying that maps are uploaded at build time and (by default) deleted from the deployed bundle via PostHog’s `deleteAfterUpload` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26a178dac72577fe16224f232d45507df011f685. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->