### PR TITLE
hotfix(web): fix 3 type errors breaking Vercel's prod build

### DIFF
--- a/apps/web/scripts/corpus/experiment-prior-context.ts
+++ b/apps/web/scripts/corpus/experiment-prior-context.ts
@@ -85,13 +85,14 @@ async function loadFromAiCorpus(
        WHERE source_identifier = $1 AND revoked_at IS NULL`,
       [sourceIdentifier],
     );
-    if (res.rows.length === 0) {
+    const row = res.rows[0];
+    if (!row) {
       throw new Error(`No source ${sourceIdentifier} in ai_corpus.`);
     }
     return {
       sourceIdentifier,
-      content: res.rows[0]?.content,
-      niveau: res.rows[0]?.niveauRang,
+      content: row.content,
+      niveau: row.niveauRang,
     };
   } finally {
     await client.end();

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/_lib/format-kerntaak.ts
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/_lib/format-kerntaak.ts
@@ -15,7 +15,10 @@ export function parseKerntaakTitel(titel: string): {
   label: string;
 } {
   const m = titel.match(TITEL_PATTERN);
-  if (m) return { code: m[1]!, label: m[2]?.trim() };
+  // Both captures are required by the pattern, so m[1]/m[2] are
+  // defined whenever `m` is truthy. Non-null assertion satisfies the
+  // compiler without a redundant runtime check.
+  if (m) return { code: m[1]!, label: m[2]!.trim() };
   return { code: null, label: titel };
 }
 
@@ -33,6 +36,8 @@ export function parseWerkprocesTitel(titel: string): {
   label: string;
 } {
   const m = titel.match(WERKPROCES_TITEL_PATTERN);
-  if (m) return { code: m[1]!, label: m[2]?.trim() };
+  // See parseKerntaakTitel above — both captures required by the
+  // regex, non-null assertion is safe when `m` is truthy.
+  if (m) return { code: m[1]!, label: m[2]!.trim() };
   return { code: null, label: titel };
 }

--- a/apps/web/src/app/(public)/partners/page.tsx
+++ b/apps/web/src/app/(public)/partners/page.tsx
@@ -8,7 +8,11 @@ import watersportverbond from "./_assets/watersportverbond.png";
 
 interface PartnerCardProps {
   name: string;
-  role: string;
+  /**
+   * Optional short role label shown next to the name (e.g.
+   * "Licentiehouder"). Card still renders cleanly when omitted.
+   */
+  role?: string;
   logo: StaticImageData;
   logoAlt: string;
   children: ReactNode;
@@ -34,9 +38,11 @@ function PartnerCard({
       </div>
       <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
         <h2 className="text-2xl font-bold text-slate-900">{name}</h2>
-        <span className="rounded-full bg-branding-dark/5 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-branding-dark">
-          {role}
-        </span>
+        {role ? (
+          <span className="rounded-full bg-branding-dark/5 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-branding-dark">
+            {role}
+          </span>
+        ) : null}
       </div>
       <div className="space-y-3 text-base leading-relaxed text-slate-600">
         {children}


### PR DESCRIPTION
## Summary

Vercel's production deploy of `main@4961155c` failed with a TypeScript
compile error. Three pre-existing type errors slipped past CI because
the repo's test workflow doesn't run `tsc --noEmit` against the whole
`apps/web` project the way Next.js's own build does.

**Immediate blocker** reported by Vercel:
\`\`\`
./scripts/corpus/experiment-prior-context.ts:93:7
Type error: Type 'string | undefined' is not assignable to type 'string'.
\`\`\`

## Fixes

1. **`scripts/corpus/experiment-prior-context.ts:93-94`** — optional chain on `res.rows[0]?.content` / `?.niveauRang` returned `undefined` even though a length guard above throws when the result is empty. TS can't see the guard. Hoisted `res.rows[0]` into a local that the guard checks, so the return reads from a definitely-defined value.

2. **`src/app/(dashboard)/(account)/profiel/[handle]/_lib/format-kerntaak.ts:18,36`** — `m[2]?.trim()` is `string | undefined` but the declared return type promises `label: string`. The regex guarantees both captures when `m` is truthy, so non-null assertion matches the runtime semantics and quiets the type.

3. **`src/app/(public)/partners/page.tsx:99,126`** — `PartnerCardProps.role` was declared required, but neither `<PartnerCard>` call site passes it. Made `role` optional and wrapped the badge render in a conditional so the card still reads cleanly without it.

## Test plan

- [x] `pnpm exec tsc --noEmit` from `apps/web/` — clean, no other type errors
- [ ] Vercel preview build turns green
- [ ] After merge: Vercel prod build turns green + deploy goes out

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-safety and small UI rendering changes only; no behavioral changes to critical logic beyond avoiding undefined values.
> 
> **Overview**
> Fixes three TypeScript issues that were breaking the Next.js/Vercel production build.
> 
> In `experiment-prior-context.ts`, the ai_corpus query result is assigned to a `row` local and validated before returning, removing `string | undefined`/`number | undefined` from the return type. In `format-kerntaak.ts`, regex capture groups are treated as definitely present when matched (using non-null assertions) so `label` is always a `string`. On the public `partners` page, `PartnerCardProps.role` is made optional and the role badge is rendered conditionally when provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cd96c0776472ed4437f33bcf5c378262b6f568a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->