### PR TITLE
fix(ai-corpus): include opt_in_shared in user's own-upload queries

### DIFF
--- a/packages/core/src/models/ai-corpus/index.ts
+++ b/packages/core/src/models/ai-corpus/index.ts
@@ -260,9 +260,12 @@ export const getChunksForCriterium = wrapQuery(
 //
 // Helpers for the "kandidaat uploads their prior PvB portfolios as
 // reference material" flow. Access is strictly user-scoped:
-// consent_level must be "user_only" AND contributedByUserId must match.
-// No cross-user visibility here; the public retrieval helper above is
-// the only path that returns seed + opt_in_shared chunks.
+// contributedByUserId must match, and consent is either "user_only"
+// (private to this user) OR "opt_in_shared" (user let us reuse the
+// content across users, but it's still _their_ upload and must appear
+// in their own management + leercoach views). No cross-user visibility
+// here; the public retrieval helper above is the only path that
+// returns seed + other users' opt_in_shared chunks.
 
 export const listUserPriorSourcesInput = z.object({
   userId: uuidSchema,
@@ -327,7 +330,12 @@ export const listUserPriorSources = wrapQuery(
         .from(s.source)
         .where(
           and(
-            eq(s.source.consentLevel, "user_only"),
+            // Include BOTH consent tiers the user could have picked at
+            // upload time — `user_only` (private) and `opt_in_shared`
+            // (shareable). Both are still _their_ upload, so both must
+            // appear in their own management view. Consent only gates
+            // cross-user visibility, not self-visibility.
+            inArray(s.source.consentLevel, ["user_only", "opt_in_shared"]),
             eq(s.source.contributedByUserId, input.userId),
             isNull(s.source.revokedAt),
           ),
@@ -453,7 +461,11 @@ export const getUserPriorChunks = wrapQuery(
     const query = useQuery();
 
     const whereClauses: SQLWrapper[] = [
-      eq(s.source.consentLevel, "user_only"),
+      // See listUserPriorSources for the full rationale: consent only
+      // gates cross-user visibility, not self-visibility. A user's own
+      // `opt_in_shared` uploads are still _theirs_ and must flow into
+      // their own leercoach context, not just their `user_only` ones.
+      inArray(s.source.consentLevel, ["user_only", "opt_in_shared"]),
       eq(s.source.contributedByUserId, input.userId),
       isNull(s.source.revokedAt),
     ];
@@ -621,7 +633,12 @@ export const revokeUserPriorSource = wrapCommand(
         .where(
           and(
             eq(s.source.id, input.sourceId),
-            eq(s.source.consentLevel, "user_only"),
+            // User can revoke ANY of their own prior-portfolio sources
+            // regardless of consent tier — "I shared it with you" isn't
+            // a trap the user can't get out of. Both `user_only` and
+            // `opt_in_shared` belong to this user; either is revocable
+            // (GDPR right to erasure extends to opt-in shares too).
+            inArray(s.source.consentLevel, ["user_only", "opt_in_shared"]),
             eq(s.source.contributedByUserId, input.userId),
           ),
         );


### PR DESCRIPTION
## Summary

Real bug reported against the PR #441 merge: user uploaded a portfolio with the "help improve the model" consent checkbox ticked → source row correctly stored with \`consent_level='opt_in_shared'\` and a real \`source_id\` + 8 anonymised chunks in the DB → but the user's own \`/profiel/<handle>/portfolios\` management page rendered as empty.

Three user-scoped queries in \`packages/core/src/models/ai-corpus/index.ts\` were filtering strictly on \`consent_level = 'user_only'\`, which excluded the user's _own_ shared uploads from their own views.

## Fixes

| Query | Call site | Bug |
|---|---|---|
| \`listUserPriorSources\` | \`/portfolios\` management page | User's opt_in_shared uploads don't appear in the list |
| \`getUserPriorChunks\` | Leercoach tool pulling user's own portfolios as session context | User's opt_in_shared chunks don't flow into their own coach |
| \`revokeUserPriorSource\` | Delete action from management page | User can't remove their shared uploads (GDPR blocker) |

All three: \`eq(consentLevel, 'user_only')\` → \`inArray(consentLevel, ['user_only', 'opt_in_shared'])\`.

## Why this is safe

- Every query already filters on \`contributedByUserId = input.userId\` — relaxing the consent tier doesn't leak across users. The caller is still only seeing rows they own.
- \`getChunksForCriterium\` was already correct: it wraps opt_in_shared under its public clause, which covers the "user's own opt_in_shared content shows up in the criterium retrieval path for anyone, including themselves" case.
- Not a schema change — pure query-layer relaxation. No migration required.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` from \`apps/web/\` clean
- [ ] After deploy: /profiel/<handle>/portfolios shows the \`opt_in_shared\` row from the original bug report (source_id \`83793e8e-...\`)
- [ ] Leercoach session picks up the chunks as context (retrieve via \`searchPriorPortfolio\` tool)
- [ ] Revoke action works on opt_in_shared rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk query change limited to user-scoped portfolio retrieval/revocation; no schema or cross-user visibility changes, but it may affect which uploads appear in UI/context.
> 
> **Overview**
> Fixes a regression where a user’s prior-portfolio uploads marked `opt_in_shared` were treated as invisible to the uploader.
> 
> User-scoped queries now accept both `user_only` and `opt_in_shared` consent levels in `listUserPriorSources`, `getUserPriorChunks`, and `revokeUserPriorSource`, ensuring shared uploads still appear in the user’s management/leercoach views and can be revoked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1303a826037fff0c4160ebc305f2f0ed11df4589. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->