### PR TITLE
fix(leercoach/chat): bump maxDuration to 300s for long coaching turns

### DIFF
--- a/apps/web/src/app/api/leercoach/chat/[id]/stream/route.ts
+++ b/apps/web/src/app/api/leercoach/chat/[id]/stream/route.ts
@@ -20,6 +20,13 @@ import { createClient } from "~/lib/supabase/server";
 //          ~1s and uses to abort streamText server-side. This keeps all
 //          LLM-abort logic in one place and survives client disconnects.
 
+// Matches the POST /chat ceiling (300s). The resumed stream replays
+// whatever the original producer wrote, so if the producer is still
+// running we may need to keep this connection open almost as long as
+// the original turn. Leaving it at Vercel's 15s default was clipping
+// legitimate resumes for long coaching turns.
+export const maxDuration = 300;
+
 let _redis: Redis | null = null;
 function getRedis(): Redis {
   if (_redis) return _redis;

--- a/apps/web/src/app/api/leercoach/chat/route.ts
+++ b/apps/web/src/app/api/leercoach/chat/route.ts
@@ -46,7 +46,17 @@ import { createClient } from "~/lib/supabase/server";
 // the assistant message fully persisted when they return. See the
 // GET route in ./[id]/stream/route.ts for the reconnect path.
 
-export const maxDuration = 60;
+// Vercel serverless ceiling. Large coaching turns (long history + one
+// or more tool calls that edit the portfolio draft) can exceed a minute
+// of wall-clock on the LLM side; observed production turn: the function
+// was killed at 60s with "Task timed out after 60 seconds" and the
+// client's auto-resume then failed with resumable-stream's 1s "Timeout
+// waiting for ack" because the producer never set its done-sentinel.
+// 300s is Vercel Pro's hard max; we're nowhere near needing it for a
+// healthy turn, but it removes the ceiling as a failure mode while we
+// invest in shrinking turn duration via compaction / tool-output
+// truncation / smaller model for draft edits.
+export const maxDuration = 300;
 
 // Model id centralized in ~/lib/ai-models so a single swap flips the
 // whole chat stack. See CHAT_MODEL for the role rationale.


### PR DESCRIPTION
## Summary

Production hit two related errors on a long chat turn (large history + tool call editing the draft):

1. `Vercel Runtime Timeout Error: Task timed out after 60 seconds` — POST \`/api/leercoach/chat\` was at \`maxDuration = 60\`.
2. `Timeout waiting for ack` — from resumable-stream's 1s pub/sub handoff inside GET \`/api/leercoach/chat/[id]/stream\`. Downstream symptom of (1): producer got killed mid-stream so no DONE sentinel landed in Redis; client's auto-resume couldn't find anything to replay and timed out on the 1s ack wait.

## Fix

- \`POST /api/leercoach/chat\`: \`60 → 300\`
- \`GET /api/leercoach/chat/[id]/stream\`: **new** \`maxDuration = 300\` (was Vercel's 15s default)

300s is Vercel Pro's hard ceiling. A healthy turn is nowhere near even 60s; removing the ceiling as a failure mode is the right call while we invest in shrinking turn duration properly:

- More aggressive compaction
- Tighter tool-output truncation
- Smaller model for trivial draft edits

The resume route at 15s was clipping legitimate reconnects for long turns — now it matches the producer ceiling so a mid-stream refresh won't throw spurious errors.

## Test plan

- [ ] Reproduce the original timeout locally or via a dev deploy
- [ ] Same turn should complete cleanly on the new maxDuration
- [ ] Check PostHog / Vercel logs: no recurrence of the `Timeout waiting for ack` pattern after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends serverless execution time for streaming chat endpoints, which can increase compute/cost and tie up connections if streams hang, but does not change auth or data mutation logic.
> 
> **Overview**
> **Increases timeout ceilings for long leercoach chat streams.** The POST `/api/leercoach/chat` route’s `maxDuration` is bumped from 60s to 300s to avoid Vercel runtime timeouts during long LLM/tool-call turns.
> 
> **Aligns resume stream behavior with the producer.** The GET `/api/leercoach/chat/[id]/stream` route now explicitly sets `maxDuration = 300` (instead of relying on Vercel’s short default) so mid-stream reconnects can stay open long enough to replay ongoing Redis-backed SSE output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f10b111c461367906dae3faf3484c790d335d36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->