### PR TITLE
fix(profiel): null-filter cohort progress aggregate + error boundary

### DIFF
--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/error.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/error.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
+import { useEffect } from "react";
+import { Button } from "~/app/(dashboard)/_components/button";
+import { Heading } from "~/app/(dashboard)/_components/heading";
+import { Text } from "~/app/(dashboard)/_components/text";
+
+export default function ProfielErrorBoundary({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[400px] flex-col items-center justify-center">
+      <div className="mx-auto max-w-md text-center">
+        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/20">
+          <ExclamationTriangleIcon className="h-8 w-8 text-red-600 dark:text-red-400" />
+        </div>
+
+        <Heading className="mb-2">Er is iets misgegaan</Heading>
+
+        <Text className="mb-6 text-gray-600 dark:text-gray-400">
+          Er is een onverwachte fout opgetreden bij het laden van dit profiel.
+          Probeer het opnieuw of neem contact op met het secretariaat als het
+          probleem zich blijft voordoen.
+        </Text>
+
+        {error.digest ? (
+          <Text className="mb-6 text-xs text-gray-500 dark:text-gray-500">
+            Referentie: {error.digest}
+          </Text>
+        ) : null}
+
+        <Button outline onClick={() => reset()}>
+          Probeer opnieuw
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/core/src/models/cohort/student-progress.ts
+++ b/packages/core/src/models/cohort/student-progress.ts
@@ -119,12 +119,15 @@ export const listByPersonId = wrapQuery(
           locationHandle: s.location.handle,
           locationName: s.location.name,
           studentCurriculumId: s.cohortAllocation.studentCurriculumId,
-          progress: jsonAggBuildObject({
-            competencyId: latestProgress.competencyId,
-            moduleId: latestProgress.moduleId,
-            progress: sql<number>`${latestProgress.progress}::integer`,
-            createdAt: latestProgress.createdAt,
-          }).as("progress"),
+          progress: jsonAggBuildObject(
+            {
+              competencyId: latestProgress.competencyId,
+              moduleId: latestProgress.moduleId,
+              progress: sql<number>`${latestProgress.progress}::integer`,
+              createdAt: latestProgress.createdAt,
+            },
+            { notNullColumn: "createdAt" },
+          ).as("progress"),
           progressVisibleUpUntil: s.cohortAllocation.progressVisibleUpUntil,
         })
         .from(s.cohortAllocation)


### PR DESCRIPTION
## Summary

- **Root cause:** `Cohort.StudentProgress.listByPersonId` LEFT JOINs the `latestProgress` CTE and aggregates with `jsonAggBuildObject` without `notNullColumn`. When a cohort allocation has zero progress rows inside the visibility window, `jsonb_agg` over the null side of the join emits `[{competencyId:null, moduleId:null, progress:null, createdAt:null}]` instead of `[]`. The downstream transform calls `dayjs(null).toISOString()` → `RangeError: Invalid time value` → `/profiel/[handle]` 500s.
- **Fix:** pass `notNullColumn: "createdAt"` so the aggregate filters the null row and emits `[]`.
- **Defense in depth:** add a route-scoped `error.tsx` at `/profiel/[handle]` (matches the existing pattern at `/locatie/[location]/pvb-aanvragen/[handle]`) so any future render error degrades to a friendly retry page instead of a generic 500.

## Context

PostHog issue: `019d20a4-4243-7ff1-b8c5-8f7150a8a5e6` — active since 2026-03-24, affecting at least one user (`/profiel/RFDTKn6jdM`). Vercel stack trace shows `RangeError: Invalid time value` from nested `.map()` → `Date.toISOString()`, matching `rows.map((row) => ({ progress: row.progress.map((p) => ({ createdAt: dayjs(p.createdAt).toISOString() })) }))` in `student-progress.ts`.

Confirmed via SQL that the reporting user has a cohort allocation where:
- `progress_visible_up_until <= NOW()` (passes outer filter)
- cohort is active (passes `respectCohortVisibility`)
- but zero `student_cohort_progress` rows satisfy the CTE's inner filter (`scp.created_at <= ca.progress_visible_up_until`)

That's exactly the LEFT JOIN → null-row → `dayjs(null)` path.

## Test plan

- [ ] Deploy to preview
- [ ] Navigate to `/profiel/RFDTKn6jdM` as the affected user — profile loads, "Lopende cursussen" tab shows the allocation with empty progress (count 0) instead of 500
- [ ] Verify PostHog stops receiving new occurrences of issue `019d20a4-4243-7ff1-b8c5-8f7150a8a5e6`
- [ ] Spot-check other users' profiles to confirm no regression in the progress view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, targeted change to a single SQL JSON aggregate and a new client-side error boundary component; main risk is minor behavioral change where some progress arrays become empty instead of containing null placeholders.
> 
> **Overview**
> Prevents `/profiel/[handle]` crashes when a cohort allocation has no visible progress by filtering out the NULL-side of the LEFT JOIN in `Cohort.StudentProgress.listByPersonId` (using `jsonAggBuildObject(..., { notNullColumn: "createdAt" })` so the aggregate returns `[]` instead of a null-filled object).
> 
> Adds a route-scoped Next.js `error.tsx` for `/profiel/[handle]` that logs the error, shows a friendly Dutch error message (optionally with the digest), and provides a **Retry** button via `reset()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e45413348cbc9b69ea795baecc9fe6b0425a152. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->