### PR TITLE
fix(tarieven): wijzigingen na merge — verduidelijking, declaratie-flow, hernoeming

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -92,6 +92,11 @@ const nextConfig = {
         permanent: true,
       },
       {
+        source: "/vereniging/tarieven",
+        destination: "/vereniging/tarieven-en-declaraties",
+        permanent: true,
+      },
+      {
         source: "/faq-instructeur",
         destination:
           "/actueel/3yHwZSTf-een-nieuw-tijdperk-voor-jou-als-instructeur-met-het-nwd",

--- a/apps/web/src/app/(public)/_components/header/header.tsx
+++ b/apps/web/src/app/(public)/_components/header/header.tsx
@@ -82,10 +82,10 @@ export default function Header() {
                 href: "/vereniging/kwaliteitscommissie",
               },
               {
-                label: "Tarieven",
-                href: "/vereniging/tarieven",
+                label: "Tarieven en declaraties",
+                href: "/vereniging/tarieven-en-declaraties",
                 description:
-                  "Vergoedingen, locatiekosten en opleidingskosten",
+                  "Declareren, vergoedingen, locatiekosten en opleidingskosten",
               },
               {
                 label: "Statuten en reglementen",

--- a/apps/web/src/app/(public)/vereniging/_utils/segments.ts
+++ b/apps/web/src/app/(public)/vereniging/_utils/segments.ts
@@ -35,10 +35,10 @@ export const verenigingsPages: (Page & { slug: string })[] = [
       "De kwaliteitscommissie bewaakt de kwaliteit van aangesloten locaties bij het Nationaal Watersportdiploma.",
   },
   {
-    title: "Tarieven",
-    slug: "tarieven",
+    title: "Tarieven en declaraties",
+    slug: "tarieven-en-declaraties",
     description:
-      "Overzicht van vergoedingen voor vrijwilligers, kosten voor aangesloten locaties en opleidingskosten voor deelnemers.",
+      "Hoe je vergoedingen declareert en het overzicht van vergoedingen voor vrijwilligers, kosten voor aangesloten locaties en opleidingskosten voor deelnemers.",
   },
   {
     title: "Statuten en reglementen",

--- a/apps/web/src/app/(public)/vereniging/tarieven-en-declaraties/page.tsx
+++ b/apps/web/src/app/(public)/vereniging/tarieven-en-declaraties/page.tsx
@@ -89,7 +89,7 @@ export default function Page() {
       </p>
       <ul>
         <li>de verrichte activiteit (rol en context);</li>
-        <li>de datum waarop de activiteit plaatsvond;</li>
+        <li>de datum én de vaarlocatie waar de activiteit plaatsvond;</li>
         <li>de gemaakte reiskosten (kilometers of OV-kosten);</li>
         <li>je IBAN en de tenaamstelling van de rekening.</li>
       </ul>

--- a/apps/web/src/app/(public)/vereniging/tarieven-en-declaraties/page.tsx
+++ b/apps/web/src/app/(public)/vereniging/tarieven-en-declaraties/page.tsx
@@ -9,14 +9,14 @@ export async function generateMetadata(
   const parentOpenGraph = (await parent).openGraph;
 
   return {
-    title: "Tarieven",
+    title: "Tarieven en declaraties",
     alternates: {
-      canonical: "/vereniging/tarieven",
+      canonical: "/vereniging/tarieven-en-declaraties",
     },
     openGraph: {
       ...parentOpenGraph,
-      title: "Tarieven",
-      url: "/vereniging/tarieven",
+      title: "Tarieven en declaraties",
+      url: "/vereniging/tarieven-en-declaraties",
     },
   };
 }
@@ -36,11 +36,15 @@ export default function Page() {
       </div>
 
       <p>
-        Op deze pagina vind je alle tarieven overzichtelijk bij elkaar. Kies
-        wat voor jou van toepassing is:
+        Op deze pagina vind je eerst hoe je je vergoeding declareert, en
+        daarna alle tarieven overzichtelijk bij elkaar:
       </p>
 
       <ul>
+        <li>
+          <Link href="#declaraties">Declaraties indienen</Link> — hoe en waar
+          dien je je vergoeding en reiskosten in?
+        </li>
         <li>
           <Link href="#vergoedingen">
             Vergoedingen voor vrijwilligers en uitvoerders
@@ -68,6 +72,27 @@ export default function Page() {
           onkostenvergoedingen en bevatten geen btw.
         </p>
       </blockquote>
+
+      <h2 id="declaraties">Declaraties indienen</h2>
+      <p>
+        Vergoedingen en reiskosten dien je achteraf in bij de penningmeester
+        via{" "}
+        <CopyToClipboard
+          value="penningmeester@nationaalwatersportdiploma.nl"
+          className="break-words underline"
+        >
+          penningmeester
+          <wbr />
+          @nationaalwatersportdiploma.nl
+        </CopyToClipboard>
+        . Vermeld in je declaratie:
+      </p>
+      <ul>
+        <li>de verrichte activiteit (rol en context);</li>
+        <li>de datum waarop de activiteit plaatsvond;</li>
+        <li>de gemaakte reiskosten (kilometers of OV-kosten);</li>
+        <li>je IBAN en de tenaamstelling van de rekening.</li>
+      </ul>
 
       <h2 id="vergoedingen">Vergoedingen voor vrijwilligers en uitvoerders</h2>
       <p>
@@ -237,27 +262,6 @@ export default function Page() {
         vergoeding omdat je in een commissie zit, maar wel voor het concrete
         werk dat je vanuit die rol uitvoert.
       </p>
-
-      <h3>Declareren</h3>
-      <p>
-        Vergoedingen en reiskosten dien je achteraf in bij de penningmeester
-        via{" "}
-        <CopyToClipboard
-          value="penningmeester@nationaalwatersportdiploma.nl"
-          className="break-words underline"
-        >
-          penningmeester
-          <wbr />
-          @nationaalwatersportdiploma.nl
-        </CopyToClipboard>
-        . Vermeld in je declaratie:
-      </p>
-      <ul>
-        <li>de verrichte activiteit (rol en context);</li>
-        <li>de datum waarop de activiteit plaatsvond;</li>
-        <li>de gemaakte reiskosten (kilometers of OV-kosten);</li>
-        <li>je IBAN en de tenaamstelling van de rekening.</li>
-      </ul>
 
       <h2 id="locaties">Kosten voor aangesloten locaties</h2>
       <p>

--- a/apps/web/src/app/(public)/vereniging/tarieven/page.tsx
+++ b/apps/web/src/app/(public)/vereniging/tarieven/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, ResolvingMetadata } from "next";
 import Link from "next/link";
+import CopyToClipboard from "~/app/(public)/_components/style/copy-to-clipboard";
 
 export async function generateMetadata(
   _props: unknown,
@@ -236,6 +237,27 @@ export default function Page() {
         vergoeding omdat je in een commissie zit, maar wel voor het concrete
         werk dat je vanuit die rol uitvoert.
       </p>
+
+      <h3>Declareren</h3>
+      <p>
+        Vergoedingen en reiskosten dien je achteraf in bij de penningmeester
+        via{" "}
+        <CopyToClipboard
+          value="penningmeester@nationaalwatersportdiploma.nl"
+          className="break-words underline"
+        >
+          penningmeester
+          <wbr />
+          @nationaalwatersportdiploma.nl
+        </CopyToClipboard>
+        . Vermeld in je declaratie:
+      </p>
+      <ul>
+        <li>de verrichte activiteit (rol en context);</li>
+        <li>de datum waarop de activiteit plaatsvond;</li>
+        <li>de gemaakte reiskosten (kilometers of OV-kosten);</li>
+        <li>je IBAN en de tenaamstelling van de rekening.</li>
+      </ul>
 
       <h2 id="locaties">Kosten voor aangesloten locaties</h2>
       <p>

--- a/apps/web/src/app/(public)/vereniging/tarieven/page.tsx
+++ b/apps/web/src/app/(public)/vereniging/tarieven/page.tsx
@@ -193,7 +193,7 @@ export default function Page() {
       <h3>Leercoach</h3>
       <p>
         Als externe leercoach begeleid je deelnemers aan de centraal
-        georganiseerde <strong>niveau&nbsp;5-opleiderscursus</strong>
+        georganiseerde <strong>niveau&nbsp;5-opleiderscursus</strong>{" "}
         (Leercoach&nbsp;5 of Beoordelaar&nbsp;5) met plaatsbezoeken voor
         observatie, feedback en reflectie. De vergoeding hieronder geldt
         voor bezoeken vanuit die cursus — niet voor begeleiding die een
@@ -208,9 +208,9 @@ export default function Page() {
         </thead>
         <tbody>
           <tr>
-            <td>Bezoek</td>
+            <td>Bezoek (dagtarief)</td>
             <td>
-              <strong>€100</strong>
+              <strong>€100</strong> per dag
             </td>
           </tr>
           <tr>

--- a/apps/web/src/app/(public)/vereniging/tarieven/page.tsx
+++ b/apps/web/src/app/(public)/vereniging/tarieven/page.tsx
@@ -95,15 +95,15 @@ export default function Page() {
         </thead>
         <tbody>
           <tr>
-            <td>PvB-afname (praktijk plus portfolio&apos;s)</td>
+            <td>Losse PvB-afname (praktijk plus portfolio&apos;s)</td>
             <td>
-              <strong>€100</strong>
+              <strong>€100</strong> per PvB
             </td>
           </tr>
           <tr>
-            <td>Afname bij een clusteraanvraag</td>
+            <td>Clusteraanvraag — dagtarief</td>
             <td>
-              <strong>€150</strong>
+              <strong>€150</strong> per dag
             </td>
           </tr>
           <tr>
@@ -114,8 +114,10 @@ export default function Page() {
       </table>
       <p>
         Bij een <strong>clusteraanvraag</strong> neem je meerdere praktijk-PvB&apos;s
-        op dezelfde dag en locatie af. Omdat reistijd en voorbereiding worden
-        gedeeld, ligt de vergoeding per dag hoger.
+        op dezelfde dag en locatie af. Het dagtarief van €150 is een vast
+        all-in bedrag voor die dag, ongeacht hoeveel PvB&apos;s je in het
+        cluster afneemt. Omdat reistijd en voorbereiding worden gedeeld,
+        levert een cluster zo meer op dan losse afnames.
       </p>
 
       <h3>Controleur</h3>

--- a/apps/web/src/app/(public)/vereniging/tarieven/page.tsx
+++ b/apps/web/src/app/(public)/vereniging/tarieven/page.tsx
@@ -194,8 +194,12 @@ export default function Page() {
 
       <h3>Leercoach</h3>
       <p>
-        Als externe leercoach begeleid je kandidaten in hun opleidingstraject
-        met plaatsbezoeken voor observatie, feedback en reflectie.
+        Als externe leercoach begeleid je deelnemers aan de centraal
+        georganiseerde <strong>niveau&nbsp;5-opleiderscursus</strong>
+        (Leercoach&nbsp;5 of Beoordelaar&nbsp;5) met plaatsbezoeken voor
+        observatie, feedback en reflectie. De vergoeding hieronder geldt
+        voor bezoeken vanuit die cursus — niet voor begeleiding die een
+        vaarlocatie zelf inzet bij lagere niveaus.
       </p>
       <table>
         <thead>

--- a/apps/web/src/app/(public)/vereniging/tarieven/page.tsx
+++ b/apps/web/src/app/(public)/vereniging/tarieven/page.tsx
@@ -97,7 +97,7 @@ export default function Page() {
           <tr>
             <td>Losse PvB-afname (praktijk plus portfolio&apos;s)</td>
             <td>
-              <strong>€100</strong> per PvB
+              <strong>€100</strong>
             </td>
           </tr>
           <tr>

--- a/apps/web/src/app/(public)/vereniging/tarieven/page.tsx
+++ b/apps/web/src/app/(public)/vereniging/tarieven/page.tsx
@@ -113,11 +113,9 @@ export default function Page() {
         </tbody>
       </table>
       <p>
-        Bij een <strong>clusteraanvraag</strong> neem je meerdere praktijk-PvB&apos;s
-        op dezelfde dag en locatie af. Het dagtarief van €150 is een vast
-        all-in bedrag voor die dag, ongeacht hoeveel PvB&apos;s je in het
-        cluster afneemt. Omdat reistijd en voorbereiding worden gedeeld,
-        levert een cluster zo meer op dan losse afnames.
+        Een <strong>clusteraanvraag</strong> betreft meerdere praktijk-PvB&apos;s
+        op dezelfde dag en locatie. Het dagtarief van €150 geldt voor de hele
+        dag, ongeacht het aantal afnames.
       </p>
 
       <h3>Controleur</h3>


### PR DESCRIPTION
## Summary
Vervolg op [#454](https://github.com/buchungapp/nationaal-watersportdiploma/pull/454) met feedback uit de praktijk.

**PvB-beoordelaar tabel**
- "Losse PvB-afname" + "Clusteraanvraag — dagtarief" met expliciete eenheid (per dag)
- Toelichting clusteraanvraag is nu nuchter: dagtarief geldt voor de hele dag, ongeacht aantal afnames

**Leercoach**
- Sectie expliciet gescoped op deelnemers van de centrale niveau 5-opleiderscursus (L5/B5)
- €100 omschreven als dagtarief voor consistentie met cluster-PvB

**Nieuwe sectie Declaraties indienen**
- Volledige declaratie-flow naar penningmeester (e-mail, vereiste velden: activiteit, datum, reiskosten, IBAN + tenaamstelling)
- Gepromoveerd tot eigen H2 boven Vergoedingen, want praktisch belangrijker dan de tarieflijsten zelf

**Hernoeming**
- Pagina-titel, menu en sidebar-segment hernoemd naar **"Tarieven en declaraties"**
- URL hernoemd naar `/vereniging/tarieven-en-declaraties`
- 308 permanent redirect toegevoegd vanaf `/vereniging/tarieven` in `next.config.mjs`

## Test plan
- [ ] `/vereniging/tarieven-en-declaraties` laadt met 200
- [ ] `/vereniging/tarieven` redirect 308 → nieuwe URL
- [ ] Header en sidebar tonen nieuwe label
- [ ] Sectie "Declaraties indienen" staat als eerste H2 op de pagina
- [ ] Quicknav noemt declaraties

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Laag risico: vooral content/SEO-updates (hernoeming, redirect, metadata) en kleine UI-navigatiewijzigingen zonder impact op core logica of dataverwerking.
> 
> **Overview**
> **Hernoemt** de verenigingspagina van `Tarieven` naar **`Tarieven en declaraties`** inclusief updates aan header-navigatie, `verenigings`-segments, en pagina-metadata (canonical/open graph) naar `/vereniging/tarieven-en-declaraties`.
> 
> Voegt een nieuwe sectie **`Declaraties indienen`** toe (met kopieerbare penningmeester-e-mail via `CopyToClipboard`) en verduidelijkt tarieftabellen/teksten voor PvB-clusters (dagtarief) en leercoach (scope + dagtarief).
> 
> Voegt een **permanente redirect** toe van `/vereniging/tarieven` naar `/vereniging/tarieven-en-declaraties` in `next.config.mjs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0818f930eee91c083dd58498e7e06cadfd8cc05d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->