### PR TITLE
feat: dashboard user menu links, secretariaat and homepage

### DIFF
--- a/apps/web/src/app/(dashboard)/(account)/@selector/layout.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/@selector/layout.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowRightStartOnRectangleIcon,
   Cog6ToothIcon,
+  HomeIcon,
   LifebuoyIcon,
   ShieldCheckIcon,
   UserIcon,
@@ -34,14 +35,16 @@ async function PersonsDropdownMenu() {
         <DropdownItem disabled>
           <DropdownLabel>Geen personen beschikbaar.</DropdownLabel>
         </DropdownItem>
+        <DropdownDivider />
+        <DropdownItem href="/">
+          <HomeIcon />
+          <DropdownLabel>Website</DropdownLabel>
+        </DropdownItem>
         {showSecretariaat && (
-          <>
-            <DropdownDivider />
-            <DropdownItem href="/secretariaat">
-              <Cog6ToothIcon />
-              <DropdownLabel>Secretariaat</DropdownLabel>
-            </DropdownItem>
-          </>
+          <DropdownItem href="/secretariaat">
+            <Cog6ToothIcon />
+            <DropdownLabel>Secretariaat</DropdownLabel>
+          </DropdownItem>
         )}
         <DropdownDivider />
         <DropdownItem href="/account">
@@ -82,14 +85,16 @@ async function PersonsDropdownMenu() {
         <ShieldCheckIcon />
         <DropdownLabel>Privacybeleid</DropdownLabel>
       </DropdownItem>
+      <DropdownDivider />
+      <DropdownItem href="/">
+        <HomeIcon />
+        <DropdownLabel>Website</DropdownLabel>
+      </DropdownItem>
       {showSecretariaat && (
-        <>
-          <DropdownDivider />
-          <DropdownItem href="/secretariaat">
-            <Cog6ToothIcon />
-            <DropdownLabel>Secretariaat</DropdownLabel>
-          </DropdownItem>
-        </>
+        <DropdownItem href="/secretariaat">
+          <Cog6ToothIcon />
+          <DropdownLabel>Secretariaat</DropdownLabel>
+        </DropdownItem>
       )}
       <DropdownDivider />
       <DropdownItem href="/account">

--- a/apps/web/src/app/(dashboard)/(management)/@sidebar/_components/user-selector.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/@sidebar/_components/user-selector.tsx
@@ -1,6 +1,8 @@
 import {
   ArrowRightStartOnRectangleIcon,
   ChevronUpIcon,
+  Cog6ToothIcon,
+  HomeIcon,
   ShieldCheckIcon,
   UserIcon,
   UsersIcon,
@@ -8,6 +10,7 @@ import {
 import { constants } from "@nawadi/lib";
 import { Suspense } from "react";
 import { Github } from "~/app/_components/socials";
+import { isSystemAdmin } from "~/lib/authorization";
 import { getUserOrThrow } from "~/lib/nwd";
 import { LogOutDropdownItem } from "../../../_components/auth";
 import { Avatar } from "../../../_components/avatar";
@@ -23,6 +26,7 @@ import { SidebarItem } from "../../../_components/sidebar";
 
 async function UserSelectorContent() {
   const currentUser = await getUserOrThrow();
+  const showSecretariaat = isSystemAdmin(currentUser.email);
 
   return (
     <Dropdown>
@@ -57,6 +61,17 @@ async function UserSelectorContent() {
           <UserIcon />
           <DropdownLabel>Mijn profiel</DropdownLabel>
         </DropdownItem>
+        <DropdownDivider />
+        <DropdownItem href="/">
+          <HomeIcon />
+          <DropdownLabel>Website</DropdownLabel>
+        </DropdownItem>
+        {showSecretariaat && (
+          <DropdownItem href="/secretariaat">
+            <Cog6ToothIcon />
+            <DropdownLabel>Secretariaat</DropdownLabel>
+          </DropdownItem>
+        )}
         <DropdownDivider />
         <DropdownItem href="/privacy" target="_blank">
           <ShieldCheckIcon />

--- a/apps/web/src/app/(dashboard)/(management)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/layout.tsx
@@ -1,5 +1,7 @@
 import {
   ArrowRightStartOnRectangleIcon,
+  Cog6ToothIcon,
+  HomeIcon,
   ShieldCheckIcon,
   UserIcon,
   UsersIcon,
@@ -7,6 +9,8 @@ import {
 import { constants } from "@nawadi/lib";
 import type React from "react";
 import { Github } from "~/app/_components/socials";
+import { isSystemAdmin } from "~/lib/authorization";
+import { getUserOrThrow } from "~/lib/nwd";
 import { LogOutDropdownItem } from "../_components/auth";
 import {
   Dropdown,
@@ -25,6 +29,49 @@ import {
 import { SidebarLayout } from "../_components/sidebar-layout";
 import { UserAvatar } from "../_components/user-avatar";
 
+async function UserDropdownMenu() {
+  const { email } = await getUserOrThrow();
+  const showSecretariaat = isSystemAdmin(email);
+
+  return (
+    <DropdownMenu className="min-w-64" anchor="bottom end">
+      <DropdownItem href="/account">
+        <UsersIcon />
+        <DropdownLabel>Mijn account</DropdownLabel>
+      </DropdownItem>
+      <DropdownItem href="/profiel">
+        <UserIcon />
+        <DropdownLabel>Mijn profiel</DropdownLabel>
+      </DropdownItem>
+      <DropdownDivider />
+      <DropdownItem href="/">
+        <HomeIcon />
+        <DropdownLabel>Website</DropdownLabel>
+      </DropdownItem>
+      {showSecretariaat && (
+        <DropdownItem href="/secretariaat">
+          <Cog6ToothIcon />
+          <DropdownLabel>Secretariaat</DropdownLabel>
+        </DropdownItem>
+      )}
+      <DropdownDivider />
+      <DropdownItem href="/privacy" target="_blank">
+        <ShieldCheckIcon />
+        <DropdownLabel>Privacyverklaring</DropdownLabel>
+      </DropdownItem>
+      <DropdownItem href={constants.GITHUB_URL} target="_blank">
+        <Github data-slot="icon" />
+        <DropdownLabel>GitHub</DropdownLabel>
+      </DropdownItem>
+      <DropdownDivider />
+      <LogOutDropdownItem>
+        <ArrowRightStartOnRectangleIcon />
+        <DropdownLabel>Uitloggen</DropdownLabel>
+      </LogOutDropdownItem>
+    </DropdownMenu>
+  );
+}
+
 export default function Layout({
   children,
   sidebar,
@@ -42,30 +89,7 @@ export default function Layout({
               <DropdownButton as={NavbarItem}>
                 <UserAvatar />
               </DropdownButton>
-              <DropdownMenu className="min-w-64" anchor="bottom end">
-                <DropdownItem href="/account">
-                  <UsersIcon />
-                  <DropdownLabel>Mijn account</DropdownLabel>
-                </DropdownItem>
-                <DropdownItem href="/profiel">
-                  <UserIcon />
-                  <DropdownLabel>Mijn profiel</DropdownLabel>
-                </DropdownItem>
-                <DropdownDivider />
-                <DropdownItem href="/privacy" target="_blank">
-                  <ShieldCheckIcon />
-                  <DropdownLabel>Privacyverklaring</DropdownLabel>
-                </DropdownItem>
-                <DropdownItem href={constants.GITHUB_URL} target="_blank">
-                  <Github data-slot="icon" />
-                  <DropdownLabel>GitHub</DropdownLabel>
-                </DropdownItem>
-                <DropdownDivider />
-                <LogOutDropdownItem>
-                  <ArrowRightStartOnRectangleIcon />
-                  <DropdownLabel>Uitloggen</DropdownLabel>
-                </LogOutDropdownItem>
-              </DropdownMenu>
+              <UserDropdownMenu />
             </Dropdown>
           </NavbarSection>
         </Navbar>


### PR DESCRIPTION
adds secretariaat button to management user menu as well as homepage button to all menu's

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds navigation items gated by `isSystemAdmin`; no data handling or auth flow changes beyond reusing existing admin check.
> 
> **Overview**
> Adds a new **"Website"** (`/`) link to dashboard user dropdown menus, including the account person selector (both empty and normal states) and management user menus.
> 
> Updates management user dropdowns to optionally show a **"Secretariaat"** (`/secretariaat`) link for system admins via `isSystemAdmin`, and refactors the management navbar menu into a dedicated `UserDropdownMenu` server component to support this conditional item.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2068a0b8625425decc11f770e8cf0010860d079. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->