### PR TITLE
[codex] Add duplicate person analysis scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ out/
 out-*/
 generated/
 coverage/
+merge-errors-*.txt
 
 !.vscode/
 !.github/

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -10,7 +10,9 @@
     "dev": "tsc --watch",
     "watch": "tsc --watch",
     "clean": "rm -rf out && tsc --build --clean",
-    "test": "node --test ./out/**/*.test.js"
+    "test": "node --test ./out/**/*.test.js",
+    "persons:duplicates:analyze": "tsx src/analyze-duplicate-persons.ts",
+    "persons:duplicates:merge": "tsx src/batch-merge-duplicates.ts"
   },
   "dependencies": {
     "@nawadi/core": "workspace:^",

--- a/packages/scripts/src/analyze-duplicate-persons.ts
+++ b/packages/scripts/src/analyze-duplicate-persons.ts
@@ -117,6 +117,10 @@ function parseOptions(args: string[]): Options {
   };
 
   for (const arg of args) {
+    if (arg === "--") {
+      continue;
+    }
+
     if (arg === "--json") {
       options.json = true;
       continue;

--- a/packages/scripts/src/analyze-duplicate-persons.ts
+++ b/packages/scripts/src/analyze-duplicate-persons.ts
@@ -4,6 +4,7 @@ import "dotenv/config";
 import assert from "node:assert";
 import { sql } from "drizzle-orm";
 import {
+  countCohortPersons,
   DEFAULT_ANALYZE_THRESHOLD,
   DEFAULT_LIMIT,
   findDuplicatePersonPairs,
@@ -14,6 +15,7 @@ type Options = {
   threshold: number;
   limit: number;
   json: boolean;
+  cohortId?: string;
 };
 
 async function main() {
@@ -23,10 +25,22 @@ async function main() {
 
   await withDatabase({ connectionString: pgUri }, async () => {
     const database = useDatabase();
-    const pairs = await findDuplicatePersonPairs(database, options);
+    const cohortPersonCount = options.cohortId
+      ? await countCohortPersons(database, options.cohortId)
+      : null;
+    const pairs =
+      cohortPersonCount === 0
+        ? []
+        : await findDuplicatePersonPairs(database, options);
 
     if (options.json) {
-      console.log(JSON.stringify({ options, pairs }, null, 2));
+      console.log(
+        JSON.stringify(
+          { options, scope: { cohortPersonCount }, pairs },
+          null,
+          2,
+        ),
+      );
       return;
     }
 
@@ -50,6 +64,10 @@ async function main() {
     console.log("=========================");
     console.log(`Threshold: ${options.threshold}`);
     console.log(`Limit: ${options.limit}`);
+    if (options.cohortId) {
+      console.log(`Cohort ID: ${options.cohortId}`);
+      console.log(`Active persons in cohort: ${cohortPersonCount}`);
+    }
     console.log("");
     console.log("Database statistics:");
     console.log(`- Total persons: ${stats.total_persons}`);
@@ -113,6 +131,10 @@ function parseOptions(args: string[]): Options {
       options.limit = parsePositiveInteger(value, "limit");
       continue;
     }
+    if ((name === "--cohort-id" || name === "--cohort") && value) {
+      options.cohortId = parseUuid(value, "cohort-id");
+      continue;
+    }
 
     if (arg === "--help" || arg === "-h") {
       printHelp();
@@ -133,6 +155,17 @@ function parsePositiveInteger(value: string, name: string) {
   return parsed;
 }
 
+function parseUuid(value: string, name: string) {
+  if (
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      value,
+    )
+  ) {
+    throw new Error(`--${name} must be a UUID`);
+  }
+  return value;
+}
+
 function printHelp() {
   console.log(`
 Usage:
@@ -141,6 +174,7 @@ Usage:
 Options:
   --threshold=N  Minimum score to show. Default: ${DEFAULT_ANALYZE_THRESHOLD}
   --limit=N      Maximum number of pairs. Default: ${DEFAULT_LIMIT}
+  --cohort-id=ID Only compare pairs where at least one person is allocated to this cohort.
   --json         Print raw JSON output.
 `);
 }

--- a/packages/scripts/src/analyze-duplicate-persons.ts
+++ b/packages/scripts/src/analyze-duplicate-persons.ts
@@ -1,0 +1,151 @@
+#!/usr/bin/env tsx
+import { useDatabase, withDatabase } from "@nawadi/core";
+import "dotenv/config";
+import assert from "node:assert";
+import { sql } from "drizzle-orm";
+import {
+  DEFAULT_ANALYZE_THRESHOLD,
+  DEFAULT_LIMIT,
+  findDuplicatePersonPairs,
+  formatPerson,
+} from "./utils/duplicate-person-detection.js";
+
+type Options = {
+  threshold: number;
+  limit: number;
+  json: boolean;
+};
+
+async function main() {
+  const options = parseOptions(process.argv.slice(2));
+  const pgUri = process.env.PGURI;
+  assert(pgUri, "PGURI environment variable is required");
+
+  await withDatabase({ connectionString: pgUri }, async () => {
+    const database = useDatabase();
+    const pairs = await findDuplicatePersonPairs(database, options);
+
+    if (options.json) {
+      console.log(JSON.stringify({ options, pairs }, null, 2));
+      return;
+    }
+
+    const statsResult = await database.execute(sql`
+      SELECT
+        COUNT(*)::int AS total_persons,
+        COUNT(*) FILTER (WHERE user_id IS NOT NULL)::int AS persons_with_user,
+        COUNT(*) FILTER (WHERE user_id IS NULL)::int AS persons_without_user,
+        COUNT(DISTINCT LOWER(CONCAT(first_name, ' ', last_name)))::int AS unique_name_combinations
+      FROM person
+      WHERE deleted_at IS NULL
+    `);
+    const stats = statsResult.rows[0] as {
+      total_persons: number;
+      persons_with_user: number;
+      persons_without_user: number;
+      unique_name_combinations: number;
+    };
+
+    console.log("Duplicate person analysis");
+    console.log("=========================");
+    console.log(`Threshold: ${options.threshold}`);
+    console.log(`Limit: ${options.limit}`);
+    console.log("");
+    console.log("Database statistics:");
+    console.log(`- Total persons: ${stats.total_persons}`);
+    console.log(`- Persons with linked user: ${stats.persons_with_user}`);
+    console.log(`- Persons without linked user: ${stats.persons_without_user}`);
+    console.log(
+      `- Unique name combinations: ${stats.unique_name_combinations}`,
+    );
+    console.log("");
+
+    if (pairs.length === 0) {
+      console.log("No potential duplicates found.");
+      return;
+    }
+
+    console.log(`Found ${pairs.length} potential duplicate pairs.`);
+    console.log("");
+
+    for (const [index, pair] of pairs.entries()) {
+      console.log(
+        `${index + 1}. Score ${pair.score}: ${pair.matchReasons.join(", ")}`,
+      );
+      if (pair.riskFlags.length > 0) {
+        console.log(`   Risks: ${pair.riskFlags.join(", ")}`);
+      }
+      console.log(`   1: ${formatPerson(pair.persons[0])}`);
+      console.log(`   2: ${formatPerson(pair.persons[1])}`);
+      console.log("");
+    }
+
+    const highConfidence = pairs.filter((pair) => pair.score >= 150).length;
+    const manualReview = pairs.filter((pair) =>
+      pair.riskFlags.includes("different linked users"),
+    ).length;
+
+    console.log("Summary:");
+    console.log(`- High confidence (score >= 150): ${highConfidence}`);
+    console.log(`- Requires manual user-account review: ${manualReview}`);
+  });
+}
+
+function parseOptions(args: string[]): Options {
+  const options: Options = {
+    threshold: DEFAULT_ANALYZE_THRESHOLD,
+    limit: DEFAULT_LIMIT,
+    json: false,
+  };
+
+  for (const arg of args) {
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+
+    const [name, value] = arg.split("=");
+    if (name === "--threshold" && value) {
+      options.threshold = parsePositiveInteger(value, "threshold");
+      continue;
+    }
+    if (name === "--limit" && value) {
+      options.limit = parsePositiveInteger(value, "limit");
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function parsePositiveInteger(value: string, name: string) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`--${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function printHelp() {
+  console.log(`
+Usage:
+  pnpm --filter @nawadi/scripts persons:duplicates:analyze [options]
+
+Options:
+  --threshold=N  Minimum score to show. Default: ${DEFAULT_ANALYZE_THRESHOLD}
+  --limit=N      Maximum number of pairs. Default: ${DEFAULT_LIMIT}
+  --json         Print raw JSON output.
+`);
+}
+
+main().catch((error) => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});

--- a/packages/scripts/src/batch-merge-duplicates.ts
+++ b/packages/scripts/src/batch-merge-duplicates.ts
@@ -1,0 +1,324 @@
+#!/usr/bin/env tsx
+import { User, useDatabase, withDatabase } from "@nawadi/core";
+import "dotenv/config";
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import path from "node:path";
+import inquirer from "inquirer";
+import {
+  chooseDefaultMerge,
+  DEFAULT_AUTO_MERGE_THRESHOLD,
+  DEFAULT_LIMIT,
+  DEFAULT_MERGE_THRESHOLD,
+  type DuplicatePersonPair,
+  findDuplicatePersonPairs,
+  formatPerson,
+  isAutoMergeSafe,
+} from "./utils/duplicate-person-detection.js";
+
+type Options = {
+  execute: boolean;
+  yes: boolean;
+  threshold: number;
+  autoThreshold: number;
+  limit: number;
+};
+
+type ErrorReport = {
+  timestamp: string;
+  personId: string;
+  targetPersonId: string;
+  score: number;
+  error: string;
+};
+
+async function main() {
+  const options = parseOptions(process.argv.slice(2));
+  const pgUri = process.env.PGURI;
+  assert(pgUri, "PGURI environment variable is required");
+
+  await withDatabase({ connectionString: pgUri }, async () => {
+    const database = useDatabase();
+    const pairs = await findDuplicatePersonPairs(database, {
+      threshold: options.threshold,
+      limit: options.limit,
+    });
+
+    console.log("Batch duplicate person merge");
+    console.log("============================");
+    console.log(`Mode: ${options.execute ? "execute" : "dry run"}`);
+    console.log(`Review threshold: ${options.threshold}`);
+    console.log(`Auto-merge threshold: ${options.autoThreshold}`);
+    console.log(`Limit: ${options.limit}`);
+    console.log("");
+
+    if (pairs.length === 0) {
+      console.log("No duplicate pairs found.");
+      return;
+    }
+
+    console.log(`Found ${pairs.length} duplicate pairs.`);
+
+    if (!options.execute) {
+      printDryRun(pairs, options);
+      return;
+    }
+
+    if (!options.yes) {
+      const { proceed } = await inquirer.prompt([
+        {
+          type: "confirm",
+          name: "proceed",
+          message:
+            "This will merge duplicate person records in the database. Continue?",
+          default: false,
+        },
+      ]);
+
+      if (!proceed) {
+        console.log("Operation cancelled.");
+        return;
+      }
+    }
+
+    const errorReports: ErrorReport[] = [];
+    let successCount = 0;
+    let skippedCount = 0;
+
+    for (const [index, pair] of pairs.entries()) {
+      const plan = chooseDefaultMerge(pair);
+      const auto = isAutoMergeSafe(pair, options.autoThreshold);
+      let keep = plan.keep;
+      let shouldMerge = auto.safe;
+
+      console.log("");
+      printPair(pair, index + 1, pairs.length);
+      console.log(`Default: keep record ${plan.keep + 1} (${plan.reason})`);
+
+      if (auto.safe) {
+        console.log(`Auto-merge: ${auto.reason}`);
+      } else if (options.yes) {
+        console.log(`Skip: ${auto.reason}`);
+        skippedCount++;
+        continue;
+      } else {
+        const response = await inquirer.prompt([
+          {
+            type: "list",
+            name: "action",
+            message: `Action for score ${pair.score}?`,
+            choices: [
+              {
+                name: `Merge - keep record 1 (${pair.persons[0].fullName})`,
+                value: "merge-keep-1",
+              },
+              {
+                name: `Merge - keep record 2 (${pair.persons[1].fullName})`,
+                value: "merge-keep-2",
+              },
+              { name: "Skip", value: "skip" },
+              { name: "Quit", value: "quit" },
+            ],
+            default: "skip",
+          },
+        ]);
+
+        if (response.action === "quit") break;
+        if (response.action === "skip") {
+          skippedCount++;
+          continue;
+        }
+
+        keep = response.action === "merge-keep-1" ? 0 : 1;
+        shouldMerge = true;
+      }
+
+      if (!shouldMerge) {
+        skippedCount++;
+        continue;
+      }
+
+      const targetPersonId = pair.persons[keep].id;
+      const personId = pair.persons[keep === 0 ? 1 : 0].id;
+
+      try {
+        console.log(`Merging ${personId} into ${targetPersonId}...`);
+        await User.Person.mergePersons({ personId, targetPersonId });
+        successCount++;
+        console.log("Merged.");
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        console.error(`Merge failed: ${errorMessage}`);
+        errorReports.push({
+          timestamp: new Date().toISOString(),
+          personId,
+          targetPersonId,
+          score: pair.score,
+          error: errorMessage,
+        });
+
+        if (!options.yes) {
+          const { errorAction } = await inquirer.prompt([
+            {
+              type: "list",
+              name: "errorAction",
+              message: "Continue after this error?",
+              choices: [
+                { name: "Continue", value: "continue" },
+                { name: "Quit", value: "quit" },
+              ],
+              default: "continue",
+            },
+          ]);
+
+          if (errorAction === "quit") break;
+        }
+      }
+    }
+
+    console.log("");
+    console.log("Summary:");
+    console.log(`- Merged: ${successCount}`);
+    console.log(`- Skipped: ${skippedCount}`);
+    console.log(`- Errors: ${errorReports.length}`);
+
+    if (errorReports.length > 0) {
+      const reportPath = await writeErrorReport(errorReports);
+      console.log(`- Error report: ${reportPath}`);
+    }
+  });
+}
+
+function printDryRun(pairs: DuplicatePersonPair[], options: Options) {
+  console.log("");
+  console.log("Dry-run plan:");
+  console.log("Use --execute to actually merge records.");
+  console.log("");
+
+  let autoCount = 0;
+  let reviewCount = 0;
+
+  for (const [index, pair] of pairs.entries()) {
+    const plan = chooseDefaultMerge(pair);
+    const auto = isAutoMergeSafe(pair, options.autoThreshold);
+    if (auto.safe) autoCount++;
+    else reviewCount++;
+
+    printPair(pair, index + 1, pairs.length);
+    console.log(`Default: keep record ${plan.keep + 1} (${plan.reason})`);
+    console.log(`Action: ${auto.safe ? "auto-merge candidate" : auto.reason}`);
+    console.log("");
+  }
+
+  console.log("Dry-run summary:");
+  console.log(`- Auto-merge candidates: ${autoCount}`);
+  console.log(`- Manual review needed: ${reviewCount}`);
+}
+
+function printPair(pair: DuplicatePersonPair, index: number, total: number) {
+  console.log(`[${index}/${total}] Score ${pair.score}`);
+  console.log(`Reasons: ${pair.matchReasons.join(", ")}`);
+  if (pair.riskFlags.length > 0) {
+    console.log(`Risks: ${pair.riskFlags.join(", ")}`);
+  }
+  console.log(`1: ${formatPerson(pair.persons[0])}`);
+  console.log(`2: ${formatPerson(pair.persons[1])}`);
+}
+
+function parseOptions(args: string[]): Options {
+  const options: Options = {
+    execute: false,
+    yes: false,
+    threshold: DEFAULT_MERGE_THRESHOLD,
+    autoThreshold: DEFAULT_AUTO_MERGE_THRESHOLD,
+    limit: DEFAULT_LIMIT,
+  };
+
+  for (const arg of args) {
+    if (arg === "--execute") {
+      options.execute = true;
+      continue;
+    }
+    if (arg === "--yes") {
+      options.yes = true;
+      continue;
+    }
+
+    const [name, value] = arg.split("=");
+    if (name === "--threshold" && value) {
+      options.threshold = parsePositiveInteger(value, "threshold");
+      continue;
+    }
+    if (name === "--auto-threshold" && value) {
+      options.autoThreshold = parsePositiveInteger(value, "auto-threshold");
+      continue;
+    }
+    if (name === "--limit" && value) {
+      options.limit = parsePositiveInteger(value, "limit");
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function parsePositiveInteger(value: string, name: string) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`--${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+async function writeErrorReport(errorReports: ErrorReport[]) {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const reportPath = path.join(process.cwd(), `merge-errors-${timestamp}.txt`);
+
+  const lines = [
+    "PERSON MERGE ERROR REPORT",
+    `Generated: ${new Date().toISOString()}`,
+    `Total errors: ${errorReports.length}`,
+    "=".repeat(60),
+    "",
+  ];
+
+  for (const report of errorReports) {
+    lines.push(`Timestamp: ${report.timestamp}`);
+    lines.push(`Score: ${report.score}`);
+    lines.push(`Person ID: ${report.personId}`);
+    lines.push(`Target Person ID: ${report.targetPersonId}`);
+    lines.push(`Error: ${report.error}`);
+    lines.push("-".repeat(60));
+    lines.push("");
+  }
+
+  await fs.writeFile(reportPath, lines.join("\n"), "utf-8");
+  return reportPath;
+}
+
+function printHelp() {
+  console.log(`
+Usage:
+  pnpm --filter @nawadi/scripts persons:duplicates:merge [options]
+
+Options:
+  --execute           Actually merge records. Without this, the script is a dry run.
+  --yes               Do not prompt. Merges only auto-safe pairs and skips the rest.
+  --threshold=N       Minimum score to review. Default: ${DEFAULT_MERGE_THRESHOLD}
+  --auto-threshold=N  Minimum score for auto-merge candidates. Default: ${DEFAULT_AUTO_MERGE_THRESHOLD}
+  --limit=N           Maximum number of pairs. Default: ${DEFAULT_LIMIT}
+`);
+}
+
+main().catch((error) => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});

--- a/packages/scripts/src/batch-merge-duplicates.ts
+++ b/packages/scripts/src/batch-merge-duplicates.ts
@@ -6,12 +6,15 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import inquirer from "inquirer";
 import {
+  buildDuplicatePersonPairKey,
   chooseDefaultMerge,
+  countCohortPersons,
   DEFAULT_AUTO_MERGE_THRESHOLD,
   DEFAULT_LIMIT,
   DEFAULT_MERGE_THRESHOLD,
   type DuplicatePersonPair,
   findDuplicatePersonPairs,
+  findStudentCurriculumConflictPairKeys,
   formatPerson,
   isAutoMergeSafe,
 } from "./utils/duplicate-person-detection.js";
@@ -22,6 +25,7 @@ type Options = {
   threshold: number;
   autoThreshold: number;
   limit: number;
+  cohortId?: string;
 };
 
 type ErrorReport = {
@@ -39,10 +43,21 @@ async function main() {
 
   await withDatabase({ connectionString: pgUri }, async () => {
     const database = useDatabase();
-    const pairs = await findDuplicatePersonPairs(database, {
-      threshold: options.threshold,
-      limit: options.limit,
-    });
+    const cohortPersonCount = options.cohortId
+      ? await countCohortPersons(database, options.cohortId)
+      : null;
+    const pairs =
+      cohortPersonCount === 0
+        ? []
+        : await findDuplicatePersonPairs(database, {
+            threshold: options.threshold,
+            limit: options.limit,
+            cohortId: options.cohortId,
+          });
+    const curriculumConflictKeys = await findStudentCurriculumConflictPairKeys(
+      database,
+      pairs,
+    );
 
     console.log("Batch duplicate person merge");
     console.log("============================");
@@ -50,6 +65,10 @@ async function main() {
     console.log(`Review threshold: ${options.threshold}`);
     console.log(`Auto-merge threshold: ${options.autoThreshold}`);
     console.log(`Limit: ${options.limit}`);
+    if (options.cohortId) {
+      console.log(`Cohort ID: ${options.cohortId}`);
+      console.log(`Active persons in cohort: ${cohortPersonCount}`);
+    }
     console.log("");
 
     if (pairs.length === 0) {
@@ -60,7 +79,7 @@ async function main() {
     console.log(`Found ${pairs.length} duplicate pairs.`);
 
     if (!options.execute) {
-      printDryRun(pairs, options);
+      printDryRun(pairs, options, curriculumConflictKeys);
       return;
     }
 
@@ -82,18 +101,37 @@ async function main() {
     }
 
     const errorReports: ErrorReport[] = [];
+    const processedPersonIds = new Set<string>();
     let successCount = 0;
     let skippedCount = 0;
 
     for (const [index, pair] of pairs.entries()) {
+      if (pair.persons.some((person) => processedPersonIds.has(person.id))) {
+        console.log("");
+        printPair(pair, index + 1, pairs.length);
+        console.log("Skip: one of these records was already merged.");
+        skippedCount++;
+        continue;
+      }
+
       const plan = chooseDefaultMerge(pair);
-      const auto = isAutoMergeSafe(pair, options.autoThreshold);
+      const mergeBlockers = getMergeBlockers(pair, curriculumConflictKeys);
+      const auto =
+        mergeBlockers.length > 0
+          ? { safe: false, reason: mergeBlockers.join(", ") }
+          : isAutoMergeSafe(pair, options.autoThreshold);
       let keep = plan.keep;
       let shouldMerge = auto.safe;
 
       console.log("");
       printPair(pair, index + 1, pairs.length);
       console.log(`Default: keep record ${plan.keep + 1} (${plan.reason})`);
+
+      if (mergeBlockers.length > 0) {
+        console.log(`Skip: ${auto.reason}`);
+        skippedCount++;
+        continue;
+      }
 
       if (auto.safe) {
         console.log(`Auto-merge: ${auto.reason}`);
@@ -144,6 +182,8 @@ async function main() {
       try {
         console.log(`Merging ${personId} into ${targetPersonId}...`);
         await User.Person.mergePersons({ personId, targetPersonId });
+        processedPersonIds.add(personId);
+        processedPersonIds.add(targetPersonId);
         successCount++;
         console.log("Merged.");
       } catch (error) {
@@ -190,7 +230,11 @@ async function main() {
   });
 }
 
-function printDryRun(pairs: DuplicatePersonPair[], options: Options) {
+function printDryRun(
+  pairs: DuplicatePersonPair[],
+  options: Options,
+  curriculumConflictKeys: Set<string>,
+) {
   console.log("");
   console.log("Dry-run plan:");
   console.log("Use --execute to actually merge records.");
@@ -198,22 +242,34 @@ function printDryRun(pairs: DuplicatePersonPair[], options: Options) {
 
   let autoCount = 0;
   let reviewCount = 0;
+  let blockedCount = 0;
 
   for (const [index, pair] of pairs.entries()) {
     const plan = chooseDefaultMerge(pair);
-    const auto = isAutoMergeSafe(pair, options.autoThreshold);
-    if (auto.safe) autoCount++;
+    const mergeBlockers = getMergeBlockers(pair, curriculumConflictKeys);
+    const auto =
+      mergeBlockers.length > 0
+        ? { safe: false, reason: mergeBlockers.join(", ") }
+        : isAutoMergeSafe(pair, options.autoThreshold);
+    if (mergeBlockers.length > 0) blockedCount++;
+    else if (auto.safe) autoCount++;
     else reviewCount++;
 
     printPair(pair, index + 1, pairs.length);
     console.log(`Default: keep record ${plan.keep + 1} (${plan.reason})`);
-    console.log(`Action: ${auto.safe ? "auto-merge candidate" : auto.reason}`);
+    console.log(
+      `Action: ${mergeBlockers.length > 0 ? "blocked" : auto.safe ? "auto-merge candidate" : auto.reason}`,
+    );
+    if (mergeBlockers.length > 0) {
+      console.log(`Blockers: ${mergeBlockers.join(", ")}`);
+    }
     console.log("");
   }
 
   console.log("Dry-run summary:");
   console.log(`- Auto-merge candidates: ${autoCount}`);
   console.log(`- Manual review needed: ${reviewCount}`);
+  console.log(`- Blocked by known merge constraints: ${blockedCount}`);
 }
 
 function printPair(pair: DuplicatePersonPair, index: number, total: number) {
@@ -258,6 +314,10 @@ function parseOptions(args: string[]): Options {
       options.limit = parsePositiveInteger(value, "limit");
       continue;
     }
+    if ((name === "--cohort-id" || name === "--cohort") && value) {
+      options.cohortId = parseUuid(value, "cohort-id");
+      continue;
+    }
 
     if (arg === "--help" || arg === "-h") {
       printHelp();
@@ -276,6 +336,30 @@ function parsePositiveInteger(value: string, name: string) {
     throw new Error(`--${name} must be a positive integer`);
   }
   return parsed;
+}
+
+function parseUuid(value: string, name: string) {
+  if (
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      value,
+    )
+  ) {
+    throw new Error(`--${name} must be a UUID`);
+  }
+  return value;
+}
+
+function getMergeBlockers(
+  pair: DuplicatePersonPair,
+  curriculumConflictKeys: Set<string>,
+): string[] {
+  const blockers: string[] = [];
+
+  if (curriculumConflictKeys.has(buildDuplicatePersonPairKey(pair))) {
+    blockers.push("student curriculum conflict requires a merge fix first");
+  }
+
+  return blockers;
 }
 
 async function writeErrorReport(errorReports: ErrorReport[]) {
@@ -315,6 +399,7 @@ Options:
   --threshold=N       Minimum score to review. Default: ${DEFAULT_MERGE_THRESHOLD}
   --auto-threshold=N  Minimum score for auto-merge candidates. Default: ${DEFAULT_AUTO_MERGE_THRESHOLD}
   --limit=N           Maximum number of pairs. Default: ${DEFAULT_LIMIT}
+  --cohort-id=ID      Only compare pairs where at least one person is allocated to this cohort.
 `);
 }
 

--- a/packages/scripts/src/batch-merge-duplicates.ts
+++ b/packages/scripts/src/batch-merge-duplicates.ts
@@ -292,6 +292,10 @@ function parseOptions(args: string[]): Options {
   };
 
   for (const arg of args) {
+    if (arg === "--") {
+      continue;
+    }
+
     if (arg === "--execute") {
       options.execute = true;
       continue;

--- a/packages/scripts/src/utils/duplicate-person-detection.ts
+++ b/packages/scripts/src/utils/duplicate-person-detection.ts
@@ -66,9 +66,70 @@ type DuplicatePersonRow = {
 export function buildDuplicatePersonQuery(args: {
   threshold: number;
   limit: number;
+  cohortId?: string;
 }): SQL {
+  const cohortCandidateFilter = args.cohortId
+    ? sql`
+        AND (
+          EXISTS (
+            SELECT 1
+            FROM cohort_person_ids cpi
+            WHERE cpi.id = p.id
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM cohort_persons cp
+            WHERE cp.id <> p.id
+              AND cp.user_id IS NOT NULL
+              AND cp.user_id = p.user_id
+          )
+          OR EXISTS (
+            SELECT 1
+            FROM cohort_persons cp
+            WHERE cp.id <> p.id
+              AND cp.date_of_birth IS NOT NULL
+              AND p.date_of_birth IS NOT NULL
+              AND ABS(cp.date_of_birth::date - p.date_of_birth::date) <= 365
+          )
+        )
+      `
+    : sql``;
+  const scopedPairFilter = args.cohortId
+    ? sql`AND (p1.in_scope OR p2.in_scope)`
+    : sql``;
+
   return sql`
-    WITH normalized_persons AS (
+    WITH cohort_person_ids AS (
+      ${
+        args.cohortId
+          ? sql`
+              SELECT DISTINCT a.person_id AS id
+              FROM cohort_allocation ca
+              INNER JOIN actor a ON a.id = ca.actor_id
+              INNER JOIN cohort c ON c.id = ca.cohort_id
+              WHERE ca.cohort_id = ${args.cohortId}
+                AND ca.deleted_at IS NULL
+                AND a.deleted_at IS NULL
+                AND a.person_id IS NOT NULL
+                AND c.deleted_at IS NULL
+            `
+          : sql`SELECT NULL::uuid AS id WHERE FALSE`
+      }
+    ),
+    cohort_persons AS (
+      SELECT
+        p.id,
+        p.user_id,
+        p.first_name,
+        p.last_name,
+        p.last_name_prefix,
+        p.date_of_birth
+      FROM person p
+      INNER JOIN cohort_person_ids cpi ON cpi.id = p.id
+      WHERE p.deleted_at IS NULL
+        AND p.first_name IS NOT NULL
+    ),
+    normalized_persons AS (
       SELECT
         p.id,
         p.handle,
@@ -82,6 +143,11 @@ export function buildDuplicatePersonQuery(args: {
         p.created_at,
         p.deleted_at,
         u.email,
+        EXISTS (
+          SELECT 1
+          FROM cohort_person_ids cpi
+          WHERE cpi.id = p.id
+        ) AS in_scope,
         TRIM(CONCAT(
           COALESCE(p.first_name, ''),
           ' ',
@@ -101,6 +167,7 @@ export function buildDuplicatePersonQuery(args: {
       LEFT JOIN "user" u ON p.user_id = u.auth_user_id
       WHERE p.deleted_at IS NULL
         AND p.first_name IS NOT NULL
+        ${cohortCandidateFilter}
     ),
     same_user_matches AS (
       SELECT
@@ -170,7 +237,9 @@ export function buildDuplicatePersonQuery(args: {
           ELSE 0
         END AS score
       FROM normalized_persons p1
-      JOIN normalized_persons p2 ON p1.user_id = p2.user_id AND p1.id < p2.id
+      JOIN normalized_persons p2 ON p1.user_id = p2.user_id
+        AND p1.id < p2.id
+        ${scopedPairFilter}
       WHERE p1.user_id IS NOT NULL
         AND (
           p1.first_norm = p2.first_norm
@@ -234,6 +303,7 @@ export function buildDuplicatePersonQuery(args: {
         END AS score
       FROM normalized_persons p1
       JOIN normalized_persons p2 ON p1.id < p2.id
+        ${scopedPairFilter}
         AND p1.first_norm <> ''
         AND p1.first_norm = p2.first_norm
         AND (
@@ -273,15 +343,77 @@ export async function findDuplicatePersonPairs(
   args: {
     threshold?: number;
     limit?: number;
+    cohortId?: string;
   } = {},
 ): Promise<DuplicatePersonPair[]> {
   const threshold = args.threshold ?? DEFAULT_ANALYZE_THRESHOLD;
   const limit = args.limit ?? DEFAULT_LIMIT;
   const result = await database.execute(
-    buildDuplicatePersonQuery({ threshold, limit }),
+    buildDuplicatePersonQuery({ threshold, limit, cohortId: args.cohortId }),
   );
 
   return (result.rows as unknown as DuplicatePersonRow[]).map(mapRowToPair);
+}
+
+export async function countCohortPersons(
+  database: Database,
+  cohortId: string,
+): Promise<number> {
+  const result = await database.execute(sql`
+    SELECT COUNT(DISTINCT a.person_id)::int AS count
+    FROM cohort_allocation ca
+    INNER JOIN actor a ON a.id = ca.actor_id
+    INNER JOIN cohort c ON c.id = ca.cohort_id
+    INNER JOIN person p ON p.id = a.person_id
+    WHERE ca.cohort_id = ${cohortId}
+      AND ca.deleted_at IS NULL
+      AND a.deleted_at IS NULL
+      AND a.person_id IS NOT NULL
+      AND c.deleted_at IS NULL
+      AND p.deleted_at IS NULL
+  `);
+
+  const row = result.rows[0] as { count?: number | string } | undefined;
+  return Number(row?.count ?? 0);
+}
+
+export async function findStudentCurriculumConflictPairKeys(
+  database: Database,
+  pairs: DuplicatePersonPair[],
+): Promise<Set<string>> {
+  if (pairs.length === 0) {
+    return new Set();
+  }
+
+  const pairValues = pairs.map(
+    (pair) => sql`(${pair.persons[0].id}::uuid, ${pair.persons[1].id}::uuid)`,
+  );
+
+  const result = await database.execute(sql`
+    WITH pairs(person_id1, person_id2) AS (
+      VALUES ${sql.join(pairValues, sql`, `)}
+    )
+    SELECT person_id1::text, person_id2::text
+    FROM pairs
+    WHERE EXISTS (
+      SELECT 1
+      FROM student_curriculum sc1
+      INNER JOIN student_curriculum sc2
+        ON sc1.curriculum_id = sc2.curriculum_id
+        AND sc1.gear_type_id = sc2.gear_type_id
+      WHERE sc1.person_id = person_id1
+        AND sc2.person_id = person_id2
+    )
+  `);
+
+  return new Set(
+    (
+      result.rows as {
+        person_id1: string;
+        person_id2: string;
+      }[]
+    ).map((row) => buildPersonPairKey(row.person_id1, row.person_id2)),
+  );
 }
 
 export function chooseDefaultMerge(pair: DuplicatePersonPair): {
@@ -365,6 +497,14 @@ export function formatPerson(person: DuplicatePerson): string {
   const primary = person.isPrimary ? "primary" : "not primary";
 
   return `${person.fullName} (${dob}) ${handle} [${email}, ${primary}] ${person.id}`;
+}
+
+export function buildDuplicatePersonPairKey(pair: DuplicatePersonPair): string {
+  return buildPersonPairKey(pair.persons[0].id, pair.persons[1].id);
+}
+
+function buildPersonPairKey(personId1: string, personId2: string): string {
+  return [personId1, personId2].sort().join(":");
 }
 
 function mapRowToPair(row: DuplicatePersonRow): DuplicatePersonPair {

--- a/packages/scripts/src/utils/duplicate-person-detection.ts
+++ b/packages/scripts/src/utils/duplicate-person-detection.ts
@@ -1,0 +1,448 @@
+import type { Database } from "@nawadi/db";
+import { type SQL, sql } from "drizzle-orm";
+
+export const DEFAULT_ANALYZE_THRESHOLD = 100;
+export const DEFAULT_MERGE_THRESHOLD = 150;
+export const DEFAULT_AUTO_MERGE_THRESHOLD = 180;
+export const DEFAULT_LIMIT = 1000;
+
+export type DuplicatePerson = {
+  id: string;
+  handle: string | null;
+  firstName: string;
+  lastName: string | null;
+  lastNamePrefix: string | null;
+  fullName: string;
+  email: string | null;
+  userId: string | null;
+  isPrimary: boolean;
+  dateOfBirth: string | null;
+  birthCity: string | null;
+  createdAt: Date;
+};
+
+export type DuplicatePersonPair = {
+  score: number;
+  matchReasons: string[];
+  riskFlags: string[];
+  persons: [DuplicatePerson, DuplicatePerson];
+};
+
+type DuplicatePersonRow = {
+  id1: string;
+  handle1: string | null;
+  first_name1: string;
+  last_name1: string | null;
+  last_name_prefix1: string | null;
+  full_name1: string;
+  email1: string | null;
+  user_id1: string | null;
+  is_primary1: boolean;
+  date_of_birth1: string | null;
+  birth_city1: string | null;
+  created_at1: Date;
+  id2: string;
+  handle2: string | null;
+  first_name2: string;
+  last_name2: string | null;
+  last_name_prefix2: string | null;
+  full_name2: string;
+  email2: string | null;
+  user_id2: string | null;
+  is_primary2: boolean;
+  date_of_birth2: string | null;
+  birth_city2: string | null;
+  created_at2: Date;
+  score: number | string;
+  same_user: boolean;
+  same_first_name: boolean;
+  similar_first_name: boolean;
+  same_last_name: boolean;
+  same_birth_date: boolean;
+  close_birth_date: boolean;
+  same_birth_city: boolean;
+};
+
+export function buildDuplicatePersonQuery(args: {
+  threshold: number;
+  limit: number;
+}): SQL {
+  return sql`
+    WITH normalized_persons AS (
+      SELECT
+        p.id,
+        p.handle,
+        p.user_id,
+        p.first_name,
+        p.last_name,
+        p.last_name_prefix,
+        p.date_of_birth,
+        p.birth_city,
+        p.is_primary,
+        p.created_at,
+        p.deleted_at,
+        u.email,
+        TRIM(CONCAT(
+          COALESCE(p.first_name, ''),
+          ' ',
+          COALESCE(p.last_name_prefix, ''),
+          CASE WHEN p.last_name_prefix IS NOT NULL THEN ' ' ELSE '' END,
+          COALESCE(p.last_name, '')
+        )) AS full_name,
+        LOWER(REGEXP_REPLACE(COALESCE(p.first_name, ''), '[^[:alnum:]]+', '', 'g')) AS first_norm,
+        LOWER(REGEXP_REPLACE(COALESCE(p.last_name, ''), '[^[:alnum:]]+', '', 'g')) AS last_norm,
+        LOWER(REGEXP_REPLACE(TRIM(CONCAT(
+          COALESCE(p.last_name_prefix, ''),
+          CASE WHEN p.last_name_prefix IS NOT NULL THEN ' ' ELSE '' END,
+          COALESCE(p.last_name, '')
+        )), '[^[:alnum:]]+', '', 'g')) AS full_last_norm,
+        LOWER(REGEXP_REPLACE(COALESCE(p.birth_city, ''), '[^[:alnum:]]+', '', 'g')) AS birth_city_norm
+      FROM person p
+      LEFT JOIN "user" u ON p.user_id = u.auth_user_id
+      WHERE p.deleted_at IS NULL
+        AND p.first_name IS NOT NULL
+    ),
+    same_user_matches AS (
+      SELECT
+        p1.id AS id1,
+        p1.handle AS handle1,
+        p1.first_name AS first_name1,
+        p1.last_name AS last_name1,
+        p1.last_name_prefix AS last_name_prefix1,
+        p1.full_name AS full_name1,
+        p1.email AS email1,
+        p1.user_id AS user_id1,
+        p1.is_primary AS is_primary1,
+        p1.date_of_birth AS date_of_birth1,
+        p1.birth_city AS birth_city1,
+        p1.created_at AS created_at1,
+        p2.id AS id2,
+        p2.handle AS handle2,
+        p2.first_name AS first_name2,
+        p2.last_name AS last_name2,
+        p2.last_name_prefix AS last_name_prefix2,
+        p2.full_name AS full_name2,
+        p2.email AS email2,
+        p2.user_id AS user_id2,
+        p2.is_primary AS is_primary2,
+        p2.date_of_birth AS date_of_birth2,
+        p2.birth_city AS birth_city2,
+        p2.created_at AS created_at2,
+        TRUE AS same_user,
+        p1.first_norm = p2.first_norm AS same_first_name,
+        LEFT(p1.first_norm, 3) = LEFT(p2.first_norm, 3) AS similar_first_name,
+        p1.full_last_norm = p2.full_last_norm OR p1.last_norm = p2.last_norm AS same_last_name,
+        p1.date_of_birth IS NOT NULL
+          AND p1.date_of_birth = p2.date_of_birth AS same_birth_date,
+        p1.date_of_birth IS NOT NULL
+          AND p2.date_of_birth IS NOT NULL
+          AND ABS(p1.date_of_birth::date - p2.date_of_birth::date) <= 7 AS close_birth_date,
+        p1.birth_city_norm <> ''
+          AND p1.birth_city_norm = p2.birth_city_norm AS same_birth_city,
+        50 +
+        CASE
+          WHEN p1.first_norm = p2.first_norm THEN 50
+          WHEN LENGTH(p1.first_norm) >= 3
+            AND LENGTH(p2.first_norm) >= 3
+            AND LEFT(p1.first_norm, 3) = LEFT(p2.first_norm, 3) THEN 20
+          ELSE 0
+        END +
+        CASE
+          WHEN p1.full_last_norm <> '' AND p1.full_last_norm = p2.full_last_norm THEN 50
+          WHEN p1.last_norm <> '' AND p1.last_norm = p2.last_norm THEN 40
+          ELSE 0
+        END +
+        CASE
+          WHEN p1.date_of_birth IS NOT NULL AND p1.date_of_birth = p2.date_of_birth THEN 50
+          WHEN p1.date_of_birth IS NOT NULL
+            AND p2.date_of_birth IS NOT NULL
+            AND ABS(p1.date_of_birth::date - p2.date_of_birth::date) <= 1 THEN 40
+          WHEN p1.date_of_birth IS NOT NULL
+            AND p2.date_of_birth IS NOT NULL
+            AND ABS(p1.date_of_birth::date - p2.date_of_birth::date) <= 7 THEN 30
+          WHEN p1.date_of_birth IS NOT NULL
+            AND p2.date_of_birth IS NOT NULL
+            AND EXTRACT(YEAR FROM p1.date_of_birth::date) = EXTRACT(YEAR FROM p2.date_of_birth::date) THEN 20
+          ELSE 0
+        END +
+        CASE
+          WHEN p1.birth_city_norm <> '' AND p1.birth_city_norm = p2.birth_city_norm THEN 10
+          ELSE 0
+        END AS score
+      FROM normalized_persons p1
+      JOIN normalized_persons p2 ON p1.user_id = p2.user_id AND p1.id < p2.id
+      WHERE p1.user_id IS NOT NULL
+        AND (
+          p1.first_norm = p2.first_norm
+          OR (
+            LENGTH(p1.first_norm) >= 3
+            AND LENGTH(p2.first_norm) >= 3
+            AND LEFT(p1.first_norm, 3) = LEFT(p2.first_norm, 3)
+          )
+        )
+    ),
+    name_birth_matches AS (
+      SELECT
+        p1.id AS id1,
+        p1.handle AS handle1,
+        p1.first_name AS first_name1,
+        p1.last_name AS last_name1,
+        p1.last_name_prefix AS last_name_prefix1,
+        p1.full_name AS full_name1,
+        p1.email AS email1,
+        p1.user_id AS user_id1,
+        p1.is_primary AS is_primary1,
+        p1.date_of_birth AS date_of_birth1,
+        p1.birth_city AS birth_city1,
+        p1.created_at AS created_at1,
+        p2.id AS id2,
+        p2.handle AS handle2,
+        p2.first_name AS first_name2,
+        p2.last_name AS last_name2,
+        p2.last_name_prefix AS last_name_prefix2,
+        p2.full_name AS full_name2,
+        p2.email AS email2,
+        p2.user_id AS user_id2,
+        p2.is_primary AS is_primary2,
+        p2.date_of_birth AS date_of_birth2,
+        p2.birth_city AS birth_city2,
+        p2.created_at AS created_at2,
+        p1.user_id IS NOT NULL AND p1.user_id = p2.user_id AS same_user,
+        p1.first_norm = p2.first_norm AS same_first_name,
+        FALSE AS similar_first_name,
+        p1.full_last_norm = p2.full_last_norm OR p1.last_norm = p2.last_norm AS same_last_name,
+        p1.date_of_birth = p2.date_of_birth AS same_birth_date,
+        ABS(p1.date_of_birth::date - p2.date_of_birth::date) <= 7 AS close_birth_date,
+        p1.birth_city_norm <> ''
+          AND p1.birth_city_norm = p2.birth_city_norm AS same_birth_city,
+        50 +
+        CASE
+          WHEN p1.full_last_norm <> '' AND p1.full_last_norm = p2.full_last_norm THEN 60
+          ELSE 50
+        END +
+        CASE
+          WHEN p1.date_of_birth = p2.date_of_birth THEN 60
+          WHEN ABS(p1.date_of_birth::date - p2.date_of_birth::date) <= 1 THEN 45
+          WHEN ABS(p1.date_of_birth::date - p2.date_of_birth::date) <= 7 THEN 35
+          WHEN EXTRACT(YEAR FROM p1.date_of_birth::date) = EXTRACT(YEAR FROM p2.date_of_birth::date) THEN 25
+          WHEN ABS(EXTRACT(YEAR FROM p1.date_of_birth::date) - EXTRACT(YEAR FROM p2.date_of_birth::date)) = 1 THEN 15
+          ELSE 0
+        END +
+        CASE
+          WHEN p1.birth_city_norm <> '' AND p1.birth_city_norm = p2.birth_city_norm THEN 10
+          ELSE 0
+        END AS score
+      FROM normalized_persons p1
+      JOIN normalized_persons p2 ON p1.id < p2.id
+        AND p1.first_norm <> ''
+        AND p1.first_norm = p2.first_norm
+        AND (
+          p1.full_last_norm <> '' AND p1.full_last_norm = p2.full_last_norm
+          OR p1.last_norm <> '' AND p1.last_norm = p2.last_norm
+        )
+        AND p1.date_of_birth IS NOT NULL
+        AND p2.date_of_birth IS NOT NULL
+        AND ABS(p1.date_of_birth::date - p2.date_of_birth::date) <= 365
+      WHERE p1.user_id IS DISTINCT FROM p2.user_id
+    ),
+    all_matches AS (
+      SELECT * FROM same_user_matches
+      UNION ALL
+      SELECT * FROM name_birth_matches
+    ),
+    ranked_matches AS (
+      SELECT
+        *,
+        ROW_NUMBER() OVER (
+          PARTITION BY LEAST(id1, id2), GREATEST(id1, id2)
+          ORDER BY score DESC
+        ) AS pair_rank
+      FROM all_matches
+      WHERE score >= ${args.threshold}
+    )
+    SELECT *
+    FROM ranked_matches
+    WHERE pair_rank = 1
+    ORDER BY score DESC, created_at1 ASC
+    LIMIT ${args.limit}
+  `;
+}
+
+export async function findDuplicatePersonPairs(
+  database: Database,
+  args: {
+    threshold?: number;
+    limit?: number;
+  } = {},
+): Promise<DuplicatePersonPair[]> {
+  const threshold = args.threshold ?? DEFAULT_ANALYZE_THRESHOLD;
+  const limit = args.limit ?? DEFAULT_LIMIT;
+  const result = await database.execute(
+    buildDuplicatePersonQuery({ threshold, limit }),
+  );
+
+  return (result.rows as unknown as DuplicatePersonRow[]).map(mapRowToPair);
+}
+
+export function chooseDefaultMerge(pair: DuplicatePersonPair): {
+  keep: 0 | 1;
+  merge: 0 | 1;
+  reason: string;
+} {
+  const [first, second] = pair.persons;
+
+  if (first.userId && !second.userId) {
+    return { keep: 0, merge: 1, reason: "record 1 has a linked user" };
+  }
+
+  if (!first.userId && second.userId) {
+    return { keep: 1, merge: 0, reason: "record 2 has a linked user" };
+  }
+
+  if (first.isPrimary && !second.isPrimary) {
+    return { keep: 0, merge: 1, reason: "record 1 is primary" };
+  }
+
+  if (!first.isPrimary && second.isPrimary) {
+    return { keep: 1, merge: 0, reason: "record 2 is primary" };
+  }
+
+  if (first.email && !second.email) {
+    return { keep: 0, merge: 1, reason: "record 1 has an email" };
+  }
+
+  if (!first.email && second.email) {
+    return { keep: 1, merge: 0, reason: "record 2 has an email" };
+  }
+
+  if (first.createdAt <= second.createdAt) {
+    return { keep: 0, merge: 1, reason: "record 1 is older" };
+  }
+
+  return { keep: 1, merge: 0, reason: "record 2 is older" };
+}
+
+export function isAutoMergeSafe(
+  pair: DuplicatePersonPair,
+  autoMergeThreshold = DEFAULT_AUTO_MERGE_THRESHOLD,
+): { safe: boolean; reason: string } {
+  if (pair.score < autoMergeThreshold) {
+    return {
+      safe: false,
+      reason: `score below auto threshold ${autoMergeThreshold}`,
+    };
+  }
+
+  const [first, second] = pair.persons;
+  if (first.userId && second.userId && first.userId !== second.userId) {
+    return {
+      safe: false,
+      reason: "different linked users require manual review",
+    };
+  }
+
+  if (!pair.matchReasons.includes("same birth date")) {
+    return {
+      safe: false,
+      reason: "birth date is not an exact match",
+    };
+  }
+
+  if (!pair.matchReasons.includes("same first name")) {
+    return {
+      safe: false,
+      reason: "first name is not an exact match",
+    };
+  }
+
+  return { safe: true, reason: "score and identity signals are strong" };
+}
+
+export function formatPerson(person: DuplicatePerson): string {
+  const handle = person.handle ? `@${person.handle}` : "no handle";
+  const dob = person.dateOfBirth ?? "no DOB";
+  const email = person.email ?? "no email";
+  const primary = person.isPrimary ? "primary" : "not primary";
+
+  return `${person.fullName} (${dob}) ${handle} [${email}, ${primary}] ${person.id}`;
+}
+
+function mapRowToPair(row: DuplicatePersonRow): DuplicatePersonPair {
+  const pair: DuplicatePersonPair = {
+    score: Number(row.score),
+    matchReasons: buildMatchReasons(row),
+    riskFlags: buildRiskFlags(row),
+    persons: [
+      {
+        id: row.id1,
+        handle: row.handle1,
+        firstName: row.first_name1,
+        lastName: row.last_name1,
+        lastNamePrefix: row.last_name_prefix1,
+        fullName: row.full_name1,
+        email: row.email1,
+        userId: row.user_id1,
+        isPrimary: row.is_primary1,
+        dateOfBirth: row.date_of_birth1,
+        birthCity: row.birth_city1,
+        createdAt: new Date(row.created_at1),
+      },
+      {
+        id: row.id2,
+        handle: row.handle2,
+        firstName: row.first_name2,
+        lastName: row.last_name2,
+        lastNamePrefix: row.last_name_prefix2,
+        fullName: row.full_name2,
+        email: row.email2,
+        userId: row.user_id2,
+        isPrimary: row.is_primary2,
+        dateOfBirth: row.date_of_birth2,
+        birthCity: row.birth_city2,
+        createdAt: new Date(row.created_at2),
+      },
+    ],
+  };
+
+  return pair;
+}
+
+function buildMatchReasons(row: DuplicatePersonRow): string[] {
+  const reasons: string[] = [];
+
+  if (row.same_user) reasons.push("same linked user");
+  if (row.same_first_name) reasons.push("same first name");
+  else if (row.similar_first_name) reasons.push("similar first name");
+  if (row.same_last_name) reasons.push("same last name");
+  if (row.same_birth_date) reasons.push("same birth date");
+  else if (row.close_birth_date) reasons.push("close birth date");
+  if (row.same_birth_city) reasons.push("same birth city");
+
+  return reasons;
+}
+
+function buildRiskFlags(row: DuplicatePersonRow): string[] {
+  const flags: string[] = [];
+
+  if (row.user_id1 && row.user_id2 && row.user_id1 !== row.user_id2) {
+    flags.push("different linked users");
+  }
+
+  if (row.date_of_birth1 && row.date_of_birth2) {
+    if (row.date_of_birth1 !== row.date_of_birth2) {
+      flags.push("birth date differs");
+    }
+  } else {
+    flags.push("missing birth date");
+  }
+
+  if (row.email1 && row.email2 && row.email1 !== row.email2) {
+    flags.push("different emails");
+  }
+
+  if (row.is_primary1 && row.is_primary2) {
+    flags.push("both records are primary");
+  }
+
+  return flags;
+}

--- a/packages/scripts/src/utils/duplicate-person-detection.ts
+++ b/packages/scripts/src/utils/duplicate-person-detection.ts
@@ -286,6 +286,10 @@ export function buildDuplicatePersonQuery(args: {
           AND p1.birth_city_norm = p2.birth_city_norm AS same_birth_city,
         50 +
         CASE
+          WHEN p1.date_of_birth = p2.date_of_birth THEN 30
+          ELSE 0
+        END +
+        CASE
           WHEN p1.full_last_norm <> '' AND p1.full_last_norm = p2.full_last_norm THEN 60
           ELSE 50
         END +
@@ -563,8 +567,11 @@ function buildMatchReasons(row: DuplicatePersonRow): string[] {
 
 function buildRiskFlags(row: DuplicatePersonRow): string[] {
   const flags: string[] = [];
+  const hasDifferentLinkedUsers = Boolean(
+    row.user_id1 && row.user_id2 && row.user_id1 !== row.user_id2,
+  );
 
-  if (row.user_id1 && row.user_id2 && row.user_id1 !== row.user_id2) {
+  if (hasDifferentLinkedUsers) {
     flags.push("different linked users");
   }
 
@@ -576,7 +583,12 @@ function buildRiskFlags(row: DuplicatePersonRow): string[] {
     flags.push("missing birth date");
   }
 
-  if (row.email1 && row.email2 && row.email1 !== row.email2) {
+  if (
+    !hasDifferentLinkedUsers &&
+    row.email1 &&
+    row.email2 &&
+    row.email1 !== row.email2
+  ) {
     flags.push("different emails");
   }
 


### PR DESCRIPTION
## What changed

Adds the duplicate-person tooling from the old feat/person-merge branch in a refined form:

- persons:duplicates:analyze ranks likely duplicate person records by score.
- persons:duplicates:merge reviews ranked pairs and merges them only when run with --execute.
- Shared detection logic scores same-user and same-name/birth-date matches without requiring the Postgres unaccent extension.
- Batch merge defaults to dry-run, only auto-merges high-signal low-risk pairs, and skips/manual-reviews pairs with different linked users.
- Merge error reports are ignored by git.

## Why

The current scripts package only had a manual two-ID merge command. Older local tooling could rank duplicate profiles and batch merge high-confidence matches, but it lived only on an old feature branch and needed to be brought forward safely.

## Validation

- tsc --project packages/scripts/tsconfig.json --pretty false
- biome check packages/scripts/src/analyze-duplicate-persons.ts packages/scripts/src/batch-merge-duplicates.ts packages/scripts/src/utils/duplicate-person-detection.ts packages/scripts/package.json
- Help-path smoke checks against compiled JS for both scripts

Note: dependency install in this isolated worktree could not complete through the sandboxed network, so validation used the already-installed package toolchain from the main local checkout.