### PR TITLE
Fix help article MDX rendering: images + angle-bracket placeholders

### DIFF
--- a/apps/web/src/app/(public)/help/artikel/_content/app-vaarlocaties/cohorten-gebruiken-als-beheerder.mdx
+++ b/apps/web/src/app/(public)/help/artikel/_content/app-vaarlocaties/cohorten-gebruiken-als-beheerder.mdx
@@ -21,9 +21,9 @@ hebt en hoe je ze kunt gebruiken.
 4. Klik op de vaarlocatie waar je heen wilt.
 
 <Image
-  src={"/images/vaarlocatie-app/overzicht-vaarlocaties.png"}
-  width={2880}
-  height={1508}
+  src="/images/vaarlocatie-app/overzicht-vaarlocaties.png"
+  width="2880"
+  height="1508"
 />
 
 Zie je de vaarlocatie niet staan? Neem dan contact op met de hoofdbeheerder van

--- a/apps/web/src/app/(public)/help/artikel/_content/app-vaarlocaties/cohorten-gebruiken-als-instructeur.mdx
+++ b/apps/web/src/app/(public)/help/artikel/_content/app-vaarlocaties/cohorten-gebruiken-als-instructeur.mdx
@@ -29,9 +29,9 @@ daarbinnen de voortgang van je cursisten kunt bijhouden.
 4. Klik op de vaarlocatie waar je heen wilt.
 
 <Image
-  src={"/images/vaarlocatie-app/overzicht-vaarlocaties.png"}
-  width={2880}
-  height={1508}
+  src="/images/vaarlocatie-app/overzicht-vaarlocaties.png"
+  width="2880"
+  height="1508"
 />
 
 Zie je de vaarlocatie niet staan? Dan ben je nog niet gekoppeld aan de
@@ -46,9 +46,9 @@ cohorten overzicht. Een cohort kent een openings- en sluitingsdatum, enkel
 binnen deze periode is het cohort voor jou als instructeur toegankelijk.
 
 <Image
-  src={"/images/vaarlocatie-app/overzicht-cohorten.png"}
-  width={2880}
-  height={1508}
+  src="/images/vaarlocatie-app/overzicht-cohorten.png"
+  width="2880"
+  height="1508"
 />
 
 ## Cursisten vinden en claimen
@@ -59,9 +59,9 @@ Je kunt ook alle cursisten zien door op 'Mijn cursisten' te klikken en daar
 vervolgens 'Alle cursisten' te selecteren.
 
 <Image
-  src={"/images/vaarlocatie-app/eigen-cursisten.png"}
-  width={2880}
-  height={1508}
+  src="/images/vaarlocatie-app/eigen-cursisten.png"
+  width="2880"
+  height="1508"
 />
 
 Als je in het overzicht met alle cursisten bent, kan je het zoekveld gebruiken
@@ -73,9 +73,9 @@ In het overzicht kan je één of meerdere cursisten selecteren, om ze vervolgens
 te claimen. Vanaf dan verschijnen ze in jouw overzicht.
 
 <Image
-  src={"/images/vaarlocatie-app/alle-cursisten.png"}
-  width={2880}
-  height={1508}
+  src="/images/vaarlocatie-app/alle-cursisten.png"
+  width="2880"
+  height="1508"
 />
 
 ## Voortgang beheren via cursuskaarten
@@ -96,17 +96,17 @@ ook een programma starten vanuit een individuele cursist, door op de cursist te
 klikken en vervolgens de stappen te volgen.
 
 <Image
-  src={"/images/vaarlocatie-app/programma-starten.png"}
-  width={2880}
-  height={1508}
+  src="/images/vaarlocatie-app/programma-starten.png"
+  width="2880"
+  height="1508"
 />
 
 ### Voortgang bijhouden
 
 <Image
-  src={"/images/vaarlocatie-app/cursuskaart-beheren.png"}
-  width={2880}
-  height={1508}
+  src="/images/vaarlocatie-app/cursuskaart-beheren.png"
+  width="2880"
+  height="1508"
 />
 
 1. Gebruik de checkbox voor de module om deze als geheel af te tekenen, of
@@ -135,9 +135,9 @@ beheerder_.
 In de 'sidebar' vind je een aantal knoppen.
 
 <Image
-  src={"/images/vaarlocatie-app/sidebar-menu.png"}
-  width={2880}
-  height={1508}
+  src="/images/vaarlocatie-app/sidebar-menu.png"
+  width="2880"
+  height="1508"
 />
 
 1. Ga naar de diplomalijnen pagina, waar je een overzicht vindt van alle

--- a/apps/web/src/app/(public)/help/artikel/_content/app-vaarlocaties/dubbele-personen-in-een-cohort-beheren.mdx
+++ b/apps/web/src/app/(public)/help/artikel/_content/app-vaarlocaties/dubbele-personen-in-een-cohort-beheren.mdx
@@ -54,31 +54,31 @@ Je hoeft niet zelf te zoeken; de app brengt mogelijke matches naar je toe.
 
 ### 1. Het tabblad "Duplicaten" op de personenpagina
 
-Op `/locatie/<jouw-locatie>/personen/duplicaten` zie je een lijst van paren
+Op `/locatie/[jouw-locatie]/personen/duplicaten` zie je een lijst van paren
 binnen jouw vaarlocatie waarvan het systeem denkt dat het hetzelfde profiel
 is. Per paar zie je een primair profiel (oudste of meest gebruikte) en een
 duplicaat-profiel, plus per profiel hoeveel diploma's, cohortplekken en
 gekoppelde gebruikers eraan hangen.
 
 <Image
-  src={"/images/vaarlocatie-app/duplicaten-personen-tab.png"}
-  width={2880}
-  height={1508}
+  src="/images/vaarlocatie-app/duplicaten-personen-tab.png"
+  width="2880"
+  height="1508"
   alt="De Duplicaten-tab op de personenpagina toont paren binnen jouw locatie."
 />
 
 ### 2. Het tabblad "Duplicaten" op een cohort
 
 Hetzelfde principe, maar dan beperkt tot één cohort:
-`/locatie/<jouw-locatie>/cohorten/<cohort>/duplicaten`. Zie je het cohort-
+`/locatie/[jouw-locatie]/cohorten/[cohort]/duplicaten`. Zie je het cohort-
 overzicht en staat er een oranje stip naast het tabblad **Duplicaten**, dan
 verwacht het systeem dat er minstens één paar in dit cohort zit dat aandacht
 nodig heeft. De stip verdwijnt zodra alle paren bevestigd of weggeklikt zijn.
 
 <Image
-  src={"/images/vaarlocatie-app/duplicaten-cohort-tab.png"}
-  width={2880}
-  height={1508}
+  src="/images/vaarlocatie-app/duplicaten-cohort-tab.png"
+  width="2880"
+  height="1508"
   alt="Tabblad Duplicaten in een cohort, met oranje aandachtsstip."
 />
 
@@ -92,9 +92,9 @@ klikken om het bestaande profiel te gebruiken in plaats van een nieuw aan te
 maken.
 
 <Image
-  src={"/images/vaarlocatie-app/dedup-hint-single-create.png"}
-  width={2880}
-  height={1508}
+  src="/images/vaarlocatie-app/dedup-hint-single-create.png"
+  width="2880"
+  height="1508"
   alt="Inline duplicaat-suggestie in het cursist-toevoegen-dialoogje."
 />
 
@@ -121,9 +121,9 @@ je vóór het opslaan een preview-overzicht. Per regel zie je een status:
   eigen profiel te geven.
 
 <Image
-  src={"/images/vaarlocatie-app/bulk-import-preview.png"}
-  width={2880}
-  height={1508}
+  src="/images/vaarlocatie-app/bulk-import-preview.png"
+  width="2880"
+  height="1508"
   alt="Bulk-import preview met per-regel status en inline kandidaatkaarten."
 />
 
@@ -135,9 +135,9 @@ een diff-weergave in code review. Per veld zie je een groen vinkje als de
 waarden overeenkomen, of een oranje waarschuwing als ze verschillen.
 
 <Image
-  src={"/images/vaarlocatie-app/operator-merge-dialog.png"}
-  width={2880}
-  height={1508}
+  src="/images/vaarlocatie-app/operator-merge-dialog.png"
+  width="2880"
+  height="1508"
   alt="Samenvoegdialoog met per-veld diff tussen primair en duplicaat profiel."
 />
 
@@ -184,9 +184,9 @@ zijn voor uitgifte. Sinds de update kun je daar ook een vierde status zien:
 **Geblokkeerd**.
 
 <Image
-  src={"/images/vaarlocatie-app/diplomas-tab-geblokkeerd.png"}
-  width={2880}
-  height={1508}
+  src="/images/vaarlocatie-app/diplomas-tab-geblokkeerd.png"
+  width="2880"
+  height="1508"
   alt="Diploma's-tab met geblokkeerd-filter en oranje badge op een rij."
 />
 

--- a/apps/web/src/app/(public)/help/artikel/_content/diplomalijn/hoe-is-de-diplomalijn-van-het-nwd-opgebouwd.mdx
+++ b/apps/web/src/app/(public)/help/artikel/_content/diplomalijn/hoe-is-de-diplomalijn-van-het-nwd-opgebouwd.mdx
@@ -85,9 +85,9 @@ Instructeursniveaus staan binnen het NWD los van de Consumentenniveaus. Het is d
 </Faq>
 
 <Image
-  src={"/images/opbouw-diplomalijn/opbouw-programma-nwd.png"}
-  width={1260 / 2}
-  height={1088 / 2}
+  src="/images/opbouw-diplomalijn/opbouw-programma-nwd.png"
+  width="630"
+  height="544"
 />
 
 Het opleidingsprogramma bepaalt in welke vaartuigen deze aangeboden kan worden. We noemen het bewust **vaartuig** omdat het voor bijvoorbeeld de Zwaardboot 1-mans discipline gaat om bootsoorten, voor het windsurfen om het type board en voor het jachtzeilen om de lengte en CE-categorie van het schip. Tussen verschillende vaartuigen is het inhoudelijke opleidingsprogramma, binnen dezelfde cursus en op hetzelfde niveau, gelijk. Dat komt omdat de eisen bij de competenties enkel het resultaat omschrijven, niet de handeling.
@@ -156,9 +156,9 @@ efficiënt en effectief onderwijs te bieden, aangepast aan zowel de behoeften va
 de cursist als de omgevingsfactoren.
 
 <Image
-  src={"/images/opbouw-diplomalijn/opbouw-programma-nwd-modules.png"}
-  width={1260 / 2}
-  height={784 / 2}
+  src="/images/opbouw-diplomalijn/opbouw-programma-nwd-modules.png"
+  width="630"
+  height="392"
 />
 
 <Faq question="Overgang vanaf CWO">

--- a/apps/web/src/app/(public)/help/artikel/_content/diplomalijn/watersportverbond-kiest-voor-het-nwd-wat-betekent-dit-voor-jou.mdx
+++ b/apps/web/src/app/(public)/help/artikel/_content/diplomalijn/watersportverbond-kiest-voor-het-nwd-wat-betekent-dit-voor-jou.mdx
@@ -20,9 +20,9 @@ Het Watersportverbond heeft aangekondigd dat het per 1 januari 2026 de licentie 
 ### Nieuwe licentiestructuur
 
 <Image
-  src={"/images/landschap/licenties-helpartikel.png"}
-  width={1200 / 2}
-  height={1500 / 2}
+  src="/images/landschap/licenties-helpartikel.png"
+  width="600"
+  height="750"
 />
 
 Het Watersportverbond is de directe licentiehouder voor watersportopleidingen in Nederland. De belangrijkste licentiegevers zijn daarbij:

--- a/apps/web/src/app/(public)/help/artikel/_content/vereniging/hoe-werkt-de-aansluitingsprocedure-van-het-nwd.mdx
+++ b/apps/web/src/app/(public)/help/artikel/_content/vereniging/hoe-werkt-de-aansluitingsprocedure-van-het-nwd.mdx
@@ -45,8 +45,8 @@ Een uitgebreide kostenvergelijking met andere scenario's (Watersport Academy, CW
 <Image
   src="/images/aansluitingsprocedure/20250923-aansluitprocedure-nwd.png"
   alt="Overzicht van de aansluitingsprocedure van de vereniging NWD"
-  width={1200}
-  height={3668}
+  width="1200"
+  height="3668"
   className="w-full h-auto"
 />
 


### PR DESCRIPTION
## Summary

Two MDX rendering bugs were breaking help articles on prod:

1. **All screenshots invisible.** JSX-expression attributes like \`src={\"...\"}\` and \`width={2880}\` on \`<Image>\` were being silently dropped by \`next-mdx-remote@6.0.0\` (added Feb 23 to resolve CVE-2026-0969). Result: \`<img>\` tags with no \`src\`/\`srcSet\`/\`width\`/\`height\` — empty placeholders. Affected 6 articles for ~2 months.
2. **Most of the duplicate-management article body invisible.** \`<jouw-locatie>\` and \`<cohort>\` inside inline-code on the new article were parsed as unclosed JSX tags, eating the entire article body and leaving only the first sentence fragment + 6 broken \`<img>\` tags + the last FAQ.

## Fix

- Convert JSX-expression attributes to plain HTML-attribute syntax (\`src=\"...\"\`, \`width=\"2880\"\`, \`height=\"1508\"\`) — v6 honors these.
- Replace \`<jouw-locatie>\`/\`<cohort>\` with \`[jouw-locatie]\`/\`[cohort]\` (matches Next.js dynamic-segment notation, no JSX collision).

## Affected articles

- \`app-vaarlocaties/dubbele-personen-in-een-cohort-beheren\` (both fixes)
- \`app-vaarlocaties/cohorten-gebruiken-als-instructeur\`
- \`app-vaarlocaties/cohorten-gebruiken-als-beheerder\`
- \`diplomalijn/hoe-is-de-diplomalijn-van-het-nwd-opgebouwd\`
- \`diplomalijn/watersportverbond-kiest-voor-het-nwd-wat-betekent-dit-voor-jou\`
- \`vereniging/hoe-werkt-de-aansluitingsprocedure-van-het-nwd\`

## Test plan

- [x] Verified locally: article body renders fully, all 6 screenshots resolve to \`/_next/image?url=...\` with proper \`srcSet\`.
- [ ] After deploy: visit \`/help/artikel/dubbele-personen-in-een-cohort-beheren\` and confirm full body + 6 screenshots load.
- [ ] Spot-check the 5 other articles for working images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only MDX edits; risk is limited to potential formatting/rendering regressions in the affected articles.
> 
> **Overview**
> Fixes MDX rendering in several help articles after the `next-mdx-remote@6` change by rewriting `<Image>` props from JSX expressions (e.g. `src={"..."}`, `width={...}`) to plain string attributes so screenshots render again.
> 
> Prevents MDX from interpreting angle-bracket placeholders as JSX in the duplicate-management article by switching route examples from `<jouw-locatie>`/`<cohort>` to `[jouw-locatie]`/`[cohort]`, restoring the missing article body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eee08a3db2377653f65da0efcb9af668088597b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->