### PR TITLE
fix(leercoach): modal overflow + chat composer half-offscreen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ supabase/kss-dev-seed.sql
 
 # Turborepo
 .turbo
+.gstack/

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/leercoach/_components/Artefact.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/leercoach/_components/Artefact.tsx
@@ -582,89 +582,91 @@ function UploadDialog() {
   return (
     <Dialog open={dialogOpen} onClose={handleClose} className="relative z-50">
       <DialogBackdrop className="fixed inset-0 bg-slate-900/50" />
-      <div className="fixed inset-0 flex items-center justify-center p-4">
-        <DialogPanel className="w-full max-w-lg rounded-2xl bg-white shadow-xl">
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-6">
-            <DialogTitle className="text-lg font-semibold text-slate-900">
-              Materiaal toevoegen
-            </DialogTitle>
-            <p className="text-sm text-slate-600">
-              Upload een document (PDF, DOCX) of afbeelding (PNG, JPG, WEBP) dat
-              je in deze sessie wil gebruiken. Alleen jij en de digitale
-              leercoach zien ’m — andere gebruikers krijgen nooit toegang.
-            </p>
+      <div className="fixed inset-0 overflow-y-auto">
+        <div className="flex min-h-full items-center justify-center p-4">
+          <DialogPanel className="w-full max-w-lg rounded-2xl bg-white shadow-xl">
+            <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-6">
+              <DialogTitle className="text-lg font-semibold text-slate-900">
+                Materiaal toevoegen
+              </DialogTitle>
+              <p className="text-sm text-slate-600">
+                Upload een document (PDF, DOCX) of afbeelding (PNG, JPG, WEBP)
+                dat je in deze sessie wil gebruiken. Alleen jij en de digitale
+                leercoach zien ’m — andere gebruikers krijgen nooit toegang.
+              </p>
 
-            <div className="flex flex-col gap-2">
-              <label
-                htmlFor={fileInputId}
-                className="text-sm font-medium text-slate-700"
-              >
-                Bestand
-              </label>
-              <input
-                id={fileInputId}
-                ref={fileInputRef}
-                type="file"
-                accept="application/pdf,.pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.docx,image/png,image/jpeg,image/webp"
-                onChange={onFileChange}
-                disabled={isPending}
-                className="text-sm text-slate-700 file:mr-3 file:rounded-lg file:border file:border-slate-300 file:bg-white file:px-3 file:py-1.5 file:text-sm file:font-semibold file:text-slate-700 hover:file:bg-slate-50"
-              />
-              {selectedFile ? (
-                <p className="text-xs text-slate-500">
-                  {selectedFile.name} · {Math.round(selectedFile.size / 1024)}{" "}
-                  KB
-                </p>
-              ) : (
-                <p className="text-xs text-slate-500">Max 15 MB.</p>
-              )}
-            </div>
+              <div className="flex flex-col gap-2">
+                <label
+                  htmlFor={fileInputId}
+                  className="text-sm font-medium text-slate-700"
+                >
+                  Bestand
+                </label>
+                <input
+                  id={fileInputId}
+                  ref={fileInputRef}
+                  type="file"
+                  accept="application/pdf,.pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.docx,image/png,image/jpeg,image/webp"
+                  onChange={onFileChange}
+                  disabled={isPending}
+                  className="text-sm text-slate-700 file:mr-3 file:rounded-lg file:border file:border-slate-300 file:bg-white file:px-3 file:py-1.5 file:text-sm file:font-semibold file:text-slate-700 hover:file:bg-slate-50"
+                />
+                {selectedFile ? (
+                  <p className="text-xs text-slate-500">
+                    {selectedFile.name} ·{" "}
+                    {Math.round(selectedFile.size / 1024)} KB
+                  </p>
+                ) : (
+                  <p className="text-xs text-slate-500">Max 15 MB.</p>
+                )}
+              </div>
 
-            <div className="flex flex-col gap-2">
-              <label
-                htmlFor={labelInputId}
-                className="text-sm font-medium text-slate-700"
-              >
-                Korte naam (optioneel)
-              </label>
-              <input
-                id={labelInputId}
-                type="text"
-                value={label}
-                onChange={(e) => setLabel(e.target.value)}
-                disabled={isPending}
-                placeholder={
-                  selectedFile
-                    ? selectedFile.name.replace(
-                        /\.(pdf|docx|png|jpe?g|webp)$/i,
-                        "",
-                      )
-                    : ""
-                }
-                maxLength={80}
-                className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
-              />
-            </div>
+              <div className="flex flex-col gap-2">
+                <label
+                  htmlFor={labelInputId}
+                  className="text-sm font-medium text-slate-700"
+                >
+                  Korte naam (optioneel)
+                </label>
+                <input
+                  id={labelInputId}
+                  type="text"
+                  value={label}
+                  onChange={(e) => setLabel(e.target.value)}
+                  disabled={isPending}
+                  placeholder={
+                    selectedFile
+                      ? selectedFile.name.replace(
+                          /\.(pdf|docx|png|jpe?g|webp)$/i,
+                          "",
+                        )
+                      : ""
+                  }
+                  maxLength={80}
+                  className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                />
+              </div>
 
-            <div className="flex items-center justify-end gap-2 pt-2">
-              <button
-                type="button"
-                onClick={handleClose}
-                disabled={isPending}
-                className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                Annuleer
-              </button>
-              <button
-                type="submit"
-                disabled={!selectedFile || isPending}
-                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {isPending ? "Verwerken…" : "Upload"}
-              </button>
-            </div>
-          </form>
-        </DialogPanel>
+              <div className="flex items-center justify-end gap-2 pt-2">
+                <button
+                  type="button"
+                  onClick={handleClose}
+                  disabled={isPending}
+                  className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Annuleer
+                </button>
+                <button
+                  type="submit"
+                  disabled={!selectedFile || isPending}
+                  className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isPending ? "Verwerken…" : "Upload"}
+                </button>
+              </div>
+            </form>
+          </DialogPanel>
+        </div>
       </div>
     </Dialog>
   );

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/leercoach/_components/ChangeScopeDialog.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/leercoach/_components/ChangeScopeDialog.tsx
@@ -60,27 +60,29 @@ export function ChangeScopeDialog({
         transition
         className="fixed inset-0 bg-slate-900/40 transition duration-200 ease-out data-closed:opacity-0"
       />
-      <div className="fixed inset-0 flex items-center justify-center p-4">
-        <DialogPanel
-          transition
-          className="flex w-full max-w-lg flex-col gap-4 rounded-xl bg-white p-5 shadow-xl transition duration-200 ease-out data-closed:scale-95 data-closed:opacity-0"
-        >
-          {/* Form keyed on `open` so it remounts each time the dialog
-              is shown — useState initializers re-read from
-              currentScope, giving the user a clean slate after
-              cancel/reopen cycles WITHOUT a setState-in-effect
-              (flagged by react-hooks/set-state-in-effect). */}
-          {open ? (
-            <ChangeScopeForm
-              key={stableScopeKey(currentScope)}
-              onClose={onClose}
-              handle={handle}
-              chatId={chatId}
-              kerntaken={kerntaken}
-              currentScope={currentScope}
-            />
-          ) : null}
-        </DialogPanel>
+      <div className="fixed inset-0 overflow-y-auto">
+        <div className="flex min-h-full items-center justify-center p-4">
+          <DialogPanel
+            transition
+            className="flex w-full max-w-lg flex-col gap-4 rounded-xl bg-white p-5 shadow-xl transition duration-200 ease-out data-closed:scale-95 data-closed:opacity-0"
+          >
+            {/* Form keyed on `open` so it remounts each time the dialog
+                is shown — useState initializers re-read from
+                currentScope, giving the user a clean slate after
+                cancel/reopen cycles WITHOUT a setState-in-effect
+                (flagged by react-hooks/set-state-in-effect). */}
+            {open ? (
+              <ChangeScopeForm
+                key={stableScopeKey(currentScope)}
+                onClose={onClose}
+                handle={handle}
+                chatId={chatId}
+                kerntaken={kerntaken}
+                currentScope={currentScope}
+              />
+            ) : null}
+          </DialogPanel>
+        </div>
       </div>
     </Dialog>
   );

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/leercoach/chat/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/leercoach/chat/[id]/page.tsx
@@ -119,11 +119,13 @@ export default async function LeercoachChatPage(props: {
     (profielId ? "Leercoach-sessie" : "Nieuwe vraag");
 
   return (
-    // Tighter than before (was `100dvh-10rem`) because the page-level
-    // header has been folded into the ChatShell toolbar. `6rem` covers
-    // the dashboard navbar + stacked-layout padding; 100dvh tracks iOS
-    // Safari's retracting address bar to keep the composer above the
-    // browser chrome.
+    // Chrome reserve differs by breakpoint because StackedLayout's inner
+    // wrapper uses `p-2` (16px V) on mobile and `lg:p-10` (80px V) on
+    // desktop. Navbar (~60px) + main pb-2 (8px) + inner padding =
+    // ~84px mobile / ~148px desktop. Reserving 6rem / 10rem leaves a
+    // little slack so the composer never sits flush against the
+    // viewport bottom. 100dvh tracks iOS Safari's retracting address
+    // bar so the composer stays above the browser chrome.
     //
     // Width-escape: the dashboard StackedLayout wraps children in a
     // `max-w-7xl mx-auto` (1280px) column which leaves a lot of empty
@@ -137,7 +139,7 @@ export default async function LeercoachChatPage(props: {
     //
     // `px-*` re-adds breathing room against the viewport edge so
     // the chat card doesn't touch the gutters on very wide screens.
-    <div className="flex h-[calc(100dvh-6rem)] flex-col mx-[calc(50%-50vw)] w-screen px-4 2xl:px-8">
+    <div className="flex h-[calc(100dvh-6rem)] lg:h-[calc(100dvh-10rem)] flex-col mx-[calc(50%-50vw)] w-screen px-4 2xl:px-8">
       <ChatShell
         handle={handle}
         chatId={chat.chatId}

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/PortfolioUploadDialog.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/portfolios/_components/PortfolioUploadDialog.tsx
@@ -107,44 +107,47 @@ export function PortfolioUploadDialog({
   return (
     <Dialog open={open} onClose={handleClose} className="relative z-50">
       <DialogBackdrop className="fixed inset-0 bg-slate-900/50" />
-      <div className="fixed inset-0 flex items-center justify-center p-4">
-        <DialogPanel className="w-full max-w-lg rounded-2xl bg-white shadow-xl">
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-6">
-            <DialogTitle className="text-lg font-semibold text-slate-900">
-              Eerder portfolio uploaden
-            </DialogTitle>
-            <p className="text-sm text-slate-600">
-              De PDF wordt server-side geanonimiseerd (namen, locaties,
-              verenigingen, datums worden eruit gehaald) voordat iets opgeslagen
-              wordt. Alleen jij ziet de geanonimiseerde tekst; de digitale
-              leercoach gebruikt ’m als context in jouw sessies. Een menselijke
-              leercoach, instructeur of beoordelaar heeft géén toegang.
-            </p>
+      <div className="fixed inset-0 overflow-y-auto">
+        <div className="flex min-h-full items-center justify-center p-4">
+          <DialogPanel className="w-full max-w-lg rounded-2xl bg-white shadow-xl">
+            <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-6">
+              <DialogTitle className="text-lg font-semibold text-slate-900">
+                Eerder portfolio uploaden
+              </DialogTitle>
+              <p className="text-sm text-slate-600">
+                De PDF wordt server-side geanonimiseerd (namen, locaties,
+                verenigingen, datums worden eruit gehaald) voordat iets
+                opgeslagen wordt. Alleen jij ziet de geanonimiseerde tekst; de
+                digitale leercoach gebruikt ’m als context in jouw sessies.
+                Een menselijke leercoach, instructeur of beoordelaar heeft géén
+                toegang.
+              </p>
 
-            <UploadFields form={form} idPrefix="prior-dialog" />
-            <UploadResultBanner state={form.state} />
+              <UploadFields form={form} idPrefix="prior-dialog" />
+              <UploadResultBanner state={form.state} />
 
-            <div className="flex items-center justify-end gap-2 pt-2">
-              <button
-                type="button"
-                onClick={handleClose}
-                disabled={isWorkflowRunning}
-                className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                Annuleer
-              </button>
-              <button
-                type="submit"
-                disabled={!form.canSubmit}
-                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {isWorkflowRunning
-                  ? "Bezig met verwerken…"
-                  : "Upload + anonimiseer"}
-              </button>
-            </div>
-          </form>
-        </DialogPanel>
+              <div className="flex items-center justify-end gap-2 pt-2">
+                <button
+                  type="button"
+                  onClick={handleClose}
+                  disabled={isWorkflowRunning}
+                  className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Annuleer
+                </button>
+                <button
+                  type="submit"
+                  disabled={!form.canSubmit}
+                  className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isWorkflowRunning
+                    ? "Bezig met verwerken…"
+                    : "Upload + anonimiseer"}
+                </button>
+              </div>
+            </form>
+          </DialogPanel>
+        </div>
       </div>
     </Dialog>
   );

--- a/apps/web/src/app/_components/ai-chat/AiChat.tsx
+++ b/apps/web/src/app/_components/ai-chat/AiChat.tsx
@@ -1142,7 +1142,7 @@ function InputForm({
     // the composer isn't a discrete card begging to be rung by a ring.
     <form
       onSubmit={handleSubmit}
-      className="border-t border-slate-200 transition-colors focus-within:bg-slate-50/40"
+      className="shrink-0 border-t border-slate-200 transition-colors focus-within:bg-slate-50/40"
     >
       {/* Centered inner container: caps chat-content width at the
           same max-w-3xl the message list uses so a wide pane doesn't


### PR DESCRIPTION
## Summary

Two user-reported bugs in the digitale-leercoach feature, plus minor chore.

**Modal overflow on small viewports** ([c17bd06f](https://github.com/buchungapp/nationaal-watersportdiploma/commit/c17bd06f))
Reported by a user on `/profiel/[handle]/portfolios` — the upload modal extended past the viewport bottom with no scroll affordance, hiding the consent checkbox + submit button. Same buggy pattern existed in two leercoach sibling dialogs (`ChangeScopeDialog`, `Artefact` upload). All three switched to the project's standard scrollable-modal pattern from [`_components/dialog.tsx`](apps/web/src/app/(dashboard)/_components/dialog.tsx).

**Chat composer half off-screen** ([5058e500](https://github.com/buchungapp/nationaal-watersportdiploma/commit/5058e500))
Reported by a user. Two root causes:
1. `h-[calc(100dvh-6rem)]` reserved 96px for surrounding chrome, but the dashboard `StackedLayout` uses `lg:p-10` (80px vertical) on desktop — actual chrome at `lg+` is ~144px. Page body overflowed 48px at every desktop viewport, scrolling pushed composer below fold. Now: `h-[calc(100dvh-6rem)] lg:h-[calc(100dvh-10rem)]`.
2. `AiChat.InputForm` rendered as last sibling of `MessageList` inside a `Frame` with `overflow-hidden`. At short heights it was the clip victim. Now: `shrink-0` so `MessageList` (flex-1) compresses first.

**Chore** ([70419b93](https://github.com/buchungapp/nationaal-watersportdiploma/commit/70419b93))
Add `.gstack/` to `.gitignore` (local browse/review tool artifacts).

## Verification

Tested with the browse tool at multiple viewports:

| Viewport | Before | After |
|---|---|---|
| 1024×500 | body overflow=48px, composer cuttable | overflow=0, fully visible |
| 1280×600 | overflow=48 | overflow=0 |
| 1280×720 | overflow=48 | overflow=0 |
| 1440×900 | overflow=48 | overflow=0 |
| Modal at 800×500 | bottom of panel clipped | scrolls cleanly |
| Modal at 1280×720 | bottom clipped (reproduces user's bug) | scrolls cleanly |

Extreme short viewports (<400px height) still have residual `Starters` ↔ composer competition — known limitation, not in real-user range, deferred. Restructuring `Starters` into the `MessageList` scroll area is the complete fix if it ever comes up.

## Test plan

- [ ] Open `/profiel/[handle]/portfolios` on a small laptop, click "Eerder portfolio uploaden", scroll within the modal to reach the consent checkbox + submit
- [ ] Open a leercoach chat session on a 13" laptop, confirm the composer is fully visible without scrolling the page
- [ ] Open `/profiel/[handle]/leercoach/chat/...` → click ellipsis → "Wijzig scope" (requires niveau-4 chat), confirm modal scrolls
- [ ] Open the in-chat attachment menu → "Materiaal toevoegen", confirm modal scrolls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only layout adjustments: makes dialogs scrollable on small viewports and tweaks flex/height calculations to avoid the chat composer being clipped on desktop.
> 
> **Overview**
> Fixes several leercoach-related **viewport overflow** issues by converting the `Artefact` upload dialog, `ChangeScopeDialog`, and `PortfolioUploadDialog` to a scrollable modal wrapper (`fixed inset-0 overflow-y-auto` + centered panel) so long content doesn’t clip off-screen.
> 
> Adjusts leercoach chat layout so the composer stays visible: `leercoach/chat/[id]` now reserves more height at `lg` breakpoints (`100dvh-6rem` → `lg:100dvh-10rem`), and `AiChat.InputForm` adds `shrink-0` so the message list compresses before the composer in tight heights.
> 
> Adds `.gstack/` to `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70419b93414c0d010099d4f13dea03fca5d0bdf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->