### PR TITLE
fix(person-merge): drop forensic-blocking audit FKs + lock on merge

### DIFF
--- a/packages/core/src/models/user/person.test.ts
+++ b/packages/core/src/models/user/person.test.ts
@@ -1,9 +1,14 @@
 import assert from "node:assert";
 import test from "node:test";
-import { schema as s } from "@nawadi/db";
+import { createDatabase, migrateDatabase, schema as s } from "@nawadi/db";
 import dayjs from "dayjs";
 import { and, eq, inArray, isNull, sql } from "drizzle-orm";
-import { useQuery, withTestTransaction } from "../../contexts/index.js";
+import {
+  useDatabase,
+  useQuery,
+  withDatabase,
+  withTestTransaction,
+} from "../../contexts/index.js";
 import {
   Certificate,
   Cohort,
@@ -1280,6 +1285,430 @@ test("user.person.mergePersons repoints PVB counterparty refs when source was be
       .where(eq(s.person.id, sourcePersonId));
     assert.equal(sourcePersonRows.length, 0, "Source person must be deleted");
   }));
+
+// REGRESSION (person-merge FK / forensic audit): person_merge_audit no
+// longer carries a RESTRICT FK on target_person_id. A chained merge
+// (A->B then B->C) must not be blocked by an audit row that recorded B as
+// a prior merge target, and that historical audit row must keep pointing
+// at B (NOT repointed to C) so forensic truth is preserved.
+test("user.person.mergePersons allows merging a person who was a prior merge target, preserving the historical audit row", () =>
+  withTestTransaction(async () => {
+    const query = useQuery();
+
+    const location = await Location.create({
+      handle: "merge-prior-target-loc",
+      name: "Merge Prior Target Location",
+    });
+
+    const [
+      { id: personA },
+      { id: personB },
+      { id: personC },
+      { id: operatorPersonId },
+    ] = await Promise.all([
+      User.Person.getOrCreate({ firstName: "ChainA", lastName: "X" }),
+      User.Person.getOrCreate({ firstName: "ChainB", lastName: "X" }),
+      User.Person.getOrCreate({ firstName: "ChainC", lastName: "X" }),
+      User.Person.getOrCreate({ firstName: "ChainOperator", lastName: "X" }),
+    ]);
+
+    await Promise.all([
+      User.Person.createLocationLink({
+        personId: personA,
+        locationId: location.id,
+      }),
+      User.Person.createLocationLink({
+        personId: personB,
+        locationId: location.id,
+      }),
+      User.Person.createLocationLink({
+        personId: personC,
+        locationId: location.id,
+      }),
+      User.Person.createLocationLink({
+        personId: operatorPersonId,
+        locationId: location.id,
+      }),
+    ]);
+
+    // First merge: A -> B. Writes an audit row with target_person_id = B.
+    await User.Person.mergePersons({
+      personId: personA,
+      targetPersonId: personB,
+      auditMetadata: {
+        performedByPersonId: operatorPersonId,
+        locationId: location.id,
+        source: "personen_page",
+      },
+    });
+
+    const firstAudit = await query
+      .select()
+      .from(s.personMergeAudit)
+      .where(eq(s.personMergeAudit.targetPersonId, personB))
+      .then((rows) => rows[0]);
+    assert.ok(
+      firstAudit,
+      "First merge should have written an audit row targeting B",
+    );
+    assert.equal(firstAudit.sourcePersonId, personA);
+
+    // Second merge: B -> C. B is a prior merge target, so before the FK
+    // drop this delete tripped person_merge_audit_target_person_id_fk.
+    await User.Person.mergePersons({
+      personId: personB,
+      targetPersonId: personC,
+      auditMetadata: {
+        performedByPersonId: operatorPersonId,
+        locationId: location.id,
+        source: "personen_page",
+      },
+    });
+
+    // B is gone.
+    const personBRows = await query
+      .select({ id: s.person.id })
+      .from(s.person)
+      .where(eq(s.person.id, personB));
+    assert.equal(
+      personBRows.length,
+      0,
+      "Person B must be deleted by the second merge",
+    );
+
+    // The historical audit row still points at B — forensic truth is
+    // preserved, NOT repointed to C.
+    const firstAuditAfter = await query
+      .select()
+      .from(s.personMergeAudit)
+      .where(eq(s.personMergeAudit.id, firstAudit.id))
+      .then((rows) => rows[0]);
+    assert.ok(
+      firstAuditAfter,
+      "Historical audit row must survive the second merge",
+    );
+    assert.equal(
+      firstAuditAfter.targetPersonId,
+      personB,
+      "Historical target_person_id must remain B (not repointed to C)",
+    );
+    assert.equal(
+      firstAuditAfter.sourcePersonId,
+      personA,
+      "Historical source_person_id must remain A",
+    );
+
+    // The second merge wrote its own audit row: B -> C.
+    const secondAudit = await query
+      .select()
+      .from(s.personMergeAudit)
+      .where(eq(s.personMergeAudit.sourcePersonId, personB))
+      .then((rows) => rows[0]);
+    assert.ok(secondAudit, "Second merge should have written an audit row");
+    assert.equal(secondAudit.targetPersonId, personC);
+  }));
+
+// REGRESSION (person-merge FK / forensic audit): person_merge_audit no
+// longer carries a RESTRICT FK on performed_by_person_id. A person who
+// PERFORMED a prior merge must still be mergeable; before the FK drop,
+// deleting them tripped person_merge_audit_performed_by_person_id_fk. The
+// historical row must keep recording them as the performer.
+test("user.person.mergePersons allows merging a person who performed a prior merge, preserving the historical performer", () =>
+  withTestTransaction(async () => {
+    const query = useQuery();
+
+    const location = await Location.create({
+      handle: "merge-prior-performer-loc",
+      name: "Merge Prior Performer Location",
+    });
+
+    const [
+      { id: personX },
+      { id: personY },
+      { id: performerPersonId },
+      { id: performerTargetPersonId },
+    ] = await Promise.all([
+      User.Person.getOrCreate({ firstName: "PerfX", lastName: "X" }),
+      User.Person.getOrCreate({ firstName: "PerfY", lastName: "X" }),
+      User.Person.getOrCreate({ firstName: "PerfPerformer", lastName: "X" }),
+      User.Person.getOrCreate({ firstName: "PerfMergeTarget", lastName: "X" }),
+    ]);
+
+    await Promise.all([
+      User.Person.createLocationLink({
+        personId: personX,
+        locationId: location.id,
+      }),
+      User.Person.createLocationLink({
+        personId: personY,
+        locationId: location.id,
+      }),
+      User.Person.createLocationLink({
+        personId: performerPersonId,
+        locationId: location.id,
+      }),
+      User.Person.createLocationLink({
+        personId: performerTargetPersonId,
+        locationId: location.id,
+      }),
+    ]);
+
+    // First merge performed BY performerPersonId. Writes an audit row with
+    // performed_by_person_id = performerPersonId.
+    await User.Person.mergePersons({
+      personId: personX,
+      targetPersonId: personY,
+      auditMetadata: {
+        performedByPersonId: performerPersonId,
+        locationId: location.id,
+        source: "sysadmin",
+      },
+    });
+
+    const firstAudit = await query
+      .select()
+      .from(s.personMergeAudit)
+      .where(eq(s.personMergeAudit.performedByPersonId, performerPersonId))
+      .then((rows) => rows[0]);
+    assert.ok(firstAudit, "First merge should have recorded the performer");
+
+    // Now merge the performer away. Before the FK drop, deleting the
+    // performer tripped person_merge_audit_performed_by_person_id_fk.
+    await User.Person.mergePersons({
+      personId: performerPersonId,
+      targetPersonId: performerTargetPersonId,
+      auditMetadata: {
+        performedByPersonId: performerTargetPersonId,
+        locationId: location.id,
+        source: "sysadmin",
+      },
+    });
+
+    // Performer is gone.
+    const performerRows = await query
+      .select({ id: s.person.id })
+      .from(s.person)
+      .where(eq(s.person.id, performerPersonId));
+    assert.equal(performerRows.length, 0, "Performer person must be deleted");
+
+    // The historical audit row still records performerPersonId as the
+    // performer — forensic truth preserved, NOT repointed.
+    const firstAuditAfter = await query
+      .select()
+      .from(s.personMergeAudit)
+      .where(eq(s.personMergeAudit.id, firstAudit.id))
+      .then((rows) => rows[0]);
+    assert.ok(firstAuditAfter, "Historical audit row must survive");
+    assert.equal(
+      firstAuditAfter.performedByPersonId,
+      performerPersonId,
+      "Historical performed_by_person_id must remain the original performer",
+    );
+  }));
+
+// REGRESSION (person-merge FK / forensic audit): the bulk-import path is
+// the OTHER writer of person_merge_audit (target_person_id +
+// performed_by_person_id). A person recorded as a bulk-import audit
+// target must still be mergeable afterwards, and the bulk-import audit
+// row must keep pointing at that original person.
+test("user.person.mergePersons allows merging a person who was a bulk-import audit target, preserving the bulk-import audit row", () =>
+  withTestTransaction(async () => {
+    const query = useQuery();
+    const location = await Location.create({
+      handle: "merge-bulk-import-target-loc",
+      name: "Merge Bulk Import Target Location",
+    });
+    const { id: existingPersonId } = await User.Person.getOrCreate({
+      firstName: "BulkAdam",
+      lastName: "Vries",
+      lastNamePrefix: "de",
+      dateOfBirth: "2010-05-12",
+    });
+    await User.Person.linkToLocation({
+      personId: existingPersonId,
+      locationId: location.id,
+    });
+    const { id: operatorPersonId } = await User.Person.getOrCreate({
+      firstName: "BulkOperator",
+      lastName: "X",
+    });
+    const { id: mergeTargetPersonId } = await User.Person.getOrCreate({
+      firstName: "BulkMergeTarget",
+      lastName: "X",
+    });
+    await User.Person.linkToLocation({
+      personId: mergeTargetPersonId,
+      locationId: location.id,
+    });
+
+    const preview = await User.Person.previewBulkImport({
+      locationId: location.id,
+      performedByPersonId: operatorPersonId,
+      roles: ["student"],
+      candidates: [
+        {
+          rowIndex: 0,
+          firstName: "BulkAdam",
+          lastName: "Vries",
+          lastNamePrefix: "de",
+          dateOfBirth: "2010-05-12",
+          birthCity: "Amsterdam",
+          birthCountry: "nl",
+          email: null,
+        },
+      ],
+    });
+
+    await User.Person.commitBulkImport({
+      previewToken: preview.previewToken,
+      performedByPersonId: operatorPersonId,
+      decisions: {
+        "0": { kind: "use_existing", personId: existingPersonId },
+      },
+    });
+
+    const bulkAudit = await query
+      .select()
+      .from(s.personMergeAudit)
+      .where(
+        eq(s.personMergeAudit.bulkImportPreviewToken, preview.previewToken),
+      )
+      .then((rows) => rows[0]);
+    assert.ok(bulkAudit, "Bulk import should have written an audit row");
+    assert.equal(bulkAudit.targetPersonId, existingPersonId);
+
+    // Merge the bulk-import audit target away. Before the FK drop this
+    // tripped person_merge_audit_target_person_id_fk.
+    await User.Person.mergePersons({
+      personId: existingPersonId,
+      targetPersonId: mergeTargetPersonId,
+      auditMetadata: {
+        performedByPersonId: operatorPersonId,
+        locationId: location.id,
+        source: "personen_page",
+      },
+    });
+
+    const existingPersonRows = await query
+      .select({ id: s.person.id })
+      .from(s.person)
+      .where(eq(s.person.id, existingPersonId));
+    assert.equal(
+      existingPersonRows.length,
+      0,
+      "Bulk-import audit target must be deletable by a later merge",
+    );
+
+    // The bulk-import audit row still points at the original person.
+    const bulkAuditAfter = await query
+      .select()
+      .from(s.personMergeAudit)
+      .where(eq(s.personMergeAudit.id, bulkAudit.id))
+      .then((rows) => rows[0]);
+    assert.ok(bulkAuditAfter, "Bulk-import audit row must survive the merge");
+    assert.equal(
+      bulkAuditAfter.targetPersonId,
+      existingPersonId,
+      "Bulk-import target_person_id must remain the original person",
+    );
+  }));
+
+// REGRESSION (concurrent merges): mergePersons takes a FOR UPDATE row
+// lock on both person rows, ordered by id, at the very start of the
+// transaction. Two concurrent merges that touch an overlapping person
+// must serialize on that lock instead of deadlocking or both deleting the
+// same source. This test runs OUTSIDE withTestTransaction so each merge
+// gets its own real (serializable) transaction on a separate pooled
+// connection; it commits its fixtures and cleans them up in a finally.
+test("user.person.mergePersons serializes concurrent merges sharing a source person (no deadlock, exactly one wins)", async () => {
+  const pgUri =
+    process.env.PGURI ??
+    "postgresql://postgres:postgres@127.0.0.1:54322/postgres";
+
+  // Make the test self-contained: the withTestTransaction-based tests are
+  // normally the migrators, so migrate here too in case this runs alone.
+  {
+    const migrationDb = createDatabase({ connectionString: pgUri, max: 1 });
+    try {
+      await migrateDatabase(migrationDb);
+    } finally {
+      await migrationDb.$client.end();
+    }
+  }
+
+  await withDatabase({ connectionString: pgUri, max: 5 }, async () => {
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const [{ id: sourceId }, { id: targetOneId }, { id: targetTwoId }] =
+      await Promise.all([
+        User.Person.getOrCreate({
+          firstName: `ConcSource-${unique}`,
+          lastName: "X",
+        }),
+        User.Person.getOrCreate({
+          firstName: `ConcTargetOne-${unique}`,
+          lastName: "X",
+        }),
+        User.Person.getOrCreate({
+          firstName: `ConcTargetTwo-${unique}`,
+          lastName: "X",
+        }),
+      ]);
+
+    try {
+      // Both merges delete the SAME source person. With the FOR UPDATE
+      // lock they serialize on that row: one wins, the other sees the
+      // source already gone (or aborts with a serialization failure) —
+      // never a deadlock.
+      const results = await Promise.allSettled([
+        User.Person.mergePersons({
+          personId: sourceId,
+          targetPersonId: targetOneId,
+        }),
+        User.Person.mergePersons({
+          personId: sourceId,
+          targetPersonId: targetTwoId,
+        }),
+      ]);
+
+      for (const result of results) {
+        if (result.status === "rejected") {
+          const message = String(
+            (result.reason as Error)?.message ?? result.reason,
+          );
+          assert.ok(
+            !/deadlock/i.test(message),
+            `concurrent merges must not deadlock, got: ${message}`,
+          );
+        }
+      }
+
+      const succeeded = results.filter(
+        (result) => result.status === "fulfilled",
+      ).length;
+      assert.equal(
+        succeeded,
+        1,
+        "exactly one concurrent merge sharing the source should succeed",
+      );
+
+      const query = useDatabase();
+      const sourceRows = await query
+        .select({ id: s.person.id })
+        .from(s.person)
+        .where(eq(s.person.id, sourceId));
+      assert.equal(
+        sourceRows.length,
+        0,
+        "the shared source person must be deleted exactly once",
+      );
+    } finally {
+      const query = useDatabase();
+      await query
+        .delete(s.person)
+        .where(inArray(s.person.id, [sourceId, targetOneId, targetTwoId]));
+    }
+  });
+});
 
 // REGRESSION (Bugbot review on PR #461): the canonical-certificate
 // ranking in withModulesRanked must NOT pick a merge-conflict

--- a/packages/core/src/models/user/person.ts
+++ b/packages/core/src/models/user/person.ts
@@ -2420,7 +2420,16 @@ export const mergePersons = wrapCommand(
     }),
     async (input) => {
       return await withTransaction(async (tx) => {
-        // First validate that both persons exist
+        // First validate that both persons exist. We take a FOR UPDATE row
+        // lock on both person rows up front, ordered by id, so two
+        // concurrent merges that touch an overlapping person can't
+        // interleave. The ORDER BY is load-bearing: without a deterministic
+        // lock order, merge(A->B) and merge(B->A) running at the same time
+        // would grab the two rows in opposite orders and deadlock. Locking
+        // min(id) then max(id) in both transactions removes the cycle — one
+        // simply waits for the other. The loser then either sees the source
+        // already gone (length check below) or aborts with a serialization
+        // failure, instead of operating on a half-merged person.
         const persons = await tx
           .select({
             id: s.person.id,
@@ -2433,7 +2442,9 @@ export const mergePersons = wrapCommand(
               inArray(s.person.id, [input.personId, input.targetPersonId]),
               isNull(s.person.deletedAt),
             ),
-          );
+          )
+          .orderBy(s.person.id)
+          .for("update");
 
         if (persons.length !== 2) {
           throw new Error("One or both persons not found");

--- a/packages/db/migrations/0039_cuddly_alex_power.sql
+++ b/packages/db/migrations/0039_cuddly_alex_power.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "person_merge_audit" DROP CONSTRAINT "person_merge_audit_performed_by_person_id_fk";
+
+ALTER TABLE "person_merge_audit" DROP CONSTRAINT "person_merge_audit_target_person_id_fk";

--- a/packages/db/migrations/meta/0039_snapshot.json
+++ b/packages/db/migrations/meta/0039_snapshot.json
@@ -1,0 +1,8306 @@
+{
+  "id": "9c37c395-d728-4fad-a198-c5c8b58b3e9a",
+  "prevId": "6f42f525-5d17-430f-95a0-dfb417a8b364",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "ai_corpus.chunk": {
+      "name": "chunk",
+      "schema": "ai_corpus",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "criterium_id": {
+          "name": "criterium_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "werkproces_id": {
+          "name": "werkproces_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chunk_criterium_quality_idx": {
+          "name": "chunk_criterium_quality_idx",
+          "columns": [
+            {
+              "expression": "criterium_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quality_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chunk_source_idx": {
+          "name": "chunk_source_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chunk_source_id_source_id_fk": {
+          "name": "chunk_source_id_source_id_fk",
+          "tableFrom": "chunk",
+          "tableTo": "source",
+          "schemaTo": "ai_corpus",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chunk_criterium_id_beoordelingscriterium_id_fk": {
+          "name": "chunk_criterium_id_beoordelingscriterium_id_fk",
+          "tableFrom": "chunk",
+          "tableTo": "beoordelingscriterium",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "criterium_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chunk_werkproces_id_werkproces_id_fk": {
+          "name": "chunk_werkproces_id_werkproces_id_fk",
+          "tableFrom": "chunk",
+          "tableTo": "werkproces",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "werkproces_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ai_corpus.outline_template": {
+      "name": "outline_template",
+      "schema": "ai_corpus",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "profiel_id": {
+          "name": "profiel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sections": {
+          "name": "sections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "outline_template_profiel_version_unique": {
+          "name": "outline_template_profiel_version_unique",
+          "columns": [
+            {
+              "expression": "profiel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outline_template_profiel_id_kwalificatieprofiel_id_fk": {
+          "name": "outline_template_profiel_id_kwalificatieprofiel_id_fk",
+          "tableFrom": "outline_template",
+          "tableTo": "kwalificatieprofiel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "profiel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ai_corpus.source": {
+      "name": "source",
+      "schema": "ai_corpus",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "domain": {
+          "name": "domain",
+          "type": "domain",
+          "typeSchema": "ai_corpus",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_identifier": {
+          "name": "source_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_level": {
+          "name": "consent_level",
+          "type": "consent_level",
+          "typeSchema": "ai_corpus",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contributed_by_user_id": {
+          "name": "contributed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profiel_id": {
+          "name": "profiel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "richting": {
+          "name": "richting",
+          "type": "richting",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "niveau_rang": {
+          "name": "niveau_rang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "char_count": {
+          "name": "char_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_storage_path": {
+          "name": "original_storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "source_domain_hash_unique": {
+          "name": "source_domain_hash_unique",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_chat_created_idx": {
+          "name": "source_chat_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_profiel_id_kwalificatieprofiel_id_fk": {
+          "name": "source_profiel_id_kwalificatieprofiel_id_fk",
+          "tableFrom": "source",
+          "tableTo": "kwalificatieprofiel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "profiel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_chat_id_chat_id_fk": {
+          "name": "source_chat_id_chat_id_fk",
+          "tableFrom": "source",
+          "tableTo": "chat",
+          "schemaTo": "leercoach",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bulk_import_preview": {
+      "name": "bulk_import_preview",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_person_id": {
+          "name": "created_by_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_cohort_id": {
+          "name": "target_cohort_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detection_snapshot": {
+          "name": "detection_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rows_parsed": {
+          "name": "rows_parsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "bulk_import_preview_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bulk_import_preview_expires_at_idx": {
+          "name": "bulk_import_preview_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bulk_import_preview_location_id_fk": {
+          "name": "bulk_import_preview_location_id_fk",
+          "tableFrom": "bulk_import_preview",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bulk_import_preview_created_by_person_id_fk": {
+          "name": "bulk_import_preview_created_by_person_id_fk",
+          "tableFrom": "bulk_import_preview",
+          "tableTo": "person",
+          "columnsFrom": [
+            "created_by_person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bulk_import_preview_target_cohort_id_fk": {
+          "name": "bulk_import_preview_target_cohort_id_fk",
+          "tableFrom": "bulk_import_preview",
+          "tableTo": "cohort",
+          "columnsFrom": [
+            "target_cohort_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_merge_audit": {
+      "name": "person_merge_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "performed_by_person_id": {
+          "name": "performed_by_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_person_id": {
+          "name": "source_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_person_id": {
+          "name": "target_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_kind": {
+          "name": "decision_kind",
+          "type": "person_merge_audit_decision_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "presented_candidate_person_ids": {
+          "name": "presented_candidate_person_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "person_merge_audit_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bulk_import_preview_token": {
+          "name": "bulk_import_preview_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_audit_target_person_id_idx": {
+          "name": "person_merge_audit_target_person_id_idx",
+          "columns": [
+            {
+              "expression": "target_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_merge_audit_location_id_idx": {
+          "name": "person_merge_audit_location_id_idx",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_merge_audit_performed_at_idx": {
+          "name": "person_merge_audit_performed_at_idx",
+          "columns": [
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_merge_audit_location_id_fk": {
+          "name": "person_merge_audit_location_id_fk",
+          "tableFrom": "person_merge_audit",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "person_merge_audit_bulk_import_preview_token_fk": {
+          "name": "person_merge_audit_bulk_import_preview_token_fk",
+          "tableFrom": "person_merge_audit",
+          "tableTo": "bulk_import_preview",
+          "columnsFrom": [
+            "bulk_import_preview_token"
+          ],
+          "columnsTo": [
+            "token"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.token": {
+      "name": "token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partial_key": {
+          "name": "partial_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "token_hashed_key_index": {
+          "name": "token_hashed_key_index",
+          "columns": [
+            {
+              "expression": "hashed_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "token_user_id_fk": {
+          "name": "token_user_id_fk",
+          "tableFrom": "token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "auth_user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.token_usage": {
+      "name": "token_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "token_usage_token_id_used_at_index": {
+          "name": "token_usage_token_id_used_at_index",
+          "columns": [
+            {
+              "expression": "token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "used_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "token_usage_token_id_fk": {
+          "name": "token_usage_token_id_fk",
+          "tableFrom": "token_usage",
+          "tableTo": "token",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cohort_allocation_role": {
+      "name": "cohort_allocation_role",
+      "schema": "",
+      "columns": {
+        "cohort_allocation_id": {
+          "name": "cohort_allocation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cohort_allocation_role_allocation_id_fk": {
+          "name": "cohort_allocation_role_allocation_id_fk",
+          "tableFrom": "cohort_allocation_role",
+          "tableTo": "cohort_allocation",
+          "columnsFrom": [
+            "cohort_allocation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_role_role_id_fk": {
+          "name": "user_role_role_id_fk",
+          "tableFrom": "cohort_allocation_role",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "cohort_allocation_role_cohort_allocation_id_role_id_pk": {
+          "name": "cohort_allocation_role_cohort_allocation_id_role_id_pk",
+          "columns": [
+            "cohort_allocation_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_role": {
+      "name": "person_role",
+      "schema": "",
+      "columns": {
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "person_role_person_id_fk": {
+          "name": "person_role_person_id_fk",
+          "tableFrom": "person_role",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_role_role_id_fk": {
+          "name": "user_role_role_id_fk",
+          "tableFrom": "person_role",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "person_role_person_id_role_id_pk": {
+          "name": "person_role_person_id_role_id_pk",
+          "columns": [
+            "person_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.privilege": {
+      "name": "privilege",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "privilege_handle_index": {
+          "name": "privilege_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "role_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "role_handle_index": {
+          "name": "role_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_location_id_fk": {
+          "name": "role_location_id_fk",
+          "tableFrom": "role",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_privilege": {
+      "name": "role_privilege",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privilege_id": {
+          "name": "privilege_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_privilege_role_id_fk": {
+          "name": "role_privilege_role_id_fk",
+          "tableFrom": "role_privilege",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "role_privilege_privilege_id_fk": {
+          "name": "role_privilege_privilege_id_fk",
+          "tableFrom": "role_privilege",
+          "tableTo": "privilege",
+          "columnsFrom": [
+            "privilege_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_privilege_pk": {
+          "name": "role_privilege_pk",
+          "columns": [
+            "role_id",
+            "privilege_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.token_privilege": {
+      "name": "token_privilege",
+      "schema": "",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privilege_id": {
+          "name": "privilege_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "token_privilege_token_id_fk": {
+          "name": "token_privilege_token_id_fk",
+          "tableFrom": "token_privilege",
+          "tableTo": "token",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "token_privilege_privilege_id_fk": {
+          "name": "token_privilege_privilege_id_fk",
+          "tableFrom": "token_privilege",
+          "tableTo": "privilege",
+          "columnsFrom": [
+            "privilege_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "token_privilege_pk": {
+          "name": "token_privilege_pk",
+          "columns": [
+            "token_id",
+            "privilege_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certificate": {
+      "name": "certificate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_curriculum_id": {
+          "name": "student_curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort_allocation_id": {
+          "name": "cohort_allocation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visible_from": {
+          "name": "visible_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "certificate_unq_handle": {
+          "name": "certificate_unq_handle",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_idx_location": {
+          "name": "certificate_idx_location",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_idx_issued_at": {
+          "name": "certificate_idx_issued_at",
+          "columns": [
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_idx_visible_from": {
+          "name": "certificate_idx_visible_from",
+          "columns": [
+            {
+              "expression": "visible_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_idx_deleted_at": {
+          "name": "certificate_idx_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_idx_location_issued_at": {
+          "name": "certificate_idx_location_issued_at",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_idx_handle_search": {
+          "name": "certificate_idx_handle_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', \"handle\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "certificate_student_curriculum_link_id_fk": {
+          "name": "certificate_student_curriculum_link_id_fk",
+          "tableFrom": "certificate",
+          "tableTo": "student_curriculum",
+          "columnsFrom": [
+            "student_curriculum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "certificate_location_id_fk": {
+          "name": "certificate_location_id_fk",
+          "tableFrom": "certificate",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "certificate_cohort_allocation_id_fk": {
+          "name": "certificate_cohort_allocation_id_fk",
+          "tableFrom": "certificate",
+          "tableTo": "cohort_allocation",
+          "columnsFrom": [
+            "cohort_allocation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_certificate": {
+      "name": "external_certificate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuing_authority": {
+          "name": "issuing_authority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuing_location": {
+          "name": "issuing_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awarded_at": {
+          "name": "awarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_comments": {
+          "name": "additional_comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "external_certificate_media_id_media_id_fk": {
+          "name": "external_certificate_media_id_media_id_fk",
+          "tableFrom": "external_certificate",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "external_certificate_person_id_fk": {
+          "name": "external_certificate_person_id_fk",
+          "tableFrom": "external_certificate",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "external_certificate_location_id_fk": {
+          "name": "external_certificate_location_id_fk",
+          "tableFrom": "external_certificate",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_completed_competency": {
+      "name": "student_completed_competency",
+      "schema": "",
+      "columns": {
+        "student_curriculum_id": {
+          "name": "student_curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "curriculum_module_competency_id": {
+          "name": "curriculum_module_competency_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "certificate_id": {
+          "name": "certificate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_merge_conflict_duplicate": {
+          "name": "is_merge_conflict_duplicate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "student_completed_competency_unq_active_non_merge": {
+          "name": "student_completed_competency_unq_active_non_merge",
+          "columns": [
+            {
+              "expression": "student_curriculum_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "curriculum_module_competency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"student_completed_competency\".\"is_merge_conflict_duplicate\" = false AND \"student_completed_competency\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_completed_competency_student_curriculum_link_id_fk": {
+          "name": "student_completed_competency_student_curriculum_link_id_fk",
+          "tableFrom": "student_completed_competency",
+          "tableTo": "student_curriculum",
+          "columnsFrom": [
+            "student_curriculum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "curriculum_competency_competency_id_fk": {
+          "name": "curriculum_competency_competency_id_fk",
+          "tableFrom": "student_completed_competency",
+          "tableTo": "curriculum_competency",
+          "columnsFrom": [
+            "curriculum_module_competency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_completed_competency_certificate_id_fk": {
+          "name": "student_completed_competency_certificate_id_fk",
+          "tableFrom": "student_completed_competency",
+          "tableTo": "certificate",
+          "columnsFrom": [
+            "certificate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "student_completed_competency_pk": {
+          "name": "student_completed_competency_pk",
+          "columns": [
+            "student_curriculum_id",
+            "curriculum_module_competency_id",
+            "certificate_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_curriculum": {
+      "name": "student_curriculum",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "curriculum_id": {
+          "name": "curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_type_id": {
+          "name": "gear_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "student_curriculum_unq_identity_gear_curriculum": {
+          "name": "student_curriculum_unq_identity_gear_curriculum",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "curriculum_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gear_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"student_curriculum\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "student_curriculum_idx_person": {
+          "name": "student_curriculum_idx_person",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_curriculum_link_curriculum_id_gear_type_id_fk": {
+          "name": "student_curriculum_link_curriculum_id_gear_type_id_fk",
+          "tableFrom": "student_curriculum",
+          "tableTo": "curriculum_gear_link",
+          "columnsFrom": [
+            "curriculum_id",
+            "gear_type_id"
+          ],
+          "columnsTo": [
+            "curriculum_id",
+            "gear_type_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_curriculum_link_curriculum_id_fk": {
+          "name": "student_curriculum_link_curriculum_id_fk",
+          "tableFrom": "student_curriculum",
+          "tableTo": "curriculum",
+          "columnsFrom": [
+            "curriculum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_curriculum_link_gear_type_id_fk": {
+          "name": "student_curriculum_link_gear_type_id_fk",
+          "tableFrom": "student_curriculum",
+          "tableTo": "gear_type",
+          "columnsFrom": [
+            "gear_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_curriculum_link_person_id_fk": {
+          "name": "student_curriculum_link_person_id_fk",
+          "tableFrom": "student_curriculum",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cohort": {
+      "name": "cohort",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_start_time": {
+          "name": "access_start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_end_time": {
+          "name": "access_end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "certificates_visible_from": {
+          "name": "certificates_visible_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cohort_handle_location_id_index": {
+          "name": "cohort_handle_location_id_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cohort_location_id_fk": {
+          "name": "cohort_location_id_fk",
+          "tableFrom": "cohort",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cohort_allocation": {
+      "name": "cohort_allocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "cohort_id": {
+          "name": "cohort_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_curriculum_id": {
+          "name": "student_curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructor_id": {
+          "name": "instructor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "progress_visible_up_until": {
+          "name": "progress_visible_up_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cohort_allocation_cohort_id_actor_id_student_curriculum_id_index": {
+          "name": "cohort_allocation_cohort_id_actor_id_student_curriculum_id_index",
+          "columns": [
+            {
+              "expression": "cohort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_curriculum_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cohort_allocation\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cohort_allocation_cohort_id_tags_index": {
+          "name": "cohort_allocation_cohort_id_tags_index",
+          "columns": [
+            {
+              "expression": "cohort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cohort_allocation_cohort_id_fk": {
+          "name": "cohort_allocation_cohort_id_fk",
+          "tableFrom": "cohort_allocation",
+          "tableTo": "cohort",
+          "columnsFrom": [
+            "cohort_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cohort_allocation_actor_id_fk": {
+          "name": "cohort_allocation_actor_id_fk",
+          "tableFrom": "cohort_allocation",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cohort_allocation_student_curriculum_id_fk": {
+          "name": "cohort_allocation_student_curriculum_id_fk",
+          "tableFrom": "cohort_allocation",
+          "tableTo": "student_curriculum",
+          "columnsFrom": [
+            "student_curriculum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cohort_allocation_instructor_id_fk": {
+          "name": "cohort_allocation_instructor_id_fk",
+          "tableFrom": "cohort_allocation",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "instructor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category": {
+      "name": "category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "parent_category_id": {
+          "name": "parent_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "category_handle_index": {
+          "name": "category_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "category_parent_category_id_fk": {
+          "name": "category_parent_category_id_fk",
+          "tableFrom": "category",
+          "tableTo": "category",
+          "columnsFrom": [
+            "parent_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competency": {
+      "name": "competency",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "competency_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "competency_handle_index": {
+          "name": "competency_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course": {
+      "name": "course",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discipline_id": {
+          "name": "discipline_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "course_handle_index": {
+          "name": "course_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_discipline_id_fk": {
+          "name": "course_discipline_id_fk",
+          "tableFrom": "course",
+          "tableTo": "discipline",
+          "columnsFrom": [
+            "discipline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_category": {
+      "name": "course_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "course_category_category_id_course_id_index": {
+          "name": "course_category_category_id_course_id_index",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_category_course_id_fk": {
+          "name": "course_category_course_id_fk",
+          "tableFrom": "course_category",
+          "tableTo": "course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "course_category_category_id_fk": {
+          "name": "course_category_category_id_fk",
+          "tableFrom": "course_category",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.degree": {
+      "name": "degree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rang": {
+          "name": "rang",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "degree_handle_index": {
+          "name": "degree_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "degree_rang_index": {
+          "name": "degree_rang_index",
+          "columns": [
+            {
+              "expression": "rang",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discipline": {
+      "name": "discipline",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "discipline_handle_index": {
+          "name": "discipline_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gear_type": {
+      "name": "gear_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gear_type_handle_index": {
+          "name": "gear_type_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.module": {
+      "name": "module",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "module_handle_index": {
+          "name": "module_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.program": {
+      "name": "program",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degree_id": {
+          "name": "degree_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "program_handle_index": {
+          "name": "program_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "program_course_id_fk": {
+          "name": "program_course_id_fk",
+          "tableFrom": "program",
+          "tableTo": "course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_degree_id_fk": {
+          "name": "program_degree_id_fk",
+          "tableFrom": "program",
+          "tableTo": "degree",
+          "columnsFrom": [
+            "degree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curriculum": {
+      "name": "curriculum",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "curriculum_program_id_revision_index": {
+          "name": "curriculum_program_id_revision_index",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curriculum_program_id_fk": {
+          "name": "curriculum_program_id_fk",
+          "tableFrom": "curriculum",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curriculum_competency": {
+      "name": "curriculum_competency",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "curriculum_id": {
+          "name": "curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competency_id": {
+          "name": "competency_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement": {
+          "name": "requirement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "curriculum_competency_unq_set": {
+          "name": "curriculum_competency_unq_set",
+          "columns": [
+            {
+              "expression": "curriculum_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "module_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curriculum_competency_curriculum_module_id_fk": {
+          "name": "curriculum_competency_curriculum_module_id_fk",
+          "tableFrom": "curriculum_competency",
+          "tableTo": "curriculum_module",
+          "columnsFrom": [
+            "curriculum_id",
+            "module_id"
+          ],
+          "columnsTo": [
+            "curriculum_id",
+            "module_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "curriculum_competency_competency_id_fk": {
+          "name": "curriculum_competency_competency_id_fk",
+          "tableFrom": "curriculum_competency",
+          "tableTo": "competency",
+          "columnsFrom": [
+            "competency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curriculum_gear_link": {
+      "name": "curriculum_gear_link",
+      "schema": "",
+      "columns": {
+        "curriculum_id": {
+          "name": "curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_type_id": {
+          "name": "gear_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "curriculum_gear_link_curriculum_id_fk": {
+          "name": "curriculum_gear_link_curriculum_id_fk",
+          "tableFrom": "curriculum_gear_link",
+          "tableTo": "curriculum",
+          "columnsFrom": [
+            "curriculum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "curriculum_gear_link_gear_type_id_fk": {
+          "name": "curriculum_gear_link_gear_type_id_fk",
+          "tableFrom": "curriculum_gear_link",
+          "tableTo": "gear_type",
+          "columnsFrom": [
+            "gear_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curriculum_gear_link_curriculum_id_gear_type_id_pk": {
+          "name": "curriculum_gear_link_curriculum_id_gear_type_id_pk",
+          "columns": [
+            "curriculum_id",
+            "gear_type_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curriculum_module": {
+      "name": "curriculum_module",
+      "schema": "",
+      "columns": {
+        "curriculum_id": {
+          "name": "curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "curriculum_module_curriculum_id_module_id_index": {
+          "name": "curriculum_module_curriculum_id_module_id_index",
+          "columns": [
+            {
+              "expression": "curriculum_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "module_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curriculum_module_curriculum_id_fk": {
+          "name": "curriculum_module_curriculum_id_fk",
+          "tableFrom": "curriculum_module",
+          "tableTo": "curriculum",
+          "columnsFrom": [
+            "curriculum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "curriculum_module_module_id_fk": {
+          "name": "curriculum_module_module_id_fk",
+          "tableFrom": "curriculum_module",
+          "tableTo": "module",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curriculum_module_curriculum_id_module_id_pk": {
+          "name": "curriculum_module_curriculum_id_module_id_pk",
+          "columns": [
+            "curriculum_id",
+            "module_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.instructie_groep": {
+      "name": "instructie_groep",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "richting": {
+          "name": "richting",
+          "type": "richting",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.instructie_groep_cursus": {
+      "name": "instructie_groep_cursus",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "instructie_groep_id": {
+          "name": "instructie_groep_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "instructie_groep_cursus_instructie_groep_id_course_id_index": {
+          "name": "instructie_groep_cursus_instructie_groep_id_course_id_index",
+          "columns": [
+            {
+              "expression": "instructie_groep_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instructie_groep_cursus_instructie_groep_id_instructie_groep_id_fk": {
+          "name": "instructie_groep_cursus_instructie_groep_id_instructie_groep_id_fk",
+          "tableFrom": "instructie_groep_cursus",
+          "tableTo": "instructie_groep",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "instructie_groep_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instructie_groep_cursus_course_id_course_id_fk": {
+          "name": "instructie_groep_cursus_course_id_course_id_fk",
+          "tableFrom": "instructie_groep_cursus",
+          "tableTo": "course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.persoon_kwalificatie": {
+      "name": "persoon_kwalificatie",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "direct_behaalde_pvb_onderdeel_id": {
+          "name": "direct_behaalde_pvb_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "afgeleide_pvb_onderdeel_id": {
+          "name": "afgeleide_pvb_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_onderdeel_id": {
+          "name": "kerntaak_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verkregen_reden": {
+          "name": "verkregen_reden",
+          "type": "kwalificatie_verkregen_reden",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'onbekend'"
+        },
+        "toegevoegd_op": {
+          "name": "toegevoegd_op",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toegevoegd_door": {
+          "name": "toegevoegd_door",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "unique_person_course_kerntaak_onderdeel": {
+          "name": "unique_person_course_kerntaak_onderdeel",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kerntaak_onderdeel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "persoon_kwalificatie_direct_behaalde_pvb_onderdeel_id_kerntaak_onderdeel_id_pvb_onderdeel_id_kerntaak_onderdeel_id_fk": {
+          "name": "persoon_kwalificatie_direct_behaalde_pvb_onderdeel_id_kerntaak_onderdeel_id_pvb_onderdeel_id_kerntaak_onderdeel_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "tableTo": "pvb_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "direct_behaalde_pvb_onderdeel_id",
+            "kerntaak_onderdeel_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_onderdeel_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persoon_kwalificatie_afgeleide_pvb_onderdeel_id_kerntaak_onderdeel_id_pvb_onderdeel_id_kerntaak_onderdeel_id_fk": {
+          "name": "persoon_kwalificatie_afgeleide_pvb_onderdeel_id_kerntaak_onderdeel_id_pvb_onderdeel_id_kerntaak_onderdeel_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "tableTo": "pvb_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "afgeleide_pvb_onderdeel_id",
+            "kerntaak_onderdeel_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_onderdeel_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persoon_kwalificatie_kerntaak_onderdeel_id_kerntaak_onderdeel_id_fk": {
+          "name": "persoon_kwalificatie_kerntaak_onderdeel_id_kerntaak_onderdeel_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "tableTo": "kerntaak_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_onderdeel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persoon_kwalificatie_course_id_course_id_fk": {
+          "name": "persoon_kwalificatie_course_id_course_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "tableTo": "course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persoon_kwalificatie_toegevoegd_door_actor_id_fk": {
+          "name": "persoon_kwalificatie_toegevoegd_door_actor_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "toegevoegd_door"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persoon_kwalificatie_person_id_person_id_fk": {
+          "name": "persoon_kwalificatie_person_id_person_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verkregen_reden_pvb_behaald_constraint": {
+          "name": "verkregen_reden_pvb_behaald_constraint",
+          "value": "(\"kss\".\"persoon_kwalificatie\".\"verkregen_reden\" != 'pvb_behaald') OR (\"kss\".\"persoon_kwalificatie\".\"direct_behaalde_pvb_onderdeel_id\" IS NOT NULL AND \"kss\".\"persoon_kwalificatie\".\"afgeleide_pvb_onderdeel_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "kss.pvb_aanvraag": {
+      "name": "pvb_aanvraag",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kandidaat_id": {
+          "name": "kandidaat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locatie_id": {
+          "name": "locatie_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "pvb_aanvraag_type",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_aanvraag_kandidaat_id_person_id_fk": {
+          "name": "pvb_aanvraag_kandidaat_id_person_id_fk",
+          "tableFrom": "pvb_aanvraag",
+          "tableTo": "person",
+          "columnsFrom": [
+            "kandidaat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_aanvraag_locatie_id_location_id_fk": {
+          "name": "pvb_aanvraag_locatie_id_location_id_fk",
+          "tableFrom": "pvb_aanvraag",
+          "tableTo": "location",
+          "columnsFrom": [
+            "locatie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pvb_aanvraag_handle_unique": {
+          "name": "pvb_aanvraag_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_aanvraag_course": {
+      "name": "pvb_aanvraag_course",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructie_groep_id": {
+          "name": "instructie_groep_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_main_course": {
+          "name": "is_main_course",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pvb_aanvraag_course_pvb_aanvraag_id_instructie_groep_id_index": {
+          "name": "pvb_aanvraag_course_pvb_aanvraag_id_instructie_groep_id_index",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instructie_groep_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kss\".\"pvb_aanvraag_course\".\"is_main_course\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pvb_aanvraag_course_pvb_aanvraag_id_instructie_groep_id_course_id_index": {
+          "name": "pvb_aanvraag_course_pvb_aanvraag_id_instructie_groep_id_course_id_index",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instructie_groep_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pvb_aanvraag_course_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_aanvraag_course_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_aanvraag_course",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_aanvraag_course_course_id_course_id_fk": {
+          "name": "pvb_aanvraag_course_course_id_course_id_fk",
+          "tableFrom": "pvb_aanvraag_course",
+          "tableTo": "course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_aanvraag_course_instructie_groep_id_instructie_groep_id_fk": {
+          "name": "pvb_aanvraag_course_instructie_groep_id_instructie_groep_id_fk",
+          "tableFrom": "pvb_aanvraag_course",
+          "tableTo": "instructie_groep",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "instructie_groep_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_aanvraag_status": {
+      "name": "pvb_aanvraag_status",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "aanvraag_status",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aangemaakt_op": {
+          "name": "aangemaakt_op",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "aangemaakt_door": {
+          "name": "aangemaakt_door",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reden": {
+          "name": "reden",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_aanvraag_status_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_aanvraag_status_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_aanvraag_status",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_aanvraag_status_aangemaakt_door_actor_id_fk": {
+          "name": "pvb_aanvraag_status_aangemaakt_door_actor_id_fk",
+          "tableFrom": "pvb_aanvraag_status",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "aangemaakt_door"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_beoordelaar_beschikbaarheid": {
+      "name": "pvb_beoordelaar_beschikbaarheid",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beoordelaar_id": {
+          "name": "beoordelaar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pvb_voorstel_datum_id": {
+          "name": "pvb_voorstel_datum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_beoordelaar_beschikbaarheid_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_beoordelaar_beschikbaarheid_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_beoordelaar_beschikbaarheid",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_beoordelaar_beschikbaarheid_beoordelaar_id_person_id_fk": {
+          "name": "pvb_beoordelaar_beschikbaarheid_beoordelaar_id_person_id_fk",
+          "tableFrom": "pvb_beoordelaar_beschikbaarheid",
+          "tableTo": "person",
+          "columnsFrom": [
+            "beoordelaar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_beoordelaar_beschikbaarheid_pvb_voorstel_datum_id_pvb_aanvraag_id_pvb_voorstel_datum_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_beoordelaar_beschikbaarheid_pvb_voorstel_datum_id_pvb_aanvraag_id_pvb_voorstel_datum_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_beoordelaar_beschikbaarheid",
+          "tableTo": "pvb_voorstel_datum",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_voorstel_datum_id",
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id",
+            "pvb_aanvraag_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_beoordelaar_beschikbaarheid_status": {
+      "name": "pvb_beoordelaar_beschikbaarheid_status",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_beoordelaar_beschikbaarheid_id": {
+          "name": "pvb_beoordelaar_beschikbaarheid_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "beoordelaar_beschikbaarheidsstatus",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aangemaakt_op": {
+          "name": "aangemaakt_op",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "aangemaakt_door": {
+          "name": "aangemaakt_door",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reden": {
+          "name": "reden",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_beoordelaar_beschikbaarheid_status_pvb_beoordelaar_beschikbaarheid_id_pvb_beoordelaar_beschikbaarheid_id_fk": {
+          "name": "pvb_beoordelaar_beschikbaarheid_status_pvb_beoordelaar_beschikbaarheid_id_pvb_beoordelaar_beschikbaarheid_id_fk",
+          "tableFrom": "pvb_beoordelaar_beschikbaarheid_status",
+          "tableTo": "pvb_beoordelaar_beschikbaarheid",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_beoordelaar_beschikbaarheid_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_beoordelaar_beschikbaarheid_status_aangemaakt_door_actor_id_fk": {
+          "name": "pvb_beoordelaar_beschikbaarheid_status_aangemaakt_door_actor_id_fk",
+          "tableFrom": "pvb_beoordelaar_beschikbaarheid_status",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "aangemaakt_door"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_beoordelaar_onderdeel_beschikbaarheid": {
+      "name": "pvb_beoordelaar_onderdeel_beschikbaarheid",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_beoordelaar_beschikbaarheid_id": {
+          "name": "pvb_beoordelaar_beschikbaarheid_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pvb_onderdeel_id": {
+          "name": "pvb_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_beoordelaar_onderdeel_beschikbaarheid_pvb_beoordelaar_beschikbaarheid_id_pvb_beoordelaar_beschikbaarheid_id_fk": {
+          "name": "pvb_beoordelaar_onderdeel_beschikbaarheid_pvb_beoordelaar_beschikbaarheid_id_pvb_beoordelaar_beschikbaarheid_id_fk",
+          "tableFrom": "pvb_beoordelaar_onderdeel_beschikbaarheid",
+          "tableTo": "pvb_beoordelaar_beschikbaarheid",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_beoordelaar_beschikbaarheid_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_beoordelaar_onderdeel_beschikbaarheid_pvb_onderdeel_id_pvb_onderdeel_id_fk": {
+          "name": "pvb_beoordelaar_onderdeel_beschikbaarheid_pvb_onderdeel_id_pvb_onderdeel_id_fk",
+          "tableFrom": "pvb_beoordelaar_onderdeel_beschikbaarheid",
+          "tableTo": "pvb_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_onderdeel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_gebeurtenis": {
+      "name": "pvb_gebeurtenis",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pvb_onderdeel_id": {
+          "name": "pvb_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gebeurtenis_type": {
+          "name": "gebeurtenis_type",
+          "type": "pvb_gebeurtenis_type",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aangemaakt_op": {
+          "name": "aangemaakt_op",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "aangemaakt_door": {
+          "name": "aangemaakt_door",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reden": {
+          "name": "reden",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_gebeurtenis_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_gebeurtenis_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_gebeurtenis",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_gebeurtenis_pvb_onderdeel_id_pvb_onderdeel_id_fk": {
+          "name": "pvb_gebeurtenis_pvb_onderdeel_id_pvb_onderdeel_id_fk",
+          "tableFrom": "pvb_gebeurtenis",
+          "tableTo": "pvb_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_onderdeel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_gebeurtenis_aangemaakt_door_actor_id_fk": {
+          "name": "pvb_gebeurtenis_aangemaakt_door_actor_id_fk",
+          "tableFrom": "pvb_gebeurtenis",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "aangemaakt_door"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_leercoach_toestemming": {
+      "name": "pvb_leercoach_toestemming",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leercoach_id": {
+          "name": "leercoach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "leercoach_toestemming_status",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aangemaakt_op": {
+          "name": "aangemaakt_op",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "aangemaakt_door": {
+          "name": "aangemaakt_door",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reden": {
+          "name": "reden",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pvb_leercoach_toestemming_recent_idx": {
+          "name": "pvb_leercoach_toestemming_recent_idx",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "leercoach_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "aangemaakt_op",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pvb_leercoach_toestemming_status_idx": {
+          "name": "pvb_leercoach_toestemming_status_idx",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "leercoach_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pvb_leercoach_toestemming_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_leercoach_toestemming_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_leercoach_toestemming",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_leercoach_toestemming_leercoach_id_person_id_fk": {
+          "name": "pvb_leercoach_toestemming_leercoach_id_person_id_fk",
+          "tableFrom": "pvb_leercoach_toestemming",
+          "tableTo": "person",
+          "columnsFrom": [
+            "leercoach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_leercoach_toestemming_aangemaakt_door_actor_id_fk": {
+          "name": "pvb_leercoach_toestemming_aangemaakt_door_actor_id_fk",
+          "tableFrom": "pvb_leercoach_toestemming",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "aangemaakt_door"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_onderdeel": {
+      "name": "pvb_onderdeel",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_onderdeel_id": {
+          "name": "kerntaak_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beoordelaar_id": {
+          "name": "beoordelaar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_datum_tijd": {
+          "name": "start_datum_tijd",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uitslag": {
+          "name": "uitslag",
+          "type": "pvb_onderdeel_uitslag",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'nog_niet_bekend'"
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pvb_onderdeel_aanvraag_id_kerntaak_onderdeel_id_beoordelaar_id_unique": {
+          "name": "pvb_onderdeel_aanvraag_id_kerntaak_onderdeel_id_beoordelaar_id_unique",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kerntaak_onderdeel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "beoordelaar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pvb_onderdeel_aanvraag_id_kerntaak_onderdeel_id_unique": {
+          "name": "pvb_onderdeel_aanvraag_id_kerntaak_onderdeel_id_unique",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kerntaak_onderdeel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pvb_onderdeel_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_onderdeel_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_onderdeel",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_onderdeel_kerntaak_onderdeel_id_kerntaak_id_kerntaak_onderdeel_id_kerntaak_id_fk": {
+          "name": "pvb_onderdeel_kerntaak_onderdeel_id_kerntaak_id_kerntaak_onderdeel_id_kerntaak_id_fk",
+          "tableFrom": "pvb_onderdeel",
+          "tableTo": "kerntaak_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_onderdeel_id",
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_onderdeel_kerntaak_id_kerntaak_id_fk": {
+          "name": "pvb_onderdeel_kerntaak_id_kerntaak_id_fk",
+          "tableFrom": "pvb_onderdeel",
+          "tableTo": "kerntaak",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_onderdeel_beoordelaar_id_person_id_fk": {
+          "name": "pvb_onderdeel_beoordelaar_id_person_id_fk",
+          "tableFrom": "pvb_onderdeel",
+          "tableTo": "person",
+          "columnsFrom": [
+            "beoordelaar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pvb_onderdeel_id_kerntaak_onderdeel_id_unique": {
+          "name": "pvb_onderdeel_id_kerntaak_onderdeel_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "kerntaak_onderdeel_id"
+          ]
+        },
+        "pvb_onderdeel_id_kerntaak_onderdeel_id_beoordelaar_id_unique": {
+          "name": "pvb_onderdeel_id_kerntaak_onderdeel_id_beoordelaar_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "kerntaak_onderdeel_id",
+            "beoordelaar_id"
+          ]
+        },
+        "pvb_onderdeel_id_kerntaak_id_unique": {
+          "name": "pvb_onderdeel_id_kerntaak_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "kerntaak_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_onderdeel_beoordelingscriterium": {
+      "name": "pvb_onderdeel_beoordelingscriterium",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_onderdeel_id": {
+          "name": "pvb_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beoordelingscriterium_id": {
+          "name": "beoordelingscriterium_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "behaald": {
+          "name": "behaald",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_onderdeel_beoordelingscriterium_pvb_onderdeel_id_kerntaak_id_pvb_onderdeel_id_kerntaak_id_fk": {
+          "name": "pvb_onderdeel_beoordelingscriterium_pvb_onderdeel_id_kerntaak_id_pvb_onderdeel_id_kerntaak_id_fk",
+          "tableFrom": "pvb_onderdeel_beoordelingscriterium",
+          "tableTo": "pvb_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_onderdeel_id",
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_onderdeel_beoordelingscriterium_beoordelingscriterium_id_kerntaak_id_beoordelingscriterium_id_kerntaak_id_fk": {
+          "name": "pvb_onderdeel_beoordelingscriterium_beoordelingscriterium_id_kerntaak_id_beoordelingscriterium_id_kerntaak_id_fk",
+          "tableFrom": "pvb_onderdeel_beoordelingscriterium",
+          "tableTo": "beoordelingscriterium",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "beoordelingscriterium_id",
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_onderdeel_beoordelingscriterium_kerntaak_id_kerntaak_id_fk": {
+          "name": "pvb_onderdeel_beoordelingscriterium_kerntaak_id_kerntaak_id_fk",
+          "tableFrom": "pvb_onderdeel_beoordelingscriterium",
+          "tableTo": "kerntaak",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pvb_onderdeel_beoordelingscriterium_pvb_onderdeel_id_beoordelingscriterium_id_unique": {
+          "name": "pvb_onderdeel_beoordelingscriterium_pvb_onderdeel_id_beoordelingscriterium_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pvb_onderdeel_id",
+            "beoordelingscriterium_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_voorstel_datum": {
+      "name": "pvb_voorstel_datum",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_na": {
+          "name": "start_na",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eind_voor": {
+          "name": "eind_voor",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voorkeur": {
+          "name": "voorkeur",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_voorstel_datum_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_voorstel_datum_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_voorstel_datum",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pvb_voorstel_datum_id_pvb_aanvraag_id_unique": {
+          "name": "pvb_voorstel_datum_id_pvb_aanvraag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "pvb_aanvraag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.beoordelingscriterium": {
+      "name": "beoordelingscriterium",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "werkproces_id": {
+          "name": "werkproces_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rang": {
+          "name": "rang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "omschrijving": {
+          "name": "omschrijving",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "beoordelingscriterium_werkproces_id_kerntaak_id_werkproces_id_kerntaak_id_fk": {
+          "name": "beoordelingscriterium_werkproces_id_kerntaak_id_werkproces_id_kerntaak_id_fk",
+          "tableFrom": "beoordelingscriterium",
+          "tableTo": "werkproces",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "werkproces_id",
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "beoordelingscriterium_kerntaak_id_kerntaak_id_fk": {
+          "name": "beoordelingscriterium_kerntaak_id_kerntaak_id_fk",
+          "tableFrom": "beoordelingscriterium",
+          "tableTo": "kerntaak",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "beoordelingscriterium_id_kerntaak_id_unique": {
+          "name": "beoordelingscriterium_id_kerntaak_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "kerntaak_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.kerntaak": {
+      "name": "kerntaak",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "titel": {
+          "name": "titel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kwalificatieprofiel_id": {
+          "name": "kwalificatieprofiel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "kerntaakType",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rang": {
+          "name": "rang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kerntaak_kwalificatieprofiel_id_kwalificatieprofiel_id_fk": {
+          "name": "kerntaak_kwalificatieprofiel_id_kwalificatieprofiel_id_fk",
+          "tableFrom": "kerntaak",
+          "tableTo": "kwalificatieprofiel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kwalificatieprofiel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.kerntaak_onderdeel": {
+      "name": "kerntaak_onderdeel",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beoordelingsType": {
+          "name": "beoordelingsType",
+          "type": "kerntaakOnderdeelType",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kerntaak_onderdeel_kerntaak_id_kerntaak_id_fk": {
+          "name": "kerntaak_onderdeel_kerntaak_id_kerntaak_id_fk",
+          "tableFrom": "kerntaak_onderdeel",
+          "tableTo": "kerntaak",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kerntaak_onderdeel_id_kerntaak_id_unique": {
+          "name": "kerntaak_onderdeel_id_kerntaak_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "kerntaak_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.kwalificatieprofiel": {
+      "name": "kwalificatieprofiel",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "titel": {
+          "name": "titel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "richting": {
+          "name": "richting",
+          "type": "richting",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "niveau_id": {
+          "name": "niveau_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kwalificatieprofiel_niveau_id_niveau_id_fk": {
+          "name": "kwalificatieprofiel_niveau_id_niveau_id_fk",
+          "tableFrom": "kwalificatieprofiel",
+          "tableTo": "niveau",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "niveau_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.niveau": {
+      "name": "niveau",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "rang": {
+          "name": "rang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.werkproces": {
+      "name": "werkproces",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "titel": {
+          "name": "titel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resultaat": {
+          "name": "resultaat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rang": {
+          "name": "rang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "werkproces_kerntaak_id_kerntaak_id_fk": {
+          "name": "werkproces_kerntaak_id_kerntaak_id_fk",
+          "tableFrom": "werkproces",
+          "tableTo": "kerntaak",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "werkproces_id_kerntaak_id_unique": {
+          "name": "werkproces_id_kerntaak_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "kerntaak_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.werkproces_kerntaak_onderdeel": {
+      "name": "werkproces_kerntaak_onderdeel",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "werkproces_id": {
+          "name": "werkproces_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_onderdeel_id": {
+          "name": "kerntaak_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "werkproces_kerntaak_onderdeel_werkproces_id_kerntaak_id_werkproces_id_kerntaak_id_fk": {
+          "name": "werkproces_kerntaak_onderdeel_werkproces_id_kerntaak_id_werkproces_id_kerntaak_id_fk",
+          "tableFrom": "werkproces_kerntaak_onderdeel",
+          "tableTo": "werkproces",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "werkproces_id",
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "werkproces_kerntaak_onderdeel_kerntaak_onderdeel_id_kerntaak_id_kerntaak_onderdeel_id_kerntaak_id_fk": {
+          "name": "werkproces_kerntaak_onderdeel_kerntaak_onderdeel_id_kerntaak_id_kerntaak_onderdeel_id_kerntaak_id_fk",
+          "tableFrom": "werkproces_kerntaak_onderdeel",
+          "tableTo": "kerntaak_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_onderdeel_id",
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "werkproces_kerntaak_onderdeel_werkproces_id_kerntaak_onderdeel_id_unique": {
+          "name": "werkproces_kerntaak_onderdeel_werkproces_id_kerntaak_onderdeel_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "werkproces_id",
+            "kerntaak_onderdeel_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leercoach.chat": {
+      "name": "chat",
+      "schema": "leercoach",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profiel_id": {
+          "name": "profiel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructie_groep_id": {
+          "name": "instructie_groep_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "chat_phase",
+          "typeSchema": "leercoach",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verkennen'"
+        },
+        "active_stream_id": {
+          "name": "active_stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portfolio_id": {
+          "name": "portfolio_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "chat_user_created_idx": {
+          "name": "chat_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_profiel_idx": {
+          "name": "chat_profiel_idx",
+          "columns": [
+            {
+              "expression": "profiel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_profiel_id_kwalificatieprofiel_id_fk": {
+          "name": "chat_profiel_id_kwalificatieprofiel_id_fk",
+          "tableFrom": "chat",
+          "tableTo": "kwalificatieprofiel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "profiel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "chat_instructie_groep_id_instructie_groep_id_fk": {
+          "name": "chat_instructie_groep_id_instructie_groep_id_fk",
+          "tableFrom": "chat",
+          "tableTo": "instructie_groep",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "instructie_groep_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leercoach.message": {
+      "name": "message",
+      "schema": "leercoach",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "compacted_into_id": {
+          "name": "compacted_into_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compaction_metadata": {
+          "name": "compaction_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "message_chat_created_idx": {
+          "name": "message_chat_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_active_chat_created_idx": {
+          "name": "message_active_chat_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"leercoach\".\"message\".\"compacted_into_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_chat_id_chat_id_fk": {
+          "name": "message_chat_id_chat_id_fk",
+          "tableFrom": "message",
+          "tableTo": "chat",
+          "schemaTo": "leercoach",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leercoach.portfolio": {
+      "name": "portfolio",
+      "schema": "leercoach",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profiel_id": {
+          "name": "profiel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructie_groep_id": {
+          "name": "instructie_groep_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "portfolio_user_created_idx": {
+          "name": "portfolio_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "portfolio_user_profiel_groep_idx": {
+          "name": "portfolio_user_profiel_groep_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profiel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instructie_groep_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "portfolio_instructie_groep_id_instructie_groep_id_fk": {
+          "name": "portfolio_instructie_groep_id_instructie_groep_id_fk",
+          "tableFrom": "portfolio",
+          "tableTo": "instructie_groep",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "instructie_groep_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leercoach.portfolio_version": {
+      "name": "portfolio_version",
+      "schema": "leercoach",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "portfolio_id": {
+          "name": "portfolio_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "portfolio_version_created_by",
+          "typeSchema": "leercoach",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_message_id": {
+          "name": "created_by_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_note": {
+          "name": "change_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "portfolio_version_portfolio_created_idx": {
+          "name": "portfolio_version_portfolio_created_idx",
+          "columns": [
+            {
+              "expression": "portfolio_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "portfolio_version_portfolio_hash_unique": {
+          "name": "portfolio_version_portfolio_hash_unique",
+          "columns": [
+            {
+              "expression": "portfolio_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "portfolio_version_portfolio_id_portfolio_id_fk": {
+          "name": "portfolio_version_portfolio_id_portfolio_id_fk",
+          "tableFrom": "portfolio_version",
+          "tableTo": "portfolio",
+          "schemaTo": "leercoach",
+          "columnsFrom": [
+            "portfolio_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "portfolio_version_parent_version_id_portfolio_version_id_fk": {
+          "name": "portfolio_version_parent_version_id_portfolio_version_id_fk",
+          "tableFrom": "portfolio_version",
+          "tableTo": "portfolio_version",
+          "schemaTo": "leercoach",
+          "columnsFrom": [
+            "parent_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leercoach.upload_job": {
+      "name": "upload_job",
+      "schema": "leercoach",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "upload_job_kind",
+          "typeSchema": "leercoach",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "upload_job_status",
+          "typeSchema": "leercoach",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "blob_path": {
+          "name": "blob_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "upload_job_user_created_idx": {
+          "name": "upload_job_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upload_job_status_idx": {
+          "name": "upload_job_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location": {
+      "name": "location",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "status": {
+          "name": "status",
+          "type": "location_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_media_id": {
+          "name": "logo_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "square_logo_media_id": {
+          "name": "square_logo_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_media_id": {
+          "name": "certificate_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "unique_handle_for_location": {
+          "name": "unique_handle_for_location",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_logo_media_id_media_id_fk": {
+          "name": "location_logo_media_id_media_id_fk",
+          "tableFrom": "location",
+          "tableTo": "media",
+          "columnsFrom": [
+            "logo_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_square_logo_media_id_media_id_fk": {
+          "name": "location_square_logo_media_id_media_id_fk",
+          "tableFrom": "location",
+          "tableTo": "media",
+          "columnsFrom": [
+            "square_logo_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_certificate_media_id_media_id_fk": {
+          "name": "location_certificate_media_id_media_id_fk",
+          "tableFrom": "location",
+          "tableTo": "media",
+          "columnsFrom": [
+            "certificate_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_resource_link": {
+      "name": "location_resource_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_type_id": {
+          "name": "gear_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discipline_id": {
+          "name": "discipline_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "location_gear_type_unique": {
+          "name": "location_gear_type_unique",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gear_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_discipline_unique": {
+          "name": "location_discipline_unique",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discipline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_resource_link_location_id_fk": {
+          "name": "location_resource_link_location_id_fk",
+          "tableFrom": "location_resource_link",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_resource_link_gear_type_id_fk": {
+          "name": "location_resource_link_gear_type_id_fk",
+          "tableFrom": "location_resource_link",
+          "tableTo": "gear_type",
+          "columnsFrom": [
+            "gear_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_resource_link_discipline_id_fk": {
+          "name": "location_resource_link_discipline_id_fk",
+          "tableFrom": "location_resource_link",
+          "tableTo": "discipline",
+          "columnsFrom": [
+            "discipline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "location_resource_link_required_one_resource": {
+          "name": "location_resource_link_required_one_resource",
+          "value": "(\n        (gear_type_id is not null)::int + \n        (discipline_id is not null)::int = 1\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.logbook": {
+      "name": "logbook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departure_port": {
+          "name": "departure_port",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arrival_port": {
+          "name": "arrival_port",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wind_power": {
+          "name": "wind_power",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wind_direction": {
+          "name": "wind_direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boat_type": {
+          "name": "boat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boat_length": {
+          "name": "boat_length",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sailed_nautical_miles": {
+          "name": "sailed_nautical_miles",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sailed_hours_in_dark": {
+          "name": "sailed_hours_in_dark",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_role": {
+          "name": "primary_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crew_names": {
+          "name": "crew_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_comments": {
+          "name": "additional_comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "logbook_person_id_fk": {
+          "name": "logbook_person_id_fk",
+          "tableFrom": "logbook",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "marketing.cashback": {
+      "name": "cashback",
+      "schema": "marketing",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "applicant_full_name": {
+          "name": "applicant_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_email": {
+          "name": "applicant_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_iban": {
+          "name": "applicant_iban",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_full_name": {
+          "name": "student_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_media_id": {
+          "name": "verification_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_location": {
+          "name": "verification_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booking_location_id": {
+          "name": "booking_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booking_number": {
+          "name": "booking_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cashback_verification_media_id_media_id_fk": {
+          "name": "cashback_verification_media_id_media_id_fk",
+          "tableFrom": "cashback",
+          "tableTo": "media",
+          "columnsFrom": [
+            "verification_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cashback_booking_location_id_location_id_fk": {
+          "name": "cashback_booking_location_id_location_id_fk",
+          "tableFrom": "cashback",
+          "tableTo": "location",
+          "columnsFrom": [
+            "booking_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "media_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_idx_name_search": {
+          "name": "media_idx_name_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', COALESCE(\"name\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_object_id_fk": {
+          "name": "media_object_id_fk",
+          "tableFrom": "media",
+          "tableTo": "objects",
+          "schemaTo": "storage",
+          "columnsFrom": [
+            "object_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "media_actor_id_fk": {
+          "name": "media_actor_id_fk",
+          "tableFrom": "media",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "media_location_id_fk": {
+          "name": "media_location_id_fk",
+          "tableFrom": "media",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.country": {
+      "name": "country",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ar": {
+          "name": "ar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bg": {
+          "name": "bg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "cs": {
+          "name": "cs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "da": {
+          "name": "da",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "de": {
+          "name": "de",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "el": {
+          "name": "el",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "en": {
+          "name": "en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "es": {
+          "name": "es",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "et": {
+          "name": "et",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "eu": {
+          "name": "eu",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "fi": {
+          "name": "fi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "fr": {
+          "name": "fr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "hu": {
+          "name": "hu",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "it": {
+          "name": "it",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ja": {
+          "name": "ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ko": {
+          "name": "ko",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "lt": {
+          "name": "lt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "nl": {
+          "name": "nl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "no": {
+          "name": "no",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "pl": {
+          "name": "pl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "pt": {
+          "name": "pt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ro": {
+          "name": "ro",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ru": {
+          "name": "ru",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sk": {
+          "name": "sk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sv": {
+          "name": "sv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "th": {
+          "name": "th",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "uk": {
+          "name": "uk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "zh": {
+          "name": "zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "zh-tw": {
+          "name": "zh-tw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "alpha_2": {
+          "name": "alpha_2",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "alpha_3": {
+          "name": "alpha_3",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "country_alpha_2_is_unique": {
+          "name": "country_alpha_2_is_unique",
+          "columns": [
+            {
+              "expression": "alpha_2",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "country_alpha_3_is_unique": {
+          "name": "country_alpha_3_is_unique",
+          "columns": [
+            {
+              "expression": "alpha_3",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "type": {
+          "name": "type",
+          "type": "feedback_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query": {
+          "name": "query",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "base": {
+          "name": "base",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "inserted_by": {
+          "name": "inserted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_inserted_by_fk": {
+          "name": "feedback_inserted_by_fk",
+          "tableFrom": "feedback",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inserted_by"
+          ],
+          "columnsTo": [
+            "auth_user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_cohort_progress": {
+      "name": "student_cohort_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "cohort_allocation_id": {
+          "name": "cohort_allocation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "curriculum_module_competency_id": {
+          "name": "curriculum_module_competency_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cohort_allocation_id_idx": {
+          "name": "cohort_allocation_id_idx",
+          "columns": [
+            {
+              "expression": "cohort_allocation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "curriculum_module_competency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_cohort_progress_cohort_allocation_id_fk": {
+          "name": "student_cohort_progress_cohort_allocation_id_fk",
+          "tableFrom": "student_cohort_progress",
+          "tableTo": "cohort_allocation",
+          "columnsFrom": [
+            "cohort_allocation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "curriculum_competency_competency_id_fk": {
+          "name": "curriculum_competency_competency_id_fk",
+          "tableFrom": "student_cohort_progress",
+          "tableTo": "curriculum_competency",
+          "columnsFrom": [
+            "curriculum_module_competency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_cohort_progress_created_by_fk": {
+          "name": "student_cohort_progress_created_by_fk",
+          "tableFrom": "student_cohort_progress",
+          "tableTo": "person",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.actor": {
+      "name": "actor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "type": {
+          "name": "type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "actor_person_id_fk": {
+          "name": "actor_person_id_fk",
+          "tableFrom": "actor",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "actor_location_link_location_id_fk": {
+          "name": "actor_location_link_location_id_fk",
+          "tableFrom": "actor",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unq_actor_type_person_location": {
+          "name": "unq_actor_type_person_location",
+          "nullsNotDistinct": true,
+          "columns": [
+            "type",
+            "person_id",
+            "location_id"
+          ]
+        },
+        "unq_actor_location_id_unique": {
+          "name": "unq_actor_location_id_unique",
+          "nullsNotDistinct": true,
+          "columns": [
+            "id",
+            "location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person": {
+      "name": "person",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_name_prefix": {
+          "name": "last_name_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_city": {
+          "name": "birth_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_country": {
+          "name": "birth_country",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "person_unq_handle": {
+          "name": "person_unq_handle",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_idx_handle_search": {
+          "name": "person_idx_handle_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', COALESCE(\"handle\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "person_idx_name_search": {
+          "name": "person_idx_name_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', \n        COALESCE(\"first_name\", '') || ' ' || \n        COALESCE(\"last_name_prefix\", '') || ' ' || \n        COALESCE(\"last_name\", '')\n      )",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "person_idx_user_id": {
+          "name": "person_idx_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_idx_is_primary": {
+          "name": "person_idx_is_primary",
+          "columns": [
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unq_primary_person": {
+          "name": "unq_primary_person",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"person\".\"is_primary\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_birth_country_country_alpha_2_fk": {
+          "name": "person_birth_country_country_alpha_2_fk",
+          "tableFrom": "person",
+          "tableTo": "country",
+          "columnsFrom": [
+            "birth_country"
+          ],
+          "columnsTo": [
+            "alpha_2"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "person_user_id_fk": {
+          "name": "person_user_id_fk",
+          "tableFrom": "person",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "auth_user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_location_link": {
+      "name": "person_location_link",
+      "schema": "",
+      "columns": {
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "person_location_link_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_level": {
+          "name": "permission_level",
+          "type": "permissionRequestStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "person_location_link_person_id_fk": {
+          "name": "person_location_link_person_id_fk",
+          "tableFrom": "person_location_link",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "person_location_link_location_id_fk": {
+          "name": "person_location_link_location_id_fk",
+          "tableFrom": "person_location_link",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "person_location_link_pk": {
+          "name": "person_location_link_pk",
+          "columns": [
+            "person_id",
+            "location_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_idx_email_full_search": {
+          "name": "user_idx_email_full_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', COALESCE(\"email\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "user_idx_email_username_search": {
+          "name": "user_idx_email_username_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', COALESCE(split_part(\"email\"::text, '@', 1), ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "user_idx_email_domain_search": {
+          "name": "user_idx_email_domain_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', COALESCE(split_part(\"email\"::text, '@', 2), ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_auth_user_id_fk": {
+          "name": "user_auth_user_id_fk",
+          "tableFrom": "user",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "auth_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "ai_corpus.consent_level": {
+      "name": "consent_level",
+      "schema": "ai_corpus",
+      "values": [
+        "seed",
+        "opt_in_shared",
+        "user_only"
+      ]
+    },
+    "ai_corpus.domain": {
+      "name": "domain",
+      "schema": "ai_corpus",
+      "values": [
+        "pvb_portfolio",
+        "diplomalijn",
+        "knowledge_center",
+        "artefact"
+      ]
+    },
+    "public.bulk_import_preview_status": {
+      "name": "bulk_import_preview_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "committed",
+        "invalidated_max"
+      ]
+    },
+    "public.person_merge_audit_decision_kind": {
+      "name": "person_merge_audit_decision_kind",
+      "schema": "public",
+      "values": [
+        "create_new",
+        "use_existing",
+        "merge",
+        "skip"
+      ]
+    },
+    "public.person_merge_audit_source": {
+      "name": "person_merge_audit_source",
+      "schema": "public",
+      "values": [
+        "bulk_import_preview",
+        "personen_page",
+        "cohort_view",
+        "single_create_dialog",
+        "sysadmin"
+      ]
+    },
+    "public.role_type": {
+      "name": "role_type",
+      "schema": "public",
+      "values": [
+        "organization",
+        "location",
+        "cohort"
+      ]
+    },
+    "public.competency_type": {
+      "name": "competency_type",
+      "schema": "public",
+      "values": [
+        "knowledge",
+        "skill"
+      ]
+    },
+    "public.kwalificatie_verkregen_reden": {
+      "name": "kwalificatie_verkregen_reden",
+      "schema": "public",
+      "values": [
+        "pvb_behaald",
+        "pvb_instructiegroep_basis",
+        "onbekend"
+      ]
+    },
+    "kss.aanvraag_status": {
+      "name": "aanvraag_status",
+      "schema": "kss",
+      "values": [
+        "concept",
+        "wacht_op_voorwaarden",
+        "gereed_voor_beoordeling",
+        "in_beoordeling",
+        "afgerond",
+        "ingetrokken",
+        "afgebroken"
+      ]
+    },
+    "kss.beoordelaar_beschikbaarheidsstatus": {
+      "name": "beoordelaar_beschikbaarheidsstatus",
+      "schema": "kss",
+      "values": [
+        "geinteresseerd",
+        "toegewezen",
+        "afgewezen_door_beoordelaar",
+        "afgewezen_door_secretariaat",
+        "afgewezen_door_vaarlocatie",
+        "ingetrokken"
+      ]
+    },
+    "kss.leercoach_toestemming_status": {
+      "name": "leercoach_toestemming_status",
+      "schema": "kss",
+      "values": [
+        "gevraagd",
+        "gegeven",
+        "geweigerd",
+        "herroepen"
+      ]
+    },
+    "kss.pvb_aanvraag_type": {
+      "name": "pvb_aanvraag_type",
+      "schema": "kss",
+      "values": [
+        "intern",
+        "extern"
+      ]
+    },
+    "kss.pvb_gebeurtenis_type": {
+      "name": "pvb_gebeurtenis_type",
+      "schema": "kss",
+      "values": [
+        "aanvraag_ingediend",
+        "leercoach_toestemming_gevraagd",
+        "leercoach_toestemming_gegeven",
+        "leercoach_toestemming_geweigerd",
+        "voorwaarden_voltooid",
+        "beoordeling_gestart",
+        "beoordeling_afgerond",
+        "aanvraag_ingetrokken",
+        "onderdeel_toegevoegd",
+        "onderdeel_beoordelaar_gewijzigd",
+        "onderdeel_uitslag_gewijzigd",
+        "onderdeel_startdatum_gewijzigd"
+      ]
+    },
+    "kss.pvb_onderdeel_uitslag": {
+      "name": "pvb_onderdeel_uitslag",
+      "schema": "kss",
+      "values": [
+        "behaald",
+        "niet_behaald",
+        "nog_niet_bekend"
+      ]
+    },
+    "kss.kerntaakOnderdeelType": {
+      "name": "kerntaakOnderdeelType",
+      "schema": "kss",
+      "values": [
+        "portfolio",
+        "praktijk"
+      ]
+    },
+    "kss.kerntaakType": {
+      "name": "kerntaakType",
+      "schema": "kss",
+      "values": [
+        "verplicht",
+        "facultatief"
+      ]
+    },
+    "kss.richting": {
+      "name": "richting",
+      "schema": "kss",
+      "values": [
+        "instructeur",
+        "leercoach",
+        "pvb_beoordelaar"
+      ]
+    },
+    "leercoach.chat_phase": {
+      "name": "chat_phase",
+      "schema": "leercoach",
+      "values": [
+        "verkennen",
+        "ordenen",
+        "concept",
+        "verfijnen"
+      ]
+    },
+    "leercoach.portfolio_version_created_by": {
+      "name": "portfolio_version_created_by",
+      "schema": "leercoach",
+      "values": [
+        "coach",
+        "user",
+        "imported"
+      ]
+    },
+    "leercoach.upload_job_kind": {
+      "name": "upload_job_kind",
+      "schema": "leercoach",
+      "values": [
+        "portfolio"
+      ]
+    },
+    "leercoach.upload_job_status": {
+      "name": "upload_job_status",
+      "schema": "leercoach",
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.location_status": {
+      "name": "location_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "hidden",
+        "archived"
+      ]
+    },
+    "public.media_status": {
+      "name": "media_status",
+      "schema": "public",
+      "values": [
+        "failed",
+        "processing",
+        "ready",
+        "uploaded",
+        "corrupt"
+      ]
+    },
+    "public.media_type": {
+      "name": "media_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "file"
+      ]
+    },
+    "public.feedback_type": {
+      "name": "feedback_type",
+      "schema": "public",
+      "values": [
+        "bug",
+        "product-feedback",
+        "program-feedback",
+        "question",
+        "other"
+      ]
+    },
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": [
+        "student",
+        "instructor",
+        "location_admin",
+        "system",
+        "pvb_beoordelaar",
+        "secretariaat"
+      ]
+    },
+    "public.permissionRequestStatus": {
+      "name": "permissionRequestStatus",
+      "schema": "public",
+      "values": [
+        "none",
+        "requested",
+        "permission_granted"
+      ]
+    },
+    "public.person_location_link_status": {
+      "name": "person_location_link_status",
+      "schema": "public",
+      "values": [
+        "linked",
+        "revoked",
+        "removed"
+      ]
+    }
+  },
+  "schemas": {
+    "ai_corpus": "ai_corpus",
+    "kss": "kss",
+    "leercoach": "leercoach",
+    "marketing": "marketing"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1777483280903,
       "tag": "0038_daily_next_avengers",
       "breakpoints": false
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1780083278742,
+      "tag": "0039_cuddly_alex_power",
+      "breakpoints": false
     }
   ]
 }

--- a/packages/db/src/schema/audit.ts
+++ b/packages/db/src/schema/audit.ts
@@ -112,23 +112,19 @@ export const personMergeAudit = pgTable(
     index("person_merge_audit_target_person_id_idx").on(table.targetPersonId),
     index("person_merge_audit_location_id_idx").on(table.locationId),
     index("person_merge_audit_performed_at_idx").on(table.performedAt),
-    foreignKey({
-      columns: [table.performedByPersonId],
-      foreignColumns: [person.id],
-      name: "person_merge_audit_performed_by_person_id_fk",
-    }),
+    // NOTE: none of the person-referencing columns (source_person_id,
+    // target_person_id, performed_by_person_id) carry a foreign key. The
+    // merge engine deletes the source person row, and any of these UUIDs may
+    // point at a person who is later merged away. This is an immutable
+    // forensic log: it records the UUIDs as historical fact and must outlive
+    // the live person rows. A RESTRICT FK here would block legitimate merges
+    // (e.g. chained A->B->C, where B was a prior target/performer), and a
+    // cascading/repointing FK would falsify the recorded history. We keep the
+    // UUIDs for traceability; the live rows may be gone.
     foreignKey({
       columns: [table.locationId],
       foreignColumns: [location.id],
       name: "person_merge_audit_location_id_fk",
-    }),
-    // NOTE: no FK on sourcePersonId. The merge engine deletes the source
-    // person row, so audit forensics must outlive that reference. We
-    // record the UUID for traceability; the live row is gone.
-    foreignKey({
-      columns: [table.targetPersonId],
-      foreignColumns: [person.id],
-      name: "person_merge_audit_target_person_id_fk",
     }),
     foreignKey({
       columns: [table.bulkImportPreviewToken],


### PR DESCRIPTION
## Summary

`mergePersons` failed with a foreign-key violation when the source person was a prior merge/import target or had performed a prior merge. The `person_merge_audit` table carried RESTRICT FKs on `target_person_id` and `performed_by_person_id`, so deleting a source person who appeared in an earlier audit row was blocked — most commonly via **chained merges** (A→B, then B→C).

`person_merge_audit` is an immutable forensic log that must outlive the live `person` rows. A RESTRICT FK is wrong here, and a cascading/repointing FK would *falsify* recorded history. The fix drops both FKs (migration `0039`), matching the table's existing FK-less `source_person_id` design. Columns, `NOT NULL`, and all indexes are kept — metadata-only, no table rewrite.

While here, hardened `mergePersons` against concurrent merges of overlapping people: it now takes a `FOR UPDATE` row lock on both person rows, **ordered by id**, at the start of the transaction. The deterministic lock order means two merges sharing a person serialize (one waits for the other) instead of deadlocking.

## Changes
- `packages/db/src/schema/audit.ts` — remove the two `foreignKey(...)` entries; document why all three person columns are intentionally FK-less.
- `packages/db/migrations/0039_cuddly_alex_power.sql` (+ snapshot/journal) — `DROP CONSTRAINT ×2`.
- `packages/core/src/models/user/person.ts` — `.orderBy(s.person.id).for("update")` on the merge validation query.
- `packages/core/src/models/user/person.test.ts` — regression + concurrency tests.

## Test plan
- [x] New regression tests pass: merging a prior **target**, a prior **performer**, and a **bulk-import** audit target all succeed, with historical audit rows preserved (not repointed).
- [x] New concurrency test passes (stable over 5 runs): two concurrent merges sharing a source serialize — no deadlock, exactly one wins.
- [x] Full existing merge + bulk-import suite green (24/24).
- [x] Migration applies cleanly from scratch (0000→0039); `tsc --build` and Biome clean.

## Notes
- `withTransaction` runs at `serializable` isolation, so the losing concurrent merge aborts with a serialization failure (retryable) rather than a clean "not found" — still safe.
- A deadlock-*reproduction* test would need forced interleaving the production code doesn't expose, so it'd be inherently flaky; the included test is a forward guard on the invariants. Deadlock avoidance itself is the structural Postgres guarantee of `ORDER BY id FOR UPDATE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches person merge and immutable audit semantics; behavior is intentional but wrong deployment could affect merge reliability and forensic audit integrity.
> 
> **Overview**
> Fixes **`mergePersons`** failing on chained merges and related cases where deleting a person was blocked by **`person_merge_audit`** RESTRICT foreign keys on **`target_person_id`** and **`performed_by_person_id`**. Migration **`0039`** drops those constraints so audit rows can outlive deleted persons without repointing historical IDs.
> 
> **`mergePersons`** now locks both person rows with **`ORDER BY id … FOR UPDATE`** at transaction start so overlapping concurrent merges serialize instead of deadlocking.
> 
> Adds regression tests (prior merge target/performer, bulk-import audit target, concurrent merges on one source) and wires the concurrency test through real DB **`withDatabase`** / migrate helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0abc4e8d95919f2cfb2b398fa6e702f76307505c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved person merge stability and reliability during concurrent operations
  * Enhanced audit trail protection to preserve historical merge records during duplicate person consolidation

* **Tests**
  * Added regression test coverage for person merge scenarios, including concurrent operation handling and audit data integrity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/buchungapp/nationaal-watersportdiploma/pull/467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->