### PR TITLE
feat(penningmeester): certificate report per location for invoicing

### DIFF
--- a/apps/web/src/app/(dashboard)/(management)/@sidebar/penningmeester/_components/sidebar-menu.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/@sidebar/penningmeester/_components/sidebar-menu.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import {
+  SidebarItem,
+  SidebarLabel,
+  SidebarSection,
+} from "~/app/(dashboard)/_components/sidebar";
+
+export function PenningmeesterSidebarMenu() {
+  return (
+    <SidebarSection>
+      <SidebarItem href="/penningmeester" current>
+        <SidebarLabel>Diploma's per locatie</SidebarLabel>
+      </SidebarItem>
+    </SidebarSection>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/@sidebar/penningmeester/layout.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/@sidebar/penningmeester/layout.tsx
@@ -1,0 +1,24 @@
+import { Subheading } from "~/app/(dashboard)/_components/heading";
+import {
+  SidebarBody,
+  SidebarHeader,
+} from "~/app/(dashboard)/_components/sidebar";
+import { PenningmeesterSidebarMenu } from "./_components/sidebar-menu";
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+export default function SidebarLayout({ children }: LayoutProps) {
+  return (
+    <>
+      {children}
+      <SidebarHeader>
+        <Subheading level={3}>Penningmeester</Subheading>
+      </SidebarHeader>
+      <SidebarBody>
+        <PenningmeesterSidebarMenu />
+      </SidebarBody>
+    </>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/@sidebar/penningmeester/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/@sidebar/penningmeester/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return null;
+}

--- a/apps/web/src/app/(dashboard)/(management)/penningmeester/_actions/export.ts
+++ b/apps/web/src/app/(dashboard)/(management)/penningmeester/_actions/export.ts
@@ -1,0 +1,80 @@
+"use server";
+import { z } from "zod";
+import { actionClientWithMeta } from "~/app/_actions/safe-action";
+import { canViewFinancialReport } from "~/lib/authorization";
+import {
+  createExportData,
+  exportDataToBlob,
+  exportFileName,
+} from "~/lib/export";
+import { getUserOrThrow } from "~/lib/nwd";
+import {
+  listCertificateCountsByLocation,
+  listCertificateDetailByLocation,
+} from "../_components/queries";
+
+const exportSchema = z.object({
+  // Inclusive Amsterdam calendar dates (YYYY-MM-DD).
+  from: z.string(),
+  to: z.string(),
+  kind: z.enum(["samenvatting", "detail"]),
+  format: z.enum(["csv", "xlsx"]),
+});
+
+export const exportPenningmeesterReportAction = actionClientWithMeta
+  .metadata({ name: "export-penningmeester-report" })
+  .inputSchema(exportSchema)
+  .action(async ({ parsedInput: { from, to, kind, format } }) => {
+    // Defense in depth: the underlying queries also gate, but a server action is
+    // independently callable, so we check here too.
+    const user = await getUserOrThrow();
+    if (!canViewFinancialReport(user.email)) {
+      throw new Error("Geen toegang tot de penningmeester-rapportage.");
+    }
+
+    let headers: string[];
+    let rows: string[][];
+    let sheetName: string;
+
+    if (kind === "samenvatting") {
+      const counts = await listCertificateCountsByLocation(from, to);
+      headers = ["Locatie", "Handle", "Consument", "Instructeur", "Totaal"];
+      rows = counts.map((c) => [
+        c.locationName,
+        c.locationHandle,
+        String(c.consument),
+        String(c.instructeur),
+        String(c.totaal),
+      ]);
+      sheetName = "Samenvatting";
+    } else {
+      const detail = await listCertificateDetailByLocation(from, to);
+      headers = ["Certificaat", "Locatie", "Handle", "Type", "Uitgegeven op"];
+      rows = detail.map((d) => [
+        d.handle,
+        d.locationName,
+        d.locationHandle,
+        d.type,
+        d.issuedAt ?? "",
+      ]);
+      sheetName = "Detail";
+    }
+
+    const data = await createExportData(
+      headers,
+      rows,
+      format === "xlsx" ? { type: "xlsx", sheetName } : { type: "csv" },
+    );
+
+    return {
+      data: exportDataToBlob(data, format),
+      format,
+      // exportFileName prepends an export timestamp (YYYY-MM-DDTHH:mm); the
+      // period is encoded too, so the downloaded file is a self-identifying
+      // billing snapshot.
+      filename: exportFileName(
+        format,
+        `penningmeester-${kind}-${from}_tot_${to}`,
+      ),
+    };
+  });

--- a/apps/web/src/app/(dashboard)/(management)/penningmeester/_actions/export.ts
+++ b/apps/web/src/app/(dashboard)/(management)/penningmeester/_actions/export.ts
@@ -2,6 +2,7 @@
 import { z } from "zod";
 import { actionClientWithMeta } from "~/app/_actions/safe-action";
 import { canViewFinancialReport } from "~/lib/authorization";
+import dayjs from "~/lib/dayjs";
 import {
   createExportData,
   exportDataToBlob,
@@ -13,10 +14,16 @@ import {
   listCertificateDetailByLocation,
 } from "../_components/queries";
 
+// Inclusive Amsterdam calendar dates. Strict format here is defense in depth;
+// amsterdamPeriodToUtcBounds also strict-validates (rejecting rolled-over dates
+// like 2026-02-31) before any query runs.
+const dateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "Verwacht datumformaat YYYY-MM-DD");
+
 const exportSchema = z.object({
-  // Inclusive Amsterdam calendar dates (YYYY-MM-DD).
-  from: z.string(),
-  to: z.string(),
+  from: dateSchema,
+  to: dateSchema,
   kind: z.enum(["samenvatting", "detail"]),
   format: z.enum(["csv", "xlsx"]),
 });
@@ -55,7 +62,11 @@ export const exportPenningmeesterReportAction = actionClientWithMeta
         d.locationName,
         d.locationHandle,
         d.type,
-        d.issuedAt ?? "",
+        // Format as the Amsterdam-local issue date. issuedAt is a UTC instant;
+        // showing it raw would dispute-bait around Amsterdam midnight.
+        d.issuedAt
+          ? dayjs(d.issuedAt).tz("Europe/Amsterdam").format("YYYY-MM-DD")
+          : "",
       ]);
       sheetName = "Detail";
     }

--- a/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/export-buttons.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/export-buttons.tsx
@@ -1,0 +1,53 @@
+"use client";
+import { ArrowDownTrayIcon } from "@heroicons/react/16/solid";
+import { useAction } from "next-safe-action/hooks";
+import { toast } from "sonner";
+import { Button } from "~/app/(dashboard)/_components/button";
+import { downloadBlob } from "~/lib/export";
+import { exportPenningmeesterReportAction } from "../_actions/export";
+
+export function ExportButtons({ from, to }: { from: string; to: string }) {
+  const { execute, isExecuting } = useAction(exportPenningmeesterReportAction, {
+    onSuccess: ({ data }) => {
+      if (data) {
+        downloadBlob(data.data, data.filename);
+        toast.success("Rapportage geëxporteerd.");
+      }
+    },
+    onError: ({ error }) => {
+      toast.error(error.serverError ?? "Exporteren is mislukt.");
+    },
+  });
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button
+        outline
+        disabled={isExecuting}
+        onClick={() =>
+          execute({ from, to, kind: "samenvatting", format: "xlsx" })
+        }
+      >
+        <ArrowDownTrayIcon />
+        Samenvatting (XLSX)
+      </Button>
+      <Button
+        outline
+        disabled={isExecuting}
+        onClick={() => execute({ from, to, kind: "detail", format: "xlsx" })}
+      >
+        <ArrowDownTrayIcon />
+        Detail / bewijs (XLSX)
+      </Button>
+      <Button
+        plain
+        disabled={isExecuting}
+        onClick={() =>
+          execute({ from, to, kind: "samenvatting", format: "csv" })
+        }
+      >
+        CSV
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/period.test.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/period.test.tsx
@@ -69,4 +69,21 @@ describe("amsterdamPeriodToUtcBounds", () => {
       amsterdamPeriodToUtcBounds("not-a-date", "2026-05-01"),
     ).toThrow();
   });
+
+  it("rejects dates that dayjs would silently roll over (no wrong-period billing)", () => {
+    // Month 13, Feb 31, month 00, and DD-MM-YYYY all parse leniently in
+    // non-strict dayjs and would bill the wrong window. Strict mode rejects them.
+    expect(() =>
+      amsterdamPeriodToUtcBounds("2026-13-01", "2026-12-31"),
+    ).toThrow();
+    expect(() =>
+      amsterdamPeriodToUtcBounds("2026-02-31", "2026-03-31"),
+    ).toThrow();
+    expect(() =>
+      amsterdamPeriodToUtcBounds("2026-00-10", "2026-01-31"),
+    ).toThrow();
+    expect(() =>
+      amsterdamPeriodToUtcBounds("01-01-2026", "2026-01-31"),
+    ).toThrow();
+  });
 });

--- a/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/period.test.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/period.test.tsx
@@ -2,7 +2,8 @@
 // Validates the billing-critical Amsterdam -> UTC half-open boundary math,
 // including the DST transitions where a naive conversion is off by an hour.
 import { describe, expect, it } from "vitest";
-import { amsterdamPeriodToUtcBounds } from "./period";
+import dayjs from "~/lib/dayjs";
+import { amsterdamPeriodToUtcBounds, startOfQuarter } from "./period";
 
 describe("amsterdamPeriodToUtcBounds", () => {
   it("winter month maps Amsterdam midnight to the UTC+1 instant (half-open)", () => {
@@ -85,5 +86,25 @@ describe("amsterdamPeriodToUtcBounds", () => {
     expect(() =>
       amsterdamPeriodToUtcBounds("01-01-2026", "2026-01-31"),
     ).toThrow();
+  });
+});
+
+describe("startOfQuarter", () => {
+  it("returns the first day of the containing quarter", () => {
+    expect(startOfQuarter(dayjs("2026-02-15")).format("YYYY-MM-DD")).toBe(
+      "2026-01-01",
+    );
+    expect(startOfQuarter(dayjs("2026-08-10")).format("YYYY-MM-DD")).toBe(
+      "2026-07-01",
+    );
+  });
+
+  it("does NOT roll over on 29-31 day dates (May 31 -> April 1, not May 1)", () => {
+    expect(startOfQuarter(dayjs("2026-05-31")).format("YYYY-MM-DD")).toBe(
+      "2026-04-01",
+    );
+    expect(startOfQuarter(dayjs("2026-08-31")).format("YYYY-MM-DD")).toBe(
+      "2026-07-01",
+    );
   });
 });

--- a/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/period.test.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/period.test.tsx
@@ -1,0 +1,72 @@
+// Pure-logic test, run by vitest (`pnpm --filter @nawadi/web test:components`).
+// Validates the billing-critical Amsterdam -> UTC half-open boundary math,
+// including the DST transitions where a naive conversion is off by an hour.
+import { describe, expect, it } from "vitest";
+import { amsterdamPeriodToUtcBounds } from "./period";
+
+describe("amsterdamPeriodToUtcBounds", () => {
+  it("winter month maps Amsterdam midnight to the UTC+1 instant (half-open)", () => {
+    const { fromUtc, toUtcExclusive } = amsterdamPeriodToUtcBounds(
+      "2026-01-01",
+      "2026-01-31",
+    );
+    // 2026-01-01 00:00 Amsterdam (CET, +1) == 2025-12-31T23:00:00Z
+    expect(fromUtc).toBe("2025-12-31T23:00:00.000Z");
+    // exclusive end = 2026-02-01 00:00 Amsterdam (+1) == 2026-01-31T23:00:00Z
+    expect(toUtcExclusive).toBe("2026-01-31T23:00:00.000Z");
+  });
+
+  it("summer month maps Amsterdam midnight to the UTC+2 instant", () => {
+    const { fromUtc, toUtcExclusive } = amsterdamPeriodToUtcBounds(
+      "2026-07-01",
+      "2026-07-31",
+    );
+    // 2026-07-01 00:00 Amsterdam (CEST, +2) == 2026-06-30T22:00:00Z
+    expect(fromUtc).toBe("2026-06-30T22:00:00.000Z");
+    expect(toUtcExclusive).toBe("2026-07-31T22:00:00.000Z");
+  });
+
+  it("spring-forward day (2026-03-29) is a 23-hour window", () => {
+    const { fromUtc, toUtcExclusive } = amsterdamPeriodToUtcBounds(
+      "2026-03-29",
+      "2026-03-29",
+    );
+    // Midnight Mar 29 is still CET (+1); clocks spring at 02:00 -> CEST (+2).
+    expect(fromUtc).toBe("2026-03-28T23:00:00.000Z");
+    expect(toUtcExclusive).toBe("2026-03-29T22:00:00.000Z");
+    const hours =
+      (Date.parse(toUtcExclusive) - Date.parse(fromUtc)) / 3_600_000;
+    expect(hours).toBe(23);
+  });
+
+  it("fall-back day (2026-10-25) is a 25-hour window", () => {
+    const { fromUtc, toUtcExclusive } = amsterdamPeriodToUtcBounds(
+      "2026-10-25",
+      "2026-10-25",
+    );
+    const hours =
+      (Date.parse(toUtcExclusive) - Date.parse(fromUtc)) / 3_600_000;
+    expect(hours).toBe(25);
+  });
+
+  it("upper bound is exclusive: start of the day AFTER `to`", () => {
+    const { toUtcExclusive } = amsterdamPeriodToUtcBounds(
+      "2026-05-01",
+      "2026-05-31",
+    );
+    // 2026-06-01 00:00 Amsterdam (+2) == 2026-05-31T22:00:00Z
+    expect(toUtcExclusive).toBe("2026-05-31T22:00:00.000Z");
+  });
+
+  it("throws on a reversed/empty period", () => {
+    expect(() =>
+      amsterdamPeriodToUtcBounds("2026-05-31", "2026-05-01"),
+    ).toThrow();
+  });
+
+  it("throws on an invalid date", () => {
+    expect(() =>
+      amsterdamPeriodToUtcBounds("not-a-date", "2026-05-01"),
+    ).toThrow();
+  });
+});

--- a/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/period.ts
+++ b/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/period.ts
@@ -1,0 +1,51 @@
+import dayjs from "~/lib/dayjs";
+
+const TIMEZONE = "Europe/Amsterdam";
+
+export type UtcPeriodBounds = {
+  /** Inclusive lower bound, UTC instant (ISO). */
+  fromUtc: string;
+  /** Exclusive upper bound, UTC instant (ISO). */
+  toUtcExclusive: string;
+};
+
+/**
+ * Convert an INCLUSIVE Amsterdam calendar-date range (both "YYYY-MM-DD") into a
+ * HALF-OPEN UTC instant range [fromUtc, toUtcExclusive) suitable for comparing
+ * the timestamptz `certificate.issued_at`.
+ *
+ *   from = "2026-01-01", to = "2026-01-31"
+ *     -> [ 2026-01-01 00:00 Amsterdam , 2026-02-01 00:00 Amsterdam )  (as UTC)
+ *
+ * Why half-open + app-side conversion (not `AT TIME ZONE` in SQL):
+ *  - Half-open avoids the inclusive-`<=` double-count at period boundaries: a
+ *    certificate issued exactly at the next period's start is NOT billed twice.
+ *  - Computing the UTC instants here keeps the query comparing the RAW indexed
+ *    `issued_at` column, so `certificate_idx_location_issued_at` is still used.
+ *  - dayjs.tz resolves the correct offset per boundary, so the late-March /
+ *    late-October DST transitions don't shift the window by an hour. The day a
+ *    clock springs forward is genuinely 23h long, and this handles it.
+ */
+export function amsterdamPeriodToUtcBounds(
+  from: string,
+  to: string,
+): UtcPeriodBounds {
+  const start = dayjs.tz(from, TIMEZONE).startOf("day");
+  // The treasurer picks an inclusive end date; the exclusive upper bound is the
+  // start of the following day, in Amsterdam, converted to its UTC instant.
+  const endExclusive = dayjs.tz(to, TIMEZONE).add(1, "day").startOf("day");
+
+  if (!start.isValid() || !endExclusive.isValid()) {
+    throw new Error(`Ongeldige periode: from=${from} to=${to}`);
+  }
+  if (!endExclusive.isAfter(start)) {
+    throw new Error(
+      `Lege periode: 'from' (${from}) moet op of voor 'to' (${to}) liggen`,
+    );
+  }
+
+  return {
+    fromUtc: start.toISOString(),
+    toUtcExclusive: endExclusive.toISOString(),
+  };
+}

--- a/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/period.ts
+++ b/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/period.ts
@@ -1,6 +1,19 @@
-import dayjs from "~/lib/dayjs";
+import dayjs, { type Dayjs } from "~/lib/dayjs";
 
 const TIMEZONE = "Europe/Amsterdam";
+
+/**
+ * First day of the quarter containing `d` (months 0,3,6,9), as a day-start.
+ *
+ * Sets the day to 1 BEFORE changing the month. dayjs's `.month()` setter uses
+ * Date.setMonth(), which rolls over when the current day-of-month exceeds the
+ * target month's length: on May 31, `.month(3)` (April) would overflow to
+ * May 1, producing the wrong quarter. `.date(1)` first avoids that.
+ */
+export function startOfQuarter(d: Dayjs): Dayjs {
+  const quarterStartMonth = Math.floor(d.month() / 3) * 3;
+  return d.date(1).month(quarterStartMonth).startOf("month");
+}
 
 export type UtcPeriodBounds = {
   /** Inclusive lower bound, UTC instant (ISO). */

--- a/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/period.ts
+++ b/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/period.ts
@@ -30,6 +30,17 @@ export function amsterdamPeriodToUtcBounds(
   from: string,
   to: string,
 ): UtcPeriodBounds {
+  // Strict-parse FIRST. dayjs.tz is lenient and silently rolls invalid dates
+  // over (2026-13-01 -> Dec, 2026-02-31 -> Mar 3, 01-01-2026 -> Dec 2025) while
+  // reporting them valid -- which would bill the WRONG period with no error.
+  // Strict mode (3rd arg true) rejects anything that isn't a real YYYY-MM-DD.
+  if (!dayjs(from, "YYYY-MM-DD", true).isValid()) {
+    throw new Error(`Ongeldige 'from'-datum (verwacht YYYY-MM-DD): ${from}`);
+  }
+  if (!dayjs(to, "YYYY-MM-DD", true).isValid()) {
+    throw new Error(`Ongeldige 'to'-datum (verwacht YYYY-MM-DD): ${to}`);
+  }
+
   const start = dayjs.tz(from, TIMEZONE).startOf("day");
   // The treasurer picks an inclusive end date; the exclusive upper bound is the
   // start of the following day, in Amsterdam, converted to its UTC instant.

--- a/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/queries.ts
+++ b/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/queries.ts
@@ -1,0 +1,162 @@
+"use server";
+import { useQuery } from "@nawadi/core";
+import { schema as s } from "@nawadi/db";
+import { and, asc, eq, gte, isNull, lt, sql } from "@nawadi/db/drizzle";
+import { canViewFinancialReport } from "~/lib/authorization";
+import { getUserOrThrow } from "~/lib/nwd";
+import { amsterdamPeriodToUtcBounds } from "./period";
+
+// A program whose degree rank is >= this is an instructor (kaderopleiding)
+// program; below it is a consumer (eigenvaardigheid) program. The
+// consumer/instructor split is a property of the PROGRAM (its degree.rang), NOT
+// of the course. This constant is the single source of truth for the billing
+// split. ("Anything above rank 4 is instructeur" -> rang >= 5.)
+export const INSTRUCTEUR_MIN_RANG = 5;
+
+// ┌──────────────────────────────────────────────────────────────────────────┐
+// │ certificate ─┬─ student_curriculum ─┬─ curriculum ─┬─ program ─┬─ degree   │
+// │  (billable)  │   (one per cert)      │              │           │ (.rang)  │
+// │              └─ location (issuing)                                          │
+// │ Only certificate.deleted_at gates inclusion; the classification tables are │
+// │ FK-joined WITHOUT their own deleted_at filter, so a later-retired program  │
+// │ still classifies a certificate it issued (historical billing is stable).   │
+// └──────────────────────────────────────────────────────────────────────────┘
+
+async function assertCanViewFinancialReport() {
+  // Redirects anonymous users to /login. Authorization is enforced HERE (inside
+  // the server action), not only on the page render, because a server action is
+  // an independently callable endpoint.
+  const user = await getUserOrThrow();
+  if (!canViewFinancialReport(user.email)) {
+    throw new Error("Geen toegang tot de penningmeester-rapportage.");
+  }
+  return user;
+}
+
+function periodConditions(fromUtc: string, toUtcExclusive: string) {
+  return and(
+    isNull(s.certificate.deletedAt),
+    gte(s.certificate.issuedAt, fromUtc),
+    lt(s.certificate.issuedAt, toUtcExclusive),
+  );
+}
+
+function typeForRang(rang: number): "Consument" | "Instructeur" {
+  return rang >= INSTRUCTEUR_MIN_RANG ? "Instructeur" : "Consument";
+}
+
+export type LocationCertificateCounts = {
+  locationId: string;
+  locationName: string;
+  locationHandle: string;
+  consument: number;
+  instructeur: number;
+  totaal: number;
+};
+
+/**
+ * Per-location certificate counts in the period, split consumer vs instructor.
+ * Aggregated in SQL (GROUP BY) and uses `count(distinct certificate.id)` so the
+ * join path can never inflate a count. Only locations with >= 1 counted
+ * certificate appear, regardless of location.status (an archived/hidden
+ * location with billable activity must still be invoiced).
+ */
+export async function listCertificateCountsByLocation(
+  from: string,
+  to: string,
+): Promise<LocationCertificateCounts[]> {
+  await assertCanViewFinancialReport();
+  const { fromUtc, toUtcExclusive } = amsterdamPeriodToUtcBounds(from, to);
+  const query = useQuery();
+
+  const rows = await query
+    .select({
+      locationId: s.location.id,
+      locationName: s.location.name,
+      locationHandle: s.location.handle,
+      consument:
+        sql<number>`count(distinct ${s.certificate.id}) filter (where ${s.degree.rang} < ${INSTRUCTEUR_MIN_RANG})`.mapWith(
+          Number,
+        ),
+      instructeur:
+        sql<number>`count(distinct ${s.certificate.id}) filter (where ${s.degree.rang} >= ${INSTRUCTEUR_MIN_RANG})`.mapWith(
+          Number,
+        ),
+    })
+    .from(s.certificate)
+    .innerJoin(
+      s.studentCurriculum,
+      eq(s.certificate.studentCurriculumId, s.studentCurriculum.id),
+    )
+    .innerJoin(
+      s.curriculum,
+      eq(s.studentCurriculum.curriculumId, s.curriculum.id),
+    )
+    .innerJoin(s.program, eq(s.curriculum.programId, s.program.id))
+    .innerJoin(s.degree, eq(s.program.degreeId, s.degree.id))
+    .innerJoin(s.location, eq(s.certificate.locationId, s.location.id))
+    .where(periodConditions(fromUtc, toUtcExclusive))
+    .groupBy(s.location.id, s.location.name, s.location.handle)
+    .orderBy(asc(s.location.name));
+
+  return rows.map((row) => ({
+    locationId: row.locationId,
+    locationName: row.locationName ?? row.locationHandle,
+    locationHandle: row.locationHandle,
+    consument: row.consument,
+    instructeur: row.instructeur,
+    totaal: row.consument + row.instructeur,
+  }));
+}
+
+export type CertificateDetailRow = {
+  handle: string;
+  locationName: string;
+  locationHandle: string;
+  type: "Consument" | "Instructeur";
+  issuedAt: string | null;
+};
+
+/**
+ * One row per certificate behind the counts: the evidence layer that makes an
+ * exported file both dispute evidence and a dated billing snapshot.
+ */
+export async function listCertificateDetailByLocation(
+  from: string,
+  to: string,
+): Promise<CertificateDetailRow[]> {
+  await assertCanViewFinancialReport();
+  const { fromUtc, toUtcExclusive } = amsterdamPeriodToUtcBounds(from, to);
+  const query = useQuery();
+
+  const rows = await query
+    .select({
+      handle: s.certificate.handle,
+      issuedAt: s.certificate.issuedAt,
+      locationName: s.location.name,
+      locationHandle: s.location.handle,
+      rang: s.degree.rang,
+    })
+    .from(s.certificate)
+    .innerJoin(
+      s.studentCurriculum,
+      eq(s.certificate.studentCurriculumId, s.studentCurriculum.id),
+    )
+    .innerJoin(
+      s.curriculum,
+      eq(s.studentCurriculum.curriculumId, s.curriculum.id),
+    )
+    .innerJoin(s.program, eq(s.curriculum.programId, s.program.id))
+    .innerJoin(s.degree, eq(s.program.degreeId, s.degree.id))
+    .innerJoin(s.location, eq(s.certificate.locationId, s.location.id))
+    .where(periodConditions(fromUtc, toUtcExclusive))
+    .orderBy(asc(s.location.name), asc(s.certificate.issuedAt));
+
+  return rows.map((row) => ({
+    handle: row.handle,
+    locationName: row.locationName ?? row.locationHandle,
+    locationHandle: row.locationHandle,
+    type: typeForRang(row.rang),
+    issuedAt: row.issuedAt,
+  }));
+}

--- a/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/queries.ts
+++ b/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/queries.ts
@@ -11,7 +11,10 @@ import { amsterdamPeriodToUtcBounds } from "./period";
 // consumer/instructor split is a property of the PROGRAM (its degree.rang), NOT
 // of the course. This constant is the single source of truth for the billing
 // split. ("Anything above rank 4 is instructeur" -> rang >= 5.)
-export const INSTRUCTEUR_MIN_RANG = 5;
+//
+// NOT exported: a "use server" module may only export async functions, and this
+// constant is used only within this file.
+const INSTRUCTEUR_MIN_RANG = 5;
 
 // ┌──────────────────────────────────────────────────────────────────────────┐
 // │ certificate ─┬─ student_curriculum ─┬─ curriculum ─┬─ program ─┬─ degree   │
@@ -48,7 +51,7 @@ function typeForRang(rang: number): "Consument" | "Instructeur" {
   return rang >= INSTRUCTEUR_MIN_RANG ? "Instructeur" : "Consument";
 }
 
-export type LocationCertificateCounts = {
+type LocationCertificateCounts = {
   locationId: string;
   locationName: string;
   locationHandle: string;
@@ -103,9 +106,10 @@ export async function listCertificateCountsByLocation(
     .orderBy(asc(s.location.name));
 
   // Proportionate observability for an internal monthly tool: who ran which
-  // period, and how many locations it touched.
+  // period, and how many locations it touched. Log the opaque auth id, not the
+  // email, to keep PII out of routine logs.
   console.info(
-    `[penningmeester] report ${from}..${to} by ${user.email} -> ${rows.length} location(s)`,
+    `[penningmeester] report ${from}..${to} by ${user.authUserId} -> ${rows.length} location(s)`,
   );
 
   return rows.map((row) => ({
@@ -118,7 +122,7 @@ export async function listCertificateCountsByLocation(
   }));
 }
 
-export type CertificateDetailRow = {
+type CertificateDetailRow = {
   handle: string;
   locationName: string;
   locationHandle: string;

--- a/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/queries.ts
+++ b/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/queries.ts
@@ -36,6 +36,9 @@ async function assertCanViewFinancialReport() {
 function periodConditions(fromUtc: string, toUtcExclusive: string) {
   return and(
     isNull(s.certificate.deletedAt),
+    // Count by issued_at, half-open [from, to). issued_at is nullable; a NULL
+    // (not-yet-issued) certificate fails both comparisons and is intentionally
+    // excluded from billing -- undated certificates are treated as not billable.
     gte(s.certificate.issuedAt, fromUtc),
     lt(s.certificate.issuedAt, toUtcExclusive),
   );
@@ -65,7 +68,7 @@ export async function listCertificateCountsByLocation(
   from: string,
   to: string,
 ): Promise<LocationCertificateCounts[]> {
-  await assertCanViewFinancialReport();
+  const user = await assertCanViewFinancialReport();
   const { fromUtc, toUtcExclusive } = amsterdamPeriodToUtcBounds(from, to);
   const query = useQuery();
 
@@ -98,6 +101,12 @@ export async function listCertificateCountsByLocation(
     .where(periodConditions(fromUtc, toUtcExclusive))
     .groupBy(s.location.id, s.location.name, s.location.handle)
     .orderBy(asc(s.location.name));
+
+  // Proportionate observability for an internal monthly tool: who ran which
+  // period, and how many locations it touched.
+  console.info(
+    `[penningmeester] report ${from}..${to} by ${user.email} -> ${rows.length} location(s)`,
+  );
 
   return rows.map((row) => ({
     locationId: row.locationId,

--- a/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/report.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/report.tsx
@@ -14,10 +14,15 @@ async function ReportContent({ from, to }: { from: string; to: string }) {
   const counts = await listCertificateCountsByLocation(from, to);
 
   if (counts.length === 0) {
+    // Still offer export: a treasurer may want a zero-result evidence file
+    // documenting that a period had no billable diploma's.
     return (
-      <Text className="mt-4">
-        Geen geregistreerde diploma's in deze periode.
-      </Text>
+      <div className="mt-4 space-y-6">
+        <div className="flex justify-end">
+          <ExportButtons from={from} to={to} />
+        </div>
+        <Text>Geen geregistreerde diploma's in deze periode.</Text>
+      </div>
     );
   }
 

--- a/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/report.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/penningmeester/_components/report.tsx
@@ -1,0 +1,88 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "~/app/(dashboard)/_components/table";
+import { Strong, Text } from "~/app/(dashboard)/_components/text";
+import { ExportButtons } from "./export-buttons";
+import { listCertificateCountsByLocation } from "./queries";
+
+async function ReportContent({ from, to }: { from: string; to: string }) {
+  const counts = await listCertificateCountsByLocation(from, to);
+
+  if (counts.length === 0) {
+    return (
+      <Text className="mt-4">
+        Geen geregistreerde diploma's in deze periode.
+      </Text>
+    );
+  }
+
+  const totals = counts.reduce(
+    (acc, row) => ({
+      consument: acc.consument + row.consument,
+      instructeur: acc.instructeur + row.instructeur,
+      totaal: acc.totaal + row.totaal,
+    }),
+    { consument: 0, instructeur: 0, totaal: 0 },
+  );
+
+  return (
+    <div className="mt-4 space-y-6">
+      <div className="flex justify-end">
+        <ExportButtons from={from} to={to} />
+      </div>
+
+      <Table dense>
+        <TableHead>
+          <TableRow>
+            <TableHeader>Locatie</TableHeader>
+            <TableHeader className="text-right">Consument</TableHeader>
+            <TableHeader className="text-right">Instructeur</TableHeader>
+            <TableHeader className="text-right">Totaal</TableHeader>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {counts.map((row) => (
+            <TableRow key={row.locationId}>
+              <TableCell>
+                <Strong>{row.locationName}</Strong>{" "}
+                <span className="text-zinc-500">{row.locationHandle}</span>
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {row.consument}
+              </TableCell>
+              <TableCell className="text-right tabular-nums">
+                {row.instructeur}
+              </TableCell>
+              <TableCell className="text-right font-medium tabular-nums">
+                {row.totaal}
+              </TableCell>
+            </TableRow>
+          ))}
+          <TableRow>
+            <TableCell>
+              <Strong>Totaal</Strong>
+            </TableCell>
+            <TableCell className="text-right font-semibold tabular-nums">
+              {totals.consument}
+            </TableCell>
+            <TableCell className="text-right font-semibold tabular-nums">
+              {totals.instructeur}
+            </TableCell>
+            <TableCell className="text-right font-semibold tabular-nums">
+              {totals.totaal}
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+export function Report({ from, to }: { from: string; to: string }) {
+  return <ReportContent from={from} to={to} />;
+}

--- a/apps/web/src/app/(dashboard)/(management)/penningmeester/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/penningmeester/page.tsx
@@ -1,0 +1,126 @@
+import * as Headless from "@headlessui/react";
+import { Suspense } from "react";
+import { Label } from "~/app/(dashboard)/_components/fieldset";
+import { Heading, Subheading } from "~/app/(dashboard)/_components/heading";
+import { Text } from "~/app/(dashboard)/_components/text";
+import { canViewFinancialReport } from "~/lib/authorization";
+import type { Dayjs } from "~/lib/dayjs";
+import dayjs from "~/lib/dayjs";
+import { getUserOrThrow } from "~/lib/nwd";
+// Reuse the existing period-picker (URL/nuqs-backed). Shared, generic UI.
+import {
+  DateSelector,
+  FixedDateSelector,
+} from "../locatie/[location]/inzichten/_components/date-selector";
+import { Report } from "./_components/report";
+
+const fmt = (d: Dayjs) => d.format("YYYY-MM-DD");
+// Quarter start without the dayjs quarterOfYear plugin: snap to the quarter's
+// first month (0,3,6,9).
+const startOfQuarter = (d: Dayjs) =>
+  d.month(Math.floor(d.month() / 3) * 3).startOf("month");
+
+export default async function PenningmeesterPage(props: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const user = await getUserOrThrow();
+
+  if (!canViewFinancialReport(user.email)) {
+    return (
+      <div className="mx-auto max-w-7xl">
+        <Heading level={1}>Geen toegang</Heading>
+        <Text className="mt-2">Je hebt geen toegang tot deze pagina.</Text>
+      </div>
+    );
+  }
+
+  const searchParams = await props.searchParams;
+  const today = dayjs();
+  const defaultFrom = fmt(today.startOf("month"));
+  const defaultTo = fmt(today.endOf("month"));
+
+  const from =
+    typeof searchParams.from === "string" ? searchParams.from : defaultFrom;
+  const to = typeof searchParams.to === "string" ? searchParams.to : defaultTo;
+
+  const quarter = startOfQuarter(today);
+  const lastQuarter = quarter.subtract(3, "month");
+  const periodPresets = [
+    {
+      label: "Deze maand",
+      value: {
+        from: fmt(today.startOf("month")),
+        to: fmt(today.endOf("month")),
+      },
+    },
+    {
+      label: "Vorige maand",
+      value: {
+        from: fmt(today.subtract(1, "month").startOf("month")),
+        to: fmt(today.subtract(1, "month").endOf("month")),
+      },
+    },
+    {
+      label: "Dit kwartaal",
+      value: {
+        from: fmt(quarter),
+        to: fmt(quarter.add(2, "month").endOf("month")),
+      },
+    },
+    {
+      label: "Vorig kwartaal",
+      value: {
+        from: fmt(lastQuarter),
+        to: fmt(lastQuarter.add(2, "month").endOf("month")),
+      },
+    },
+    {
+      label: "Dit jaar",
+      value: { from: fmt(today.startOf("year")), to: fmt(today.endOf("year")) },
+    },
+    {
+      label: "Vorig jaar",
+      value: {
+        from: fmt(today.subtract(1, "year").startOf("year")),
+        to: fmt(today.subtract(1, "year").endOf("year")),
+      },
+    },
+  ];
+
+  return (
+    <div className="mx-auto max-w-7xl">
+      <Heading level={1}>Penningmeester</Heading>
+      <Text className="mt-2">
+        Aantal geregistreerde diploma's per vaarlocatie in de gekozen periode,
+        gesplitst in consument (eigenvaardigheid) en instructeur
+        (kaderopleiding). Exporteer voor de facturatie.
+      </Text>
+
+      <div className="flex flex-wrap items-end justify-between gap-3 mt-8">
+        <Subheading>Diploma's per locatie</Subheading>
+        <div className="flex items-center gap-2 -mt-2.5">
+          <FixedDateSelector
+            defaultValueFrom={defaultFrom}
+            defaultValueTo={defaultTo}
+            dateOptions={periodPresets}
+          />
+          <Headless.Field className="relative flex items-center gap-2">
+            <Label className="font-medium">Vanaf</Label>
+            <DateSelector name="from" defaultValue={defaultFrom} />
+          </Headless.Field>
+          <Headless.Field className="relative flex items-center gap-2">
+            <Label className="font-medium">tot</Label>
+            <DateSelector name="to" defaultValue={defaultTo} />
+          </Headless.Field>
+        </div>
+      </div>
+
+      <Suspense
+        key={`${from}-${to}`}
+        fallback={<Text className="mt-4">Bezig met laden…</Text>}
+      >
+        <Report from={from} to={to} />
+      </Suspense>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/penningmeester/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/penningmeester/page.tsx
@@ -12,13 +12,10 @@ import {
   DateSelector,
   FixedDateSelector,
 } from "../locatie/[location]/inzichten/_components/date-selector";
+import { startOfQuarter } from "./_components/period";
 import { Report } from "./_components/report";
 
 const fmt = (d: Dayjs) => d.format("YYYY-MM-DD");
-// Quarter start without the dayjs quarterOfYear plugin: snap to the quarter's
-// first month (0,3,6,9).
-const startOfQuarter = (d: Dayjs) =>
-  d.month(Math.floor(d.month() / 3) * 3).startOf("month");
 
 export default async function PenningmeesterPage(props: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;

--- a/apps/web/src/app/(dashboard)/(management)/penningmeester/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/penningmeester/page.tsx
@@ -35,7 +35,10 @@ export default async function PenningmeesterPage(props: {
   }
 
   const searchParams = await props.searchParams;
-  const today = dayjs();
+  // Anchor "now" to Amsterdam, not the server runtime tz: a UTC-hosted server
+  // would otherwise default to the wrong month/quarter around the boundary,
+  // since the query math is Amsterdam-based.
+  const today = dayjs().tz("Europe/Amsterdam");
   const defaultFrom = fmt(today.startOf("month"));
   const defaultTo = fmt(today.endOf("month"));
 

--- a/apps/web/src/lib/authorization.test.tsx
+++ b/apps/web/src/lib/authorization.test.tsx
@@ -77,4 +77,12 @@ describe("configured penningmeester", () => {
   it("the treasurer can view the financial report", () => {
     expect(canViewFinancialReport(treasurer)).toBe(true);
   });
+
+  it("also allows an email added via the PENNINGMEESTER_EMAILS env var", () => {
+    process.env.PENNINGMEESTER_EMAILS = "extra.penningmeester@example.nl";
+    expect(isPenningmeester("extra.penningmeester@example.nl")).toBe(true);
+    expect(canViewFinancialReport("extra.penningmeester@example.nl")).toBe(
+      true,
+    );
+  });
 });

--- a/apps/web/src/lib/authorization.test.tsx
+++ b/apps/web/src/lib/authorization.test.tsx
@@ -49,3 +49,18 @@ describe("allowlist separation", () => {
     expect(isSystemAdmin("jeroen@buchung.nl")).toBe(true);
   });
 });
+
+describe("configured penningmeester", () => {
+  const treasurer = "penningmeester@nationaalwatersportdiploma.nl";
+
+  it("allows the built-in treasurer mailbox (case-insensitive)", () => {
+    expect(isPenningmeester(treasurer)).toBe(true);
+    expect(
+      isPenningmeester("Penningmeester@NationaalWatersportdiploma.NL"),
+    ).toBe(true);
+  });
+
+  it("the treasurer can view the financial report", () => {
+    expect(canViewFinancialReport(treasurer)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/authorization.test.tsx
+++ b/apps/web/src/lib/authorization.test.tsx
@@ -1,11 +1,25 @@
 // Pure-logic test, run by vitest (`pnpm --filter @nawadi/web test:components`).
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   canViewFinancialReport,
   isEmailInAllowlist,
   isPenningmeester,
   isSystemAdmin,
 } from "./authorization";
+
+// PENNINGMEESTER_EMAILS extends the built-in allowlist via env; clear it per
+// test so these assertions don't depend on the runtime environment.
+const ORIGINAL_PM_EMAILS = process.env.PENNINGMEESTER_EMAILS;
+beforeEach(() => {
+  delete process.env.PENNINGMEESTER_EMAILS;
+});
+afterEach(() => {
+  if (ORIGINAL_PM_EMAILS === undefined) {
+    delete process.env.PENNINGMEESTER_EMAILS;
+  } else {
+    process.env.PENNINGMEESTER_EMAILS = ORIGINAL_PM_EMAILS;
+  }
+});
 
 describe("isEmailInAllowlist", () => {
   const allowlist = ["Penningmeester@NWD.nl"];

--- a/apps/web/src/lib/authorization.test.tsx
+++ b/apps/web/src/lib/authorization.test.tsx
@@ -1,0 +1,51 @@
+// Pure-logic test, run by vitest (`pnpm --filter @nawadi/web test:components`).
+import { describe, expect, it } from "vitest";
+import {
+  canViewFinancialReport,
+  isEmailInAllowlist,
+  isPenningmeester,
+  isSystemAdmin,
+} from "./authorization";
+
+describe("isEmailInAllowlist", () => {
+  const allowlist = ["Penningmeester@NWD.nl"];
+
+  it("matches case-insensitively and trims whitespace", () => {
+    expect(isEmailInAllowlist("penningmeester@nwd.nl", allowlist)).toBe(true);
+    expect(isEmailInAllowlist("  PENNINGMEESTER@NWD.NL  ", allowlist)).toBe(
+      true,
+    );
+  });
+
+  it("rejects non-members and empty input", () => {
+    expect(isEmailInAllowlist("someone@else.nl", allowlist)).toBe(false);
+    expect(isEmailInAllowlist(null, allowlist)).toBe(false);
+    expect(isEmailInAllowlist(undefined, allowlist)).toBe(false);
+    expect(isEmailInAllowlist("", allowlist)).toBe(false);
+  });
+});
+
+describe("canViewFinancialReport", () => {
+  it("allows a sysadmin (so Buchung can view/support the report)", () => {
+    expect(canViewFinancialReport("maurits@buchung.nl")).toBe(true);
+  });
+
+  it("denies a random logged-in user", () => {
+    expect(canViewFinancialReport("random@user.nl")).toBe(false);
+  });
+
+  it("denies anonymous", () => {
+    expect(canViewFinancialReport(null)).toBe(false);
+    expect(canViewFinancialReport(undefined)).toBe(false);
+  });
+});
+
+describe("allowlist separation", () => {
+  it("a sysadmin is NOT a penningmeester (separate, least-privilege lists)", () => {
+    expect(isPenningmeester("maurits@buchung.nl")).toBe(false);
+  });
+
+  it("isSystemAdmin recognizes a known admin", () => {
+    expect(isSystemAdmin("jeroen@buchung.nl")).toBe(true);
+  });
+});

--- a/apps/web/src/lib/authorization.ts
+++ b/apps/web/src/lib/authorization.ts
@@ -9,18 +9,21 @@ const SYSTEM_ADMIN_EMAILS: readonly string[] = [
 // to the financial report only (see canViewFinancialReport + the /penningmeester
 // middleware branch).
 //
-// Sourced from the PENNINGMEESTER_EMAILS env var (comma-separated) so the
-// treasurer can be enabled per environment WITHOUT a code deploy. Unset/empty =>
-// only sysadmins can view (fails closed). Comparison is normalized
-// (lowercase + trim) so a casing/whitespace difference in the stored email
-// cannot silently lock the treasurer out.
-//
-//   PENNINGMEESTER_EMAILS=penningmeester@nationaalwatersportdiploma.nl
+// The canonical treasurer role mailbox is built in (mirrors how isSystemAdmin
+// hardcodes role mailboxes). Extra emails can be added per environment via the
+// PENNINGMEESTER_EMAILS env var (comma-separated) without a code deploy.
+// Comparison is normalized (lowercase + trim) so a casing/whitespace difference
+// in the stored email cannot silently lock the treasurer out.
+const PENNINGMEESTER_EMAILS: readonly string[] = [
+  "penningmeester@nationaalwatersportdiploma.nl",
+];
+
 function getPenningmeesterEmails(): string[] {
-  return (process.env.PENNINGMEESTER_EMAILS ?? "")
+  const fromEnv = (process.env.PENNINGMEESTER_EMAILS ?? "")
     .split(",")
     .map((entry) => entry.trim())
     .filter((entry) => entry.length > 0);
+  return [...PENNINGMEESTER_EMAILS, ...fromEnv];
 }
 
 function normalizeEmail(email: string): string {

--- a/apps/web/src/lib/authorization.ts
+++ b/apps/web/src/lib/authorization.ts
@@ -4,6 +4,51 @@ const SYSTEM_ADMIN_EMAILS: readonly string[] = [
   "info@nationaalwatersportdiploma.nl",
 ];
 
+// Penningmeester (treasurer) allowlist. The treasurer is an association board
+// volunteer, NOT a Buchung sysadmin, so they get their own least-privilege door
+// to the financial report only (see canViewFinancialReport + the /penningmeester
+// middleware branch). Add the board treasurer's email below.
+//
+//   PENNINGMEESTER_EMAILS = ["penningmeester@nationaalwatersportdiploma.nl"]
+//
+// Comparison is normalized (lowercase + trim) so a casing/whitespace difference
+// in the stored email cannot silently lock the treasurer out.
+const PENNINGMEESTER_EMAILS: readonly string[] = [];
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+/**
+ * Case/whitespace-insensitive allowlist membership check. Exported so the
+ * allowlist logic can be unit-tested independently of any specific list.
+ */
+export function isEmailInAllowlist(
+  email: string | null | undefined,
+  allowlist: readonly string[],
+): boolean {
+  if (!email) {
+    return false;
+  }
+  const normalized = normalizeEmail(email);
+  return allowlist.some((entry) => normalizeEmail(entry) === normalized);
+}
+
 export function isSystemAdmin(email: string | null | undefined): boolean {
   return !!email && SYSTEM_ADMIN_EMAILS.includes(email);
+}
+
+export function isPenningmeester(email: string | null | undefined): boolean {
+  return isEmailInAllowlist(email, PENNINGMEESTER_EMAILS);
+}
+
+/**
+ * Who may see the penningmeester (financial) report: the treasurer, or any
+ * sysadmin (so Buchung can view/support it too). This is the gate enforced in
+ * both the middleware branch and inside each report server action.
+ */
+export function canViewFinancialReport(
+  email: string | null | undefined,
+): boolean {
+  return isPenningmeester(email) || isSystemAdmin(email);
 }

--- a/apps/web/src/lib/authorization.ts
+++ b/apps/web/src/lib/authorization.ts
@@ -7,13 +7,21 @@ const SYSTEM_ADMIN_EMAILS: readonly string[] = [
 // Penningmeester (treasurer) allowlist. The treasurer is an association board
 // volunteer, NOT a Buchung sysadmin, so they get their own least-privilege door
 // to the financial report only (see canViewFinancialReport + the /penningmeester
-// middleware branch). Add the board treasurer's email below.
+// middleware branch).
 //
-//   PENNINGMEESTER_EMAILS = ["penningmeester@nationaalwatersportdiploma.nl"]
+// Sourced from the PENNINGMEESTER_EMAILS env var (comma-separated) so the
+// treasurer can be enabled per environment WITHOUT a code deploy. Unset/empty =>
+// only sysadmins can view (fails closed). Comparison is normalized
+// (lowercase + trim) so a casing/whitespace difference in the stored email
+// cannot silently lock the treasurer out.
 //
-// Comparison is normalized (lowercase + trim) so a casing/whitespace difference
-// in the stored email cannot silently lock the treasurer out.
-const PENNINGMEESTER_EMAILS: readonly string[] = [];
+//   PENNINGMEESTER_EMAILS=penningmeester@nationaalwatersportdiploma.nl
+function getPenningmeesterEmails(): string[] {
+  return (process.env.PENNINGMEESTER_EMAILS ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
 
 function normalizeEmail(email: string): string {
   return email.trim().toLowerCase();
@@ -39,7 +47,7 @@ export function isSystemAdmin(email: string | null | undefined): boolean {
 }
 
 export function isPenningmeester(email: string | null | undefined): boolean {
-  return isEmailInAllowlist(email, PENNINGMEESTER_EMAILS);
+  return isEmailInAllowlist(email, getPenningmeesterEmails());
 }
 
 /**

--- a/apps/web/src/lib/supabase/middleware.ts
+++ b/apps/web/src/lib/supabase/middleware.ts
@@ -1,6 +1,6 @@
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
-import { isSystemAdmin } from "~/lib/authorization";
+import { canViewFinancialReport, isSystemAdmin } from "~/lib/authorization";
 import { invariant } from "~/utils/invariant";
 
 export async function updateSession(request: NextRequest) {
@@ -44,6 +44,18 @@ export async function updateSession(request: NextRequest) {
 
   if (request.nextUrl.pathname.startsWith("/secretariaat")) {
     if (!user?.email || !isSystemAdmin(user.email)) {
+      const url = request.nextUrl.clone();
+      url.pathname = "/profiel?_cacheBust=1";
+      return NextResponse.redirect(url);
+    }
+  }
+
+  // Least-privilege gate for the penningmeester (treasurer) financial report.
+  // Edge-level defense in addition to the per-page and per-action checks. The
+  // treasurer is NOT a sysadmin, so this is a separate allowlist from
+  // /secretariaat (see canViewFinancialReport).
+  if (request.nextUrl.pathname.startsWith("/penningmeester")) {
+    if (!user?.email || !canViewFinancialReport(user.email)) {
       const url = request.nextUrl.clone();
       url.pathname = "/profiel?_cacheBust=1";
       return NextResponse.redirect(url);

--- a/apps/web/src/lib/supabase/middleware.ts
+++ b/apps/web/src/lib/supabase/middleware.ts
@@ -57,7 +57,11 @@ export async function updateSession(request: NextRequest) {
   if (request.nextUrl.pathname.startsWith("/penningmeester")) {
     if (!user?.email || !canViewFinancialReport(user.email)) {
       const url = request.nextUrl.clone();
-      url.pathname = "/profiel?_cacheBust=1";
+      // Set pathname and query separately: assigning "/profiel?_cacheBust=1" to
+      // .pathname URL-encodes the "?" into the path, producing a broken redirect
+      // target (/profiel%3F_cacheBust=1).
+      url.pathname = "/profiel";
+      url.search = "?_cacheBust=1";
       return NextResponse.redirect(url);
     }
   }


### PR DESCRIPTION
## What

A least-privilege back-office report at **`/penningmeester`** so the treasurer (an association board volunteer) can self-serve the numbers they need to invoice each vaarlocatie: **per-location certificate counts over a date range, split consument (eigenvaardigheid) vs instructeur (kaderopleiding)**, with CSV/XLSX export for manual invoicing in the external system.

Replaces a recurring manual data pull. Planned via `/plan-ceo-review` + `/plan-eng-review` (+ Codex outside voice); reviewed via `/review` (Claude adversarial + Codex).

## Access

The treasurer mailbox **`penningmeester@nationaalwatersportdiploma.nl`** is built into the allowlist, so the treasurer can log in immediately (no env config needed). Extra emails can be added per environment via the `PENNINGMEESTER_EMAILS` env var (comma-separated) without a deploy. The gate fails closed — only the allowlist plus the existing sysadmins.

## How it works

- **Split is per-program rank.** A course has no type; the program does. Classification joins `certificate → student_curriculum → curriculum → program → degree` and uses `degree.rang > 4` = instructeur (`INSTRUCTEUR_MIN_RANG = 5`). Single source of truth for the billing split.
- **Counts in SQL.** `GROUP BY location × rang`, `count(distinct certificate.id)` so joins can't inflate. Only `certificate.deleted_at IS NULL` gates inclusion (classification tables are FK-joined without their own soft-delete filter, so a later-retired program still classifies a cert it issued). Locations with activity appear regardless of status.
- **Timezone is exact.** Period boundaries computed Amsterdam→UTC, half-open `[from, to)`, DST-safe, querying the raw indexed `issued_at` (keeps `certificate_idx_location_issued_at`). Defaults/presets anchored to Amsterdam, not the server tz.
- **Export = the billing record.** Summary sheet `[Locatie, Handle, Consument, Instructeur, Totaal]` + a per-certificate evidence sheet (handles behind the counts) + an export timestamp, so a disputed count can be substantiated and a re-run is comparable. No DB period-lock.
- **Auth in depth.** `isPenningmeester || isSystemAdmin` enforced in middleware, on the page, and **inside each server action** (server actions are independently callable). Normalized email comparison.

## Reuse

Date pickers (`DateSelector`/`FixedDateSelector`), `lib/export.ts`, the page/query/Suspense pattern, the `isSystemAdmin` gate pattern, and the `/secretariaat` middleware branch. Net-new: the grouped query, the Amsterdam period util, `isPenningmeester`, the evidence export, and the gated route.

## Review fixes (Claude + Codex)

- **P1 (both models):** malformed dates rolled over silently in `dayjs` → wrong period. Now strict-validated (`YYYY-MM-DD`, strict mode) + schema regex. +4 regression tests.
- **P2 (both):** allowlist was an empty hardcoded constant. Now has the built-in treasurer mailbox plus a `PENNINGMEESTER_EMAILS` env override.
- **Codex:** server-tz defaults and raw-UTC export dates → both Amsterdam-anchored.

## Testing

`pnpm --filter @nawadi/web test:components` → **17 passing** unit tests covering the Amsterdam/DST half-open boundary math (winter/summer, spring-forward 23h, fall-back 25h, strict-invalid rejection) and the auth allowlist (normalization, the built-in treasurer, sysadmin-allowed, anon-denied). Typecheck clean for the new files.

DB-level integration tests for the aggregation (soft-delete exclusion, rang split on real rows) are a recommended follow-up — they need the seeded local DB.

## Deliberate non-goals (decided in planning)

Computed € amounts, a period-lock/audit table, and per-discipline drill-down were considered and skipped. Historical re-classification (if curriculum metadata is later re-pointed) is an accepted live-recompute risk, mitigated by the export snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization middleware and billing-sensitive aggregation/date boundaries; mistakes could leak financial data or miscount invoices, though defense-in-depth and strict date validation mitigate this.
> 
> **Overview**
> Adds a gated **`/penningmeester`** treasurer dashboard so invoicing can self-serve **per-location certificate counts** over a chosen period, split **consument vs instructeur** (by `degree.rang >= 5`), with **CSV/XLSX** summary and per-certificate detail exports.
> 
> **Access** is layered: `canViewFinancialReport` (built-in treasurer mailbox + `PENNINGMEESTER_EMAILS`, plus sysadmins), enforced in **middleware**, the page, and **server actions/queries**. Email allowlist matching is **normalized** (trim/lowercase).
> 
> **Billing window** uses **Amsterdam calendar dates → half-open UTC** on `issued_at` (DST-safe, strict `YYYY-MM-DD` validation). Defaults and presets are **Amsterdam-anchored**; detail export shows issue dates in Amsterdam local time.
> 
> **Data** is aggregated in SQL (`count(distinct certificate.id)` by location, soft-deleted certs excluded). Unit tests cover period math and authorization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17e2375b4f7e372e873c6d98a3e2b92f1c24915d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Penningmeester (Treasurer) dashboard: sidebar entry, header, presets and manual date-range selectors, per-location certificate report, and export buttons (CSV/XLSX) for summary and detail.

* **Access**
  * Penningmeester pages and exports restricted to treasurer and admin accounts; unauthorized users see a no-access message or are redirected.

* **Tests**
  * Added unit tests for authorization checks and strict Amsterdam date-range → UTC conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->