### PR TITLE
Feat(secretariaat): nwd c registratie (stacked on #426)

### DIFF
--- a/apps/web/src/app/(certificate)/diploma/[id]/_components/template.tsx
+++ b/apps/web/src/app/(certificate)/diploma/[id]/_components/template.tsx
@@ -68,6 +68,8 @@ export default async function CertificateTemplate({
     uniqueCompletedModules.includes(module.id),
   );
 
+  const isNwdC = certificate.program.degree.handle === "niveau-c";
+
   return (
     <div className="min-h-full flex flex-col @container">
       <TemplateHeader
@@ -88,60 +90,74 @@ export default async function CertificateTemplate({
         </div>
         <div className="relative flex flex-col w-full">
           <div>
-            <DataLabel>Afgeronde modules</DataLabel>
+            <DataLabel>
+              {isNwdC ? "NWD-C eigenvaardigheid" : "Afgeronde modules"}
+            </DataLabel>
             <p className="text-base">
-              Klik op een module voor meer informatie.
+              {isNwdC
+                ? "NWD-C is een registratie van eigenvaardigheid zonder afzonderlijke modules."
+                : "Klik op een module voor meer informatie."}
             </p>
           </div>
-          <div className="mt-8 grid grid-cols-1 lg:grid-cols-2 gap-y-8 gap-x-6">
-            {modules.map((module) => {
-              return (
-                <Module
-                  key={module.id}
-                  button={
-                    <>
-                      <span className="font-semibold">{module.title}</span>
+          {isNwdC ? (
+            <p className="mt-8 text-base text-zinc-700 dark:text-zinc-300">
+              Deze instructeur beschikt over NWD-C eigenvaardigheid voor{" "}
+              {(certificate.gearType.title ?? "dit vaartuig").toLowerCase()} binnen{" "}
+              {certificate.program.course.discipline.title?.toLowerCase() ??
+                "deze discipline"}
+              .
+            </p>
+          ) : (
+            <div className="mt-8 grid grid-cols-1 lg:grid-cols-2 gap-y-8 gap-x-6">
+              {modules.map((module) => {
+                return (
+                  <Module
+                    key={module.id}
+                    button={
+                      <>
+                        <span className="font-semibold">{module.title}</span>
 
-                      <div className="flex flex-col gap-y-[4px]">
-                        <hr className="w-full h-0.5 bg-branding-dark" />
-                        <hr className="w-full h-0.5 bg-branding-dark" />
-                      </div>
-                    </>
-                  }
-                >
-                  <DialogTitle>{module.title}</DialogTitle>
+                        <div className="flex flex-col gap-y-[4px]">
+                          <hr className="w-full h-0.5 bg-branding-dark" />
+                          <hr className="w-full h-0.5 bg-branding-dark" />
+                        </div>
+                      </>
+                    }
+                  >
+                    <DialogTitle>{module.title}</DialogTitle>
 
-                  <p className="mt-2 text-pretty text-base/6 text-zinc-500 sm:text-sm/6">
-                    Hieronder staan de competenties die onder deze module
-                    vallen, en jij hebt laten zien dat je ze beheerst!
-                  </p>
+                    <p className="mt-2 text-pretty text-base/6 text-zinc-500 sm:text-sm/6">
+                      Hieronder staan de competenties die onder deze module
+                      vallen, en jij hebt laten zien dat je ze beheerst!
+                    </p>
 
-                  <DialogBody className="text-sm/6 text-zinc-900">
-                    <ul className="flex flex-col gap-y-3.5 divide-y divide-slate-200 pt-2 pb-8">
-                      {module.competencies.map((competency) => {
-                        return (
-                          <li
-                            key={competency.id}
-                            className="flex flex-col pt-3.5"
-                          >
-                            <div className="flex items-center">
-                              <CheckIcon className="size-4 mr-2 text-green-500" />
-                              <span className="font-semibold">
-                                {competency.title}
+                    <DialogBody className="text-sm/6 text-zinc-900">
+                      <ul className="flex flex-col gap-y-3.5 divide-y divide-slate-200 pt-2 pb-8">
+                        {module.competencies.map((competency) => {
+                          return (
+                            <li
+                              key={competency.id}
+                              className="flex flex-col pt-3.5"
+                            >
+                              <div className="flex items-center">
+                                <CheckIcon className="size-4 mr-2 text-green-500" />
+                                <span className="font-semibold">
+                                  {competency.title}
+                                </span>
+                              </div>
+                              <span className="pl-6">
+                                {competency.requirement}
                               </span>
-                            </div>
-                            <span className="pl-6">
-                              {competency.requirement}
-                            </span>
-                          </li>
-                        );
-                      })}
-                    </ul>
-                  </DialogBody>
-                </Module>
-              );
-            })}
-          </div>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    </DialogBody>
+                  </Module>
+                );
+              })}
+            </div>
+          )}
         </div>
         <div className="flex relative flex-col gap-4">
           <div className="flex flex-col gap-y-3.5 gap-x-2.5 md:flex-row justify-between items-start">

--- a/apps/web/src/app/(certificate)/diploma/[id]/_components/template.tsx
+++ b/apps/web/src/app/(certificate)/diploma/[id]/_components/template.tsx
@@ -102,7 +102,8 @@ export default async function CertificateTemplate({
           {isNwdC ? (
             <p className="mt-8 text-base text-zinc-700 dark:text-zinc-300">
               Deze instructeur beschikt over NWD-C eigenvaardigheid voor{" "}
-              {(certificate.gearType.title ?? "dit vaartuig").toLowerCase()} binnen{" "}
+              {(certificate.gearType.title ?? "dit vaartuig").toLowerCase()}{" "}
+              binnen{" "}
               {certificate.program.course.discipline.title?.toLowerCase() ??
                 "deze discipline"}
               .

--- a/apps/web/src/app/(certificate)/diploma/_utils/generate-advise.ts
+++ b/apps/web/src/app/(certificate)/diploma/_utils/generate-advise.ts
@@ -11,6 +11,10 @@ export async function generateAdvise(
     certificate = await retrieveCertificateById(certificate);
   }
 
+  if (certificate.program.degree.handle === "niveau-c") {
+    return "Je hebt NWD-C eigenvaardigheid behaald. Blijf jezelf ontwikkelen binnen het NWD of verken een nieuwe discipline!";
+  }
+
   const uniqueCompletedModules = Array.from(
     new Set(
       certificate.completedCompetencies.map(

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/_components/progress/certificates.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/_components/progress/certificates.tsx
@@ -91,6 +91,7 @@ async function Certificates({
         const keuzemodules = certificate.completedModules.filter(
           (m) => !m.module.isRequired,
         );
+        const isNwdC = certificate.program.degree.handle === "niveau-c";
 
         return (
           <li key={certificate.id}>
@@ -150,65 +151,78 @@ async function Certificates({
 
                 <ProgressCardDisclosure
                   header={
-                    <>
-                      Behaalde modules{" "}
-                      <ProgressCardBadge>
-                        {certificate.completedModules.length}
-                      </ProgressCardBadge>
-                    </>
+                    isNwdC ? (
+                      "NWD-C eigenvaardigheid"
+                    ) : (
+                      <>
+                        Behaalde modules{" "}
+                        <ProgressCardBadge>
+                          {certificate.completedModules.length}
+                        </ProgressCardBadge>
+                      </>
+                    )
                   }
                 >
-                  <Text>Kernmodules</Text>
-                  {kernModules.length > 0 ? (
-                    <ProgressCardStatusList>
-                      {kernModules.map(({ module }) => (
-                        <ModuleDisclosure
-                          key={module.id}
-                          module={
-                            module as Student.Curriculum.$schema.StudentCurriculum["curriculum"]["modules"][number]
-                          }
-                          progress={100}
-                        >
-                          <ProgressCardStatusSubList>
-                            {module.competencies.map((c) => (
-                              <Competency
-                                key={c.id}
-                                competency={c}
-                                progress={100}
-                              />
-                            ))}
-                          </ProgressCardStatusSubList>
-                        </ModuleDisclosure>
-                      ))}
-                    </ProgressCardStatusList>
+                  {isNwdC ? (
+                    <Text>
+                      NWD-C is een registratie van eigenvaardigheid zonder
+                      afzonderlijke modules.
+                    </Text>
                   ) : (
-                    <Text className="italic">Geen kernmodules</Text>
-                  )}
-                  <Text className="mt-2">Keuzemodules</Text>
-                  {keuzemodules.length > 0 ? (
-                    <ProgressCardStatusList>
-                      {keuzemodules.map(({ module }) => (
-                        <ModuleDisclosure
-                          key={module.id}
-                          module={
-                            module as Student.Curriculum.$schema.StudentCurriculum["curriculum"]["modules"][number]
-                          }
-                          progress={100}
-                        >
-                          <ProgressCardStatusSubList>
-                            {module.competencies.map((c) => (
-                              <Competency
-                                key={c.id}
-                                competency={c}
-                                progress={100}
-                              />
-                            ))}
-                          </ProgressCardStatusSubList>
-                        </ModuleDisclosure>
-                      ))}
-                    </ProgressCardStatusList>
-                  ) : (
-                    <Text className="italic">Geen keuzemodules</Text>
+                    <>
+                      <Text>Kernmodules</Text>
+                      {kernModules.length > 0 ? (
+                        <ProgressCardStatusList>
+                          {kernModules.map(({ module }) => (
+                            <ModuleDisclosure
+                              key={module.id}
+                              module={
+                                module as Student.Curriculum.$schema.StudentCurriculum["curriculum"]["modules"][number]
+                              }
+                              progress={100}
+                            >
+                              <ProgressCardStatusSubList>
+                                {module.competencies.map((c) => (
+                                  <Competency
+                                    key={c.id}
+                                    competency={c}
+                                    progress={100}
+                                  />
+                                ))}
+                              </ProgressCardStatusSubList>
+                            </ModuleDisclosure>
+                          ))}
+                        </ProgressCardStatusList>
+                      ) : (
+                        <Text className="italic">Geen kernmodules</Text>
+                      )}
+                      <Text className="mt-2">Keuzemodules</Text>
+                      {keuzemodules.length > 0 ? (
+                        <ProgressCardStatusList>
+                          {keuzemodules.map(({ module }) => (
+                            <ModuleDisclosure
+                              key={module.id}
+                              module={
+                                module as Student.Curriculum.$schema.StudentCurriculum["curriculum"]["modules"][number]
+                              }
+                              progress={100}
+                            >
+                              <ProgressCardStatusSubList>
+                                {module.competencies.map((c) => (
+                                  <Competency
+                                    key={c.id}
+                                    competency={c}
+                                    progress={100}
+                                  />
+                                ))}
+                              </ProgressCardStatusSubList>
+                            </ModuleDisclosure>
+                          ))}
+                        </ProgressCardStatusList>
+                      ) : (
+                        <Text className="italic">Geen keuzemodules</Text>
+                      )}
+                    </>
                   )}
                 </ProgressCardDisclosure>
               </ProgressCardDisclosures>

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/add-nwd-c-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/add-nwd-c-dialog.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useFormStatus } from "react-dom";
+import { toast } from "sonner";
+import {
+  getGearTypesForNwdCCurriculum,
+  registerNwdCAction,
+} from "~/app/_actions/eigenvaardigheid/manage-nwd-c";
+import { Button } from "~/app/(dashboard)/_components/button";
+import {
+  Combobox,
+  ComboboxOption,
+} from "~/app/(dashboard)/_components/combobox";
+import {
+  Dialog,
+  DialogActions,
+  DialogBody,
+  DialogDescription,
+  DialogTitle,
+} from "~/app/(dashboard)/_components/dialog";
+import { Field, Fieldset, Label } from "~/app/(dashboard)/_components/fieldset";
+import { Input } from "~/app/(dashboard)/_components/input";
+import { Textarea } from "~/app/(dashboard)/_components/textarea";
+import dayjs from "~/lib/dayjs";
+
+type NwdCProgram = Awaited<
+  ReturnType<
+    typeof import("~/app/_actions/eigenvaardigheid/manage-nwd-c").getNwdCPrograms
+  >
+>[number];
+
+type LocationOption = Awaited<
+  ReturnType<
+    typeof import("~/app/_actions/eigenvaardigheid/manage-nwd-c").listLocationsForNwdCRegistration
+  >
+>[number];
+
+type ExistingNwdCKey = Awaited<
+  ReturnType<
+    typeof import("~/app/_actions/eigenvaardigheid/manage-nwd-c").getExistingNwdCCertificateKeys
+  >
+>[number];
+
+type GearType = Awaited<
+  ReturnType<typeof getGearTypesForNwdCCurriculum>
+>[number];
+
+function SubmitButton({ disabled }: { disabled: boolean }) {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending || disabled}>
+      {pending ? "Registreren..." : "NWD-C registreren"}
+    </Button>
+  );
+}
+
+export default function AddNwdCDialog({
+  isOpen,
+  onClose,
+  personId,
+  programs,
+  locations,
+  existingNwdCKeys,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  personId: string;
+  programs: NwdCProgram[];
+  locations: LocationOption[];
+  existingNwdCKeys: ExistingNwdCKey[];
+}) {
+  const [selectedProgram, setSelectedProgram] = useState<NwdCProgram | null>(
+    null,
+  );
+  const [selectedGearType, setSelectedGearType] = useState<GearType | null>(
+    null,
+  );
+  const [selectedLocation, setSelectedLocation] =
+    useState<LocationOption | null>(null);
+  const [gearTypes, setGearTypes] = useState<GearType[]>([]);
+  const [isLoadingGearTypes, setIsLoadingGearTypes] = useState(false);
+  const [issuedDate, setIssuedDate] = useState(
+    dayjs().format("YYYY-MM-DD"),
+  );
+  const [opmerkingen, setOpmerkingen] = useState("");
+  const [programQuery, setProgramQuery] = useState("");
+  const [gearQuery, setGearQuery] = useState("");
+  const [locationQuery, setLocationQuery] = useState("");
+
+  useEffect(() => {
+    if (!selectedProgram?.curriculum?.id) {
+      setGearTypes([]);
+      setSelectedGearType(null);
+      return;
+    }
+
+    setIsLoadingGearTypes(true);
+    getGearTypesForNwdCCurriculum(selectedProgram.curriculum.id)
+      .then((types) => {
+        setGearTypes(types);
+        setSelectedGearType(null);
+      })
+      .catch(() => {
+        toast.error("Vaartuigen laden mislukt");
+        setGearTypes([]);
+      })
+      .finally(() => {
+        setIsLoadingGearTypes(false);
+      });
+  }, [selectedProgram?.curriculum?.id]);
+
+  const isCombinationExisting = (
+    curriculumId: string | undefined,
+    gearTypeId: string | undefined,
+  ) => {
+    if (!curriculumId || !gearTypeId) return false;
+    return existingNwdCKeys.some(
+      (key) =>
+        key.curriculumId === curriculumId && key.gearTypeId === gearTypeId,
+    );
+  };
+
+  const availableGearTypes = gearTypes.filter(
+    (gearType) =>
+      !isCombinationExisting(selectedProgram?.curriculum?.id, gearType.id),
+  );
+
+  const resetForm = () => {
+    setSelectedProgram(null);
+    setSelectedGearType(null);
+    setSelectedLocation(null);
+    setGearTypes([]);
+    setIssuedDate(dayjs().format("YYYY-MM-DD"));
+    setOpmerkingen("");
+    setProgramQuery("");
+    setGearQuery("");
+    setLocationQuery("");
+  };
+
+  const handleClose = () => {
+    onClose();
+    resetForm();
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (
+      !selectedProgram?.curriculum?.id ||
+      !selectedGearType ||
+      !selectedLocation
+    ) {
+      return;
+    }
+
+    if (
+      isCombinationExisting(
+        selectedProgram.curriculum.id,
+        selectedGearType.id,
+      )
+    ) {
+      toast.error("Deze NWD-C combinatie bestaat al voor deze persoon");
+      return;
+    }
+
+    try {
+      const result = await registerNwdCAction({
+        personId,
+        curriculumId: selectedProgram.curriculum.id,
+        gearTypeId: selectedGearType.id,
+        locationId: selectedLocation.id,
+        issuedAt: dayjs(issuedDate).startOf("day").toISOString(),
+        opmerkingen: opmerkingen || undefined,
+      });
+
+      if (result?.data?.success) {
+        toast.success("NWD-C geregistreerd");
+        handleClose();
+      } else if (result?.serverError) {
+        toast.error(result.serverError);
+      } else {
+        toast.error("Registratie mislukt");
+      }
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Registratie mislukt",
+      );
+    }
+  };
+
+  const canSubmit =
+    !!selectedProgram?.curriculum?.id &&
+    !!selectedGearType &&
+    !!selectedLocation &&
+    !!issuedDate;
+
+  return (
+    <Dialog open={isOpen} onClose={handleClose} size="2xl">
+      <DialogTitle>NWD-C registreren</DialogTitle>
+      <DialogDescription>
+        Registreer een NWD-C eigenvaardigheid voor deze instructeur. Per
+        discipline is maximaal één C per vaartuig toegestaan.
+      </DialogDescription>
+
+      <form onSubmit={handleSubmit}>
+        <DialogBody>
+          <Fieldset>
+            <Field>
+              <Label htmlFor="program">Discipline / programma</Label>
+              <Combobox
+                value={selectedProgram}
+                onChange={(program) => {
+                  setSelectedProgram(program);
+                  setSelectedGearType(null);
+                }}
+                options={programs}
+                displayValue={(program) =>
+                  program
+                    ? `${program.course.discipline.title ?? program.course.handle} — ${program.title ?? program.handle}`
+                    : ""
+                }
+                filter={(program, query) =>
+                  program
+                    ? (program.course.discipline.title
+                        ?.toLowerCase()
+                        .includes(query.toLowerCase()) ??
+                        false) ||
+                      program.title
+                        ?.toLowerCase()
+                        .includes(query.toLowerCase()) ||
+                      program.handle.toLowerCase().includes(query.toLowerCase())
+                    : false
+                }
+                placeholder="Zoek een discipline..."
+                setQuery={setProgramQuery}
+              >
+                {(program) => (
+                  <ComboboxOption value={program}>
+                    <div>
+                      <div className="font-medium">
+                        {program.course.discipline.title ??
+                          program.course.handle}
+                      </div>
+                      <div className="text-sm text-zinc-500 dark:text-zinc-400">
+                        {program.title ?? program.handle}
+                      </div>
+                    </div>
+                  </ComboboxOption>
+                )}
+              </Combobox>
+            </Field>
+
+            {selectedProgram && (
+              <Field>
+                <Label htmlFor="gearType">Vaartuig</Label>
+                {isLoadingGearTypes ? (
+                  <p className="text-sm text-zinc-500">Vaartuigen laden...</p>
+                ) : availableGearTypes.length === 0 ? (
+                  <p className="text-sm text-zinc-500">
+                    Geen beschikbare vaartuigen (alle combinaties zijn al
+                    geregistreerd).
+                  </p>
+                ) : (
+                  <Combobox
+                    value={selectedGearType}
+                    onChange={setSelectedGearType}
+                    options={availableGearTypes}
+                    displayValue={(gearType) => gearType?.title ?? ""}
+                    filter={(gearType, query) =>
+                      gearType
+                        ? (gearType.title ?? gearType.handle)
+                            .toLowerCase()
+                            .includes(query.toLowerCase())
+                        : false
+                    }
+                    placeholder="Selecteer vaartuig..."
+                    setQuery={setGearQuery}
+                  >
+                    {(gearType) => (
+                      <ComboboxOption value={gearType}>
+                        {gearType.title ?? gearType.handle}
+                      </ComboboxOption>
+                    )}
+                  </Combobox>
+                )}
+              </Field>
+            )}
+
+            <Field>
+              <Label htmlFor="location">Locatie van registratie</Label>
+              <Combobox
+                value={selectedLocation}
+                onChange={setSelectedLocation}
+                options={locations}
+                displayValue={(location) => location?.name ?? ""}
+                filter={(location, query) =>
+                  location
+                    ? (location.name ?? location.handle)
+                        .toLowerCase()
+                        .includes(query.toLowerCase())
+                    : false
+                }
+                placeholder="Zoek een locatie..."
+                setQuery={setLocationQuery}
+              >
+                {(location) => (
+                  <ComboboxOption value={location}>
+                    {location.name ?? location.handle}
+                  </ComboboxOption>
+                )}
+              </Combobox>
+            </Field>
+
+            <Field>
+              <Label htmlFor="issuedDate">Datum van registratie</Label>
+              <Input
+                id="issuedDate"
+                type="date"
+                value={issuedDate}
+                onChange={(e) => setIssuedDate(e.target.value)}
+                required
+              />
+            </Field>
+
+            <Field>
+              <Label htmlFor="opmerkingen">Opmerkingen (optioneel)</Label>
+              <Textarea
+                id="opmerkingen"
+                rows={3}
+                value={opmerkingen}
+                onChange={(e) => setOpmerkingen(e.target.value)}
+                placeholder="Bijv. naam beoordelaar of context van de registratie"
+              />
+            </Field>
+          </Fieldset>
+        </DialogBody>
+
+        <DialogActions>
+          <Button plain onClick={handleClose} type="button">
+            Annuleren
+          </Button>
+          <SubmitButton disabled={!canSubmit} />
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/add-nwd-c-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/add-nwd-c-dialog.tsx
@@ -80,13 +80,11 @@ export default function AddNwdCDialog({
     useState<LocationOption | null>(null);
   const [gearTypes, setGearTypes] = useState<GearType[]>([]);
   const [isLoadingGearTypes, setIsLoadingGearTypes] = useState(false);
-  const [issuedDate, setIssuedDate] = useState(
-    dayjs().format("YYYY-MM-DD"),
-  );
+  const [issuedDate, setIssuedDate] = useState(dayjs().format("YYYY-MM-DD"));
   const [opmerkingen, setOpmerkingen] = useState("");
-  const [programQuery, setProgramQuery] = useState("");
-  const [gearQuery, setGearQuery] = useState("");
-  const [locationQuery, setLocationQuery] = useState("");
+  const [_programQuery, setProgramQuery] = useState("");
+  const [_gearQuery, setGearQuery] = useState("");
+  const [_locationQuery, setLocationQuery] = useState("");
 
   useEffect(() => {
     if (!selectedProgram?.curriculum?.id) {
@@ -155,10 +153,7 @@ export default function AddNwdCDialog({
     }
 
     if (
-      isCombinationExisting(
-        selectedProgram.curriculum.id,
-        selectedGearType.id,
-      )
+      isCombinationExisting(selectedProgram.curriculum.id, selectedGearType.id)
     ) {
       toast.error("Deze NWD-C combinatie bestaat al voor deze persoon");
       return;
@@ -170,7 +165,7 @@ export default function AddNwdCDialog({
         curriculumId: selectedProgram.curriculum.id,
         gearTypeId: selectedGearType.id,
         locationId: selectedLocation.id,
-        issuedAt: dayjs(issuedDate).startOf("day").toISOString(),
+        issuedAt: dayjs.tz(issuedDate).startOf("day").toISOString(),
         opmerkingen: opmerkingen || undefined,
       });
 

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview-client.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview-client.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { TrashIcon } from "@heroicons/react/16/solid";
+import { useState } from "react";
+import { Button } from "~/app/(dashboard)/_components/button";
+import dayjs from "~/lib/dayjs";
+import type { listCertificatesForPersonAsAdmin } from "~/lib/nwd";
+import AddNwdCDialog from "./add-nwd-c-dialog";
+import RemoveNwdCDialog from "./remove-nwd-c-dialog";
+
+type Certificate = Awaited<
+  ReturnType<typeof listCertificatesForPersonAsAdmin>
+>[number];
+
+type NwdCProgram = Awaited<
+  ReturnType<
+    typeof import("~/app/_actions/eigenvaardigheid/manage-nwd-c").getNwdCPrograms
+  >
+>[number];
+
+type LocationOption = Awaited<
+  ReturnType<
+    typeof import("~/app/_actions/eigenvaardigheid/manage-nwd-c").listLocationsForNwdCRegistration
+  >
+>[number];
+
+type ExistingNwdCKey = Awaited<
+  ReturnType<
+    typeof import("~/app/_actions/eigenvaardigheid/manage-nwd-c").getExistingNwdCCertificateKeys
+  >
+>[number];
+
+interface GroupedByDiscipline {
+  disciplineTitle: string;
+  certificates: Certificate[];
+}
+
+export function EigenvaardigheidOverviewClient({
+  personId,
+  certificates,
+  programs,
+  locations,
+  existingNwdCKeys,
+}: {
+  personId: string;
+  certificates: Certificate[];
+  programs: NwdCProgram[];
+  locations: LocationOption[];
+  existingNwdCKeys: ExistingNwdCKey[];
+}) {
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+  const [certificateToRemove, setCertificateToRemove] =
+    useState<Certificate | null>(null);
+
+  const grouped: GroupedByDiscipline[] = certificates.reduce((acc, cert) => {
+    const disciplineTitle = cert.program.course.discipline.title ?? "Onbekend";
+    let group = acc.find((g) => g.disciplineTitle === disciplineTitle);
+    if (!group) {
+      group = { disciplineTitle, certificates: [] };
+      acc.push(group);
+    }
+    group.certificates.push(cert);
+    return acc;
+  }, [] as GroupedByDiscipline[]);
+
+  return (
+    <div className="mt-8">
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h3 className="text-lg leading-6 font-medium text-gray-900 dark:text-white">
+            Eigenvaardigheid
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Behaalde NWD-diploma&apos;s van deze persoon
+          </p>
+        </div>
+        <Button onClick={() => setIsAddDialogOpen(true)}>
+          NWD-C registreren
+        </Button>
+      </div>
+
+      {certificates.length === 0 ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400 italic">
+          Geen NWD-diploma&apos;s gevonden.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          {grouped.map((group) => (
+            <div
+              key={group.disciplineTitle}
+              className="bg-white dark:bg-gray-800 shadow overflow-hidden sm:rounded-lg"
+            >
+              <div className="px-4 py-5 sm:px-6">
+                <h4 className="text-base font-medium text-gray-900 dark:text-white capitalize">
+                  {group.disciplineTitle}
+                </h4>
+              </div>
+              <div className="border-t border-gray-200 dark:border-gray-700 overflow-x-auto">
+                <table className="min-w-full">
+                  <thead className="bg-gray-50 dark:bg-gray-700">
+                    <tr>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                        Niveau
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                        Vaartuig
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                        Behaald op
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                        Locatie
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                        Opmerkingen
+                      </th>
+                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                        Acties
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                    {group.certificates.map((cert) => {
+                      const isNwdC =
+                        cert.program.degree.handle === "niveau-c";
+
+                      return (
+                        <tr key={cert.id}>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                            {cert.program.degree.title}
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                            {cert.gearType.title}
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                            {dayjs(cert.issuedAt).format("DD-MM-YYYY")}
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                            {cert.location.name}
+                          </td>
+                          <td className="px-6 py-4 text-sm text-gray-900 dark:text-gray-100 max-w-xs">
+                            {cert.opmerkingen ? (
+                              <span className="line-clamp-2">
+                                {cert.opmerkingen}
+                              </span>
+                            ) : (
+                              <span className="text-gray-400 italic">—</span>
+                            )}
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-right text-sm">
+                            {isNwdC ? (
+                              <button
+                                type="button"
+                                onClick={() => setCertificateToRemove(cert)}
+                                className="inline-flex items-center text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
+                                title="NWD-C intrekken"
+                              >
+                                <TrashIcon className="h-4 w-4" />
+                              </button>
+                            ) : null}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <AddNwdCDialog
+        isOpen={isAddDialogOpen}
+        onClose={() => setIsAddDialogOpen(false)}
+        personId={personId}
+        programs={programs}
+        locations={locations}
+        existingNwdCKeys={existingNwdCKeys}
+      />
+
+      <RemoveNwdCDialog
+        isOpen={certificateToRemove !== null}
+        onClose={() => setCertificateToRemove(null)}
+        personId={personId}
+        certificate={certificateToRemove}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
@@ -35,19 +35,16 @@ export async function EigenvaardigheidOverview({
     );
   }
 
-  const grouped: GroupedByDiscipline[] = certificates.reduce(
-    (acc, cert) => {
-      const courseTitle = cert.program.course.title;
-      let group = acc.find((g) => g.courseTitle === courseTitle);
-      if (!group) {
-        group = { courseTitle, certificates: [] };
-        acc.push(group);
-      }
-      group.certificates.push(cert);
-      return acc;
-    },
-    [] as GroupedByDiscipline[],
-  );
+  const grouped: GroupedByDiscipline[] = certificates.reduce((acc, cert) => {
+    const courseTitle = cert.program.course.title;
+    let group = acc.find((g) => g.courseTitle === courseTitle);
+    if (!group) {
+      group = { courseTitle, certificates: [] };
+      acc.push(group);
+    }
+    group.certificates.push(cert);
+    return acc;
+  }, [] as GroupedByDiscipline[]);
 
   return (
     <div className="mt-8">

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
@@ -1,0 +1,117 @@
+import dayjs from "~/lib/dayjs";
+import { listCertificatesForPersonAsAdmin } from "~/lib/nwd";
+
+type Certificate = Awaited<
+  ReturnType<typeof listCertificatesForPersonAsAdmin>
+>[number];
+
+interface GroupedByDiscipline {
+  courseTitle: string;
+  certificates: Certificate[];
+}
+
+export async function EigenvaardigheidOverview({
+  personId,
+}: {
+  personId: string;
+}) {
+  const certificates = await listCertificatesForPersonAsAdmin(personId);
+
+  if (certificates.length === 0) {
+    return (
+      <div className="mt-8">
+        <div className="mb-6">
+          <h3 className="text-lg leading-6 font-medium text-gray-900 dark:text-white">
+            Eigenvaardigheid
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Behaalde NWD-diploma&apos;s van deze persoon
+          </p>
+        </div>
+        <p className="text-sm text-gray-500 dark:text-gray-400 italic">
+          Geen NWD-diploma&apos;s gevonden.
+        </p>
+      </div>
+    );
+  }
+
+  const grouped: GroupedByDiscipline[] = certificates.reduce(
+    (acc, cert) => {
+      const courseTitle = cert.program.course.title;
+      let group = acc.find((g) => g.courseTitle === courseTitle);
+      if (!group) {
+        group = { courseTitle, certificates: [] };
+        acc.push(group);
+      }
+      group.certificates.push(cert);
+      return acc;
+    },
+    [] as GroupedByDiscipline[],
+  );
+
+  return (
+    <div className="mt-8">
+      <div className="mb-6">
+        <h3 className="text-lg leading-6 font-medium text-gray-900 dark:text-white">
+          Eigenvaardigheid
+        </h3>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Behaalde NWD-diploma&apos;s van deze persoon
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        {grouped.map((group) => (
+          <div
+            key={group.courseTitle}
+            className="bg-white dark:bg-gray-800 shadow overflow-hidden sm:rounded-lg"
+          >
+            <div className="px-4 py-5 sm:px-6">
+              <h4 className="text-base font-medium text-gray-900 dark:text-white capitalize">
+                {group.courseTitle}
+              </h4>
+            </div>
+            <div className="border-t border-gray-200 dark:border-gray-700">
+              <table className="min-w-full">
+                <thead className="bg-gray-50 dark:bg-gray-700">
+                  <tr>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Niveau
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Vaartuig
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Behaald op
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      Locatie
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                  {group.certificates.map((cert) => (
+                    <tr key={cert.id}>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                        {cert.program.degree.title}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                        {cert.gearType.title}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                        {dayjs(cert.issuedAt).format("DD-MM-YYYY")}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                        {cert.location.name}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
@@ -6,7 +6,7 @@ type Certificate = Awaited<
 >[number];
 
 interface GroupedByDiscipline {
-  courseTitle: string;
+  disciplineTitle: string;
   certificates: Certificate[];
 }
 
@@ -36,10 +36,10 @@ export async function EigenvaardigheidOverview({
   }
 
   const grouped: GroupedByDiscipline[] = certificates.reduce((acc, cert) => {
-    const courseTitle = cert.program.course.title;
-    let group = acc.find((g) => g.courseTitle === courseTitle);
+    const disciplineTitle = cert.program.course.discipline.title;
+    let group = acc.find((g) => g.disciplineTitle === disciplineTitle);
     if (!group) {
-      group = { courseTitle, certificates: [] };
+      group = { disciplineTitle, certificates: [] };
       acc.push(group);
     }
     group.certificates.push(cert);
@@ -60,12 +60,12 @@ export async function EigenvaardigheidOverview({
       <div className="space-y-4">
         {grouped.map((group) => (
           <div
-            key={group.courseTitle}
+            key={group.disciplineTitle}
             className="bg-white dark:bg-gray-800 shadow overflow-hidden sm:rounded-lg"
           >
             <div className="px-4 py-5 sm:px-6">
               <h4 className="text-base font-medium text-gray-900 dark:text-white capitalize">
-                {group.courseTitle}
+                {group.disciplineTitle}
               </h4>
             </div>
             <div className="border-t border-gray-200 dark:border-gray-700">

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
@@ -1,117 +1,35 @@
-import dayjs from "~/lib/dayjs";
+import {
+  getExistingNwdCCertificateKeys,
+  getNwdCPrograms,
+  listLocationsForNwdCRegistration,
+} from "~/app/_actions/eigenvaardigheid/manage-nwd-c";
 import { listCertificatesForPersonAsAdmin } from "~/lib/nwd";
-
-type Certificate = Awaited<
-  ReturnType<typeof listCertificatesForPersonAsAdmin>
->[number];
-
-interface GroupedByDiscipline {
-  disciplineTitle: string;
-  certificates: Certificate[];
-}
+import { EigenvaardigheidOverviewClient } from "./eigenvaardigheid-overview-client";
 
 export async function EigenvaardigheidOverview({
   personId,
 }: {
   personId: string;
 }) {
-  const allCertificates = await listCertificatesForPersonAsAdmin(personId);
+  const [allCertificates, programs, locations, existingNwdCKeys] =
+    await Promise.all([
+      listCertificatesForPersonAsAdmin(personId),
+      getNwdCPrograms(),
+      listLocationsForNwdCRegistration(),
+      getExistingNwdCCertificateKeys(personId),
+    ]);
+
   const certificates = allCertificates.filter(
     (cert) => cert.program.degree.rang >= 5,
   );
 
-  if (certificates.length === 0) {
-    return (
-      <div className="mt-8">
-        <div className="mb-6">
-          <h3 className="text-lg leading-6 font-medium text-gray-900 dark:text-white">
-            Eigenvaardigheid
-          </h3>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            Behaalde NWD-diploma&apos;s van deze persoon
-          </p>
-        </div>
-        <p className="text-sm text-gray-500 dark:text-gray-400 italic">
-          Geen NWD-diploma&apos;s gevonden.
-        </p>
-      </div>
-    );
-  }
-
-  const grouped: GroupedByDiscipline[] = certificates.reduce((acc, cert) => {
-    const disciplineTitle = cert.program.course.discipline.title ?? "Onbekend";
-    let group = acc.find((g) => g.disciplineTitle === disciplineTitle);
-    if (!group) {
-      group = { disciplineTitle, certificates: [] };
-      acc.push(group);
-    }
-    group.certificates.push(cert);
-    return acc;
-  }, [] as GroupedByDiscipline[]);
-
   return (
-    <div className="mt-8">
-      <div className="mb-6">
-        <h3 className="text-lg leading-6 font-medium text-gray-900 dark:text-white">
-          Eigenvaardigheid
-        </h3>
-        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-          Behaalde NWD-diploma&apos;s van deze persoon
-        </p>
-      </div>
-
-      <div className="space-y-4">
-        {grouped.map((group) => (
-          <div
-            key={group.disciplineTitle}
-            className="bg-white dark:bg-gray-800 shadow overflow-hidden sm:rounded-lg"
-          >
-            <div className="px-4 py-5 sm:px-6">
-              <h4 className="text-base font-medium text-gray-900 dark:text-white capitalize">
-                {group.disciplineTitle}
-              </h4>
-            </div>
-            <div className="border-t border-gray-200 dark:border-gray-700">
-              <table className="min-w-full">
-                <thead className="bg-gray-50 dark:bg-gray-700">
-                  <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                      Niveau
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                      Vaartuig
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                      Behaald op
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                      Locatie
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
-                  {group.certificates.map((cert) => (
-                    <tr key={cert.id}>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
-                        {cert.program.degree.title}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
-                        {cert.gearType.title}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
-                        {dayjs(cert.issuedAt).format("DD-MM-YYYY")}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
-                        {cert.location.name}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
+    <EigenvaardigheidOverviewClient
+      personId={personId}
+      certificates={certificates}
+      programs={programs}
+      locations={locations}
+      existingNwdCKeys={existingNwdCKeys}
+    />
   );
 }

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
@@ -36,7 +36,7 @@ export async function EigenvaardigheidOverview({
   }
 
   const grouped: GroupedByDiscipline[] = certificates.reduce((acc, cert) => {
-    const disciplineTitle = cert.program.course.discipline.title;
+    const disciplineTitle = cert.program.course.discipline.title ?? "Onbekend";
     let group = acc.find((g) => g.disciplineTitle === disciplineTitle);
     if (!group) {
       group = { disciplineTitle, certificates: [] };

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/eigenvaardigheid-overview.tsx
@@ -15,7 +15,10 @@ export async function EigenvaardigheidOverview({
 }: {
   personId: string;
 }) {
-  const certificates = await listCertificatesForPersonAsAdmin(personId);
+  const allCertificates = await listCertificatesForPersonAsAdmin(personId);
+  const certificates = allCertificates.filter(
+    (cert) => cert.program.degree.rang >= 5,
+  );
 
   if (certificates.length === 0) {
     return (

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/remove-nwd-c-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/_components/remove-nwd-c-dialog.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { Dialog, Transition } from "@headlessui/react";
+import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
+import { Fragment } from "react";
+import { toast } from "sonner";
+import { removeNwdCAction } from "~/app/_actions/eigenvaardigheid/manage-nwd-c";
+import { Button } from "~/app/(dashboard)/_components/button";
+import dayjs from "~/lib/dayjs";
+import type { listCertificatesForPersonAsAdmin } from "~/lib/nwd";
+
+type Certificate = Awaited<
+  ReturnType<typeof listCertificatesForPersonAsAdmin>
+>[number];
+
+export default function RemoveNwdCDialog({
+  isOpen,
+  onClose,
+  personId,
+  certificate,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  personId: string;
+  certificate: Certificate | null;
+}) {
+  const handleRemove = async () => {
+    if (!certificate) return;
+
+    try {
+      const result = await removeNwdCAction({
+        personId,
+        certificateId: certificate.id,
+      });
+
+      if (result?.data?.success) {
+        toast.success("NWD-C ingetrokken");
+        onClose();
+      } else {
+        toast.error("Intrekken mislukt");
+      }
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Intrekken mislukt",
+      );
+    }
+  };
+
+  return (
+    <Transition.Root show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 z-10 overflow-y-auto">
+          <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+              enterTo="opacity-100 translate-y-0 sm:scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 translate-y-0 sm:scale-100"
+              leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+            >
+              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+                <div className="sm:flex sm:items-start">
+                  <div className="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-red-100 dark:bg-red-900 sm:mx-0 sm:h-10 sm:w-10">
+                    <ExclamationTriangleIcon
+                      className="h-6 w-6 text-red-600 dark:text-red-400"
+                      aria-hidden="true"
+                    />
+                  </div>
+                  <div className="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
+                    <Dialog.Title
+                      as="h3"
+                      className="text-base font-semibold leading-6 text-gray-900 dark:text-white"
+                    >
+                      NWD-C intrekken
+                    </Dialog.Title>
+                    <div className="mt-2">
+                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                        Weet je zeker dat je deze NWD-C registratie wilt
+                        intrekken? Dit kan niet ongedaan worden gemaakt.
+                      </p>
+                      {certificate && (
+                        <div className="mt-3 bg-gray-50 dark:bg-gray-700 rounded-md p-3">
+                          <dl className="text-sm">
+                            <div className="mb-1">
+                              <dt className="inline font-medium text-gray-500 dark:text-gray-400">
+                                Discipline:{" "}
+                              </dt>
+                              <dd className="inline text-gray-900 dark:text-gray-100">
+                                {certificate.program.course.discipline.title}
+                              </dd>
+                            </div>
+                            <div className="mb-1">
+                              <dt className="inline font-medium text-gray-500 dark:text-gray-400">
+                                Vaartuig:{" "}
+                              </dt>
+                              <dd className="inline text-gray-900 dark:text-gray-100">
+                                {certificate.gearType.title}
+                              </dd>
+                            </div>
+                            <div>
+                              <dt className="inline font-medium text-gray-500 dark:text-gray-400">
+                                Datum:{" "}
+                              </dt>
+                              <dd className="inline text-gray-900 dark:text-gray-100">
+                                {dayjs(certificate.issuedAt).format("DD-MM-YYYY")}
+                              </dd>
+                            </div>
+                          </dl>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+                <div className="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
+                  <Button
+                    type="button"
+                    color="red"
+                    onClick={handleRemove}
+                    className="w-full sm:ml-3 sm:w-auto"
+                  >
+                    Intrekken
+                  </Button>
+                  <Button
+                    type="button"
+                    outline
+                    onClick={onClose}
+                    className="mt-3 w-full sm:mt-0 sm:w-auto"
+                  >
+                    Annuleren
+                  </Button>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/page.tsx
@@ -42,7 +42,13 @@ async function KwalificatiesContent({
   return (
     <>
       <PersonInfo person={person} />
-      <Suspense fallback={<div className="mt-8 text-sm text-gray-500">Eigenvaardigheid laden...</div>}>
+      <Suspense
+        fallback={
+          <div className="mt-8 text-sm text-gray-500">
+            Eigenvaardigheid laden...
+          </div>
+        }
+      >
         <EigenvaardigheidOverview personId={person.id} />
       </Suspense>
       <KwalificatiesTable

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/instructeur/[personId]/page.tsx
@@ -10,6 +10,7 @@ import { Heading } from "~/app/(dashboard)/_components/heading";
 import { Text } from "~/app/(dashboard)/_components/text";
 import { isSystemAdmin } from "~/lib/authorization";
 import { getUserOrThrow, listCourses } from "~/lib/nwd";
+import { EigenvaardigheidOverview } from "./_components/eigenvaardigheid-overview";
 import KwalificatiesTable from "./_components/kwalificaties-table";
 import { PersonInfo } from "./_components/person-info";
 
@@ -41,6 +42,9 @@ async function KwalificatiesContent({
   return (
     <>
       <PersonInfo person={person} />
+      <Suspense fallback={<div className="mt-8 text-sm text-gray-500">Eigenvaardigheid laden...</div>}>
+        <EigenvaardigheidOverview personId={person.id} />
+      </Suspense>
       <KwalificatiesTable
         personId={person.id}
         detailedKwalificaties={detailedKwalificaties}

--- a/apps/web/src/app/_actions/eigenvaardigheid/manage-nwd-c.ts
+++ b/apps/web/src/app/_actions/eigenvaardigheid/manage-nwd-c.ts
@@ -1,12 +1,6 @@
 "use server";
 
-import {
-  Certificate,
-  Course,
-  Curriculum,
-  Location,
-  withTransaction,
-} from "@nawadi/core";
+import { Certificate, Course, Curriculum, Location } from "@nawadi/core";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { isSystemAdmin } from "~/lib/authorization";
@@ -65,8 +59,9 @@ export const removeNwdCAction = actionClientWithMeta
       throw new Error("Geen toegang tot deze functie");
     }
 
-    await withTransaction(async () => {
-      await Certificate.withdrawByAdmin(input.certificateId);
+    await Certificate.withdrawNwdC({
+      certificateId: input.certificateId,
+      personId: input.personId,
     });
 
     revalidatePath(`/secretariaat/instructeur/${input.personId}`);
@@ -81,7 +76,9 @@ export async function getNwdCPrograms() {
     throw new Error("Geen toegang tot deze functie");
   }
 
-  const degree = await Course.Degree.fromHandle(Certificate.NWD_C_DEGREE_HANDLE);
+  const degree = await Course.Degree.fromHandle(
+    Certificate.NWD_C_DEGREE_HANDLE,
+  );
   if (!degree) {
     return [];
   }
@@ -155,9 +152,7 @@ export async function listLocationsForNwdCRegistration() {
       handle: location.handle,
       name: location.name,
     }))
-    .toSorted((a, b) =>
-      (a.name ?? a.handle).localeCompare(b.name ?? b.handle),
-    );
+    .toSorted((a, b) => (a.name ?? a.handle).localeCompare(b.name ?? b.handle));
 }
 
 export async function getExistingNwdCCertificateKeys(personId: string) {
@@ -174,7 +169,8 @@ export async function getExistingNwdCCertificateKeys(personId: string) {
   return certificates.items
     .filter(
       (certificate) =>
-        certificate.program.degree.handle === Certificate.NWD_C_DEGREE_HANDLE,
+        certificate.program.degree.handle === Certificate.NWD_C_DEGREE_HANDLE &&
+        Boolean(certificate.issuedAt),
     )
     .map((certificate) => ({
       curriculumId: certificate.curriculum.id,

--- a/apps/web/src/app/_actions/eigenvaardigheid/manage-nwd-c.ts
+++ b/apps/web/src/app/_actions/eigenvaardigheid/manage-nwd-c.ts
@@ -1,0 +1,183 @@
+"use server";
+
+import {
+  Certificate,
+  Course,
+  Curriculum,
+  Location,
+  withTransaction,
+} from "@nawadi/core";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { isSystemAdmin } from "~/lib/authorization";
+import { getUserOrThrow } from "~/lib/nwd";
+import { actionClientWithMeta } from "../safe-action";
+
+const registerNwdCSchema = z.object({
+  personId: z.string().uuid(),
+  curriculumId: z.string().uuid(),
+  gearTypeId: z.string().uuid(),
+  locationId: z.string().uuid(),
+  issuedAt: z.string().datetime(),
+  opmerkingen: z.string().optional(),
+});
+
+export const registerNwdCAction = actionClientWithMeta
+  .metadata({ name: "eigenvaardigheid.register-nwd-c" })
+  .inputSchema(registerNwdCSchema)
+  .action(async ({ parsedInput: input }) => {
+    const user = await getUserOrThrow();
+
+    if (!isSystemAdmin(user.email)) {
+      throw new Error("Geen toegang tot deze functie");
+    }
+
+    const actor = user.persons[0]?.actors.find((a) => a.type === "system");
+
+    const result = await Certificate.registerNwdC({
+      personId: input.personId,
+      curriculumId: input.curriculumId,
+      gearTypeId: input.gearTypeId,
+      locationId: input.locationId,
+      issuedAt: input.issuedAt,
+      visibleFrom: input.issuedAt,
+      opmerkingen: input.opmerkingen,
+      toegevoegdDoor: actor?.id,
+    });
+
+    revalidatePath(`/secretariaat/instructeur/${input.personId}`);
+
+    return { success: true, certificateId: result.id };
+  });
+
+const removeNwdCSchema = z.object({
+  personId: z.string().uuid(),
+  certificateId: z.string().uuid(),
+});
+
+export const removeNwdCAction = actionClientWithMeta
+  .metadata({ name: "eigenvaardigheid.remove-nwd-c" })
+  .inputSchema(removeNwdCSchema)
+  .action(async ({ parsedInput: input }) => {
+    const user = await getUserOrThrow();
+
+    if (!isSystemAdmin(user.email)) {
+      throw new Error("Geen toegang tot deze functie");
+    }
+
+    await withTransaction(async () => {
+      await Certificate.withdrawByAdmin(input.certificateId);
+    });
+
+    revalidatePath(`/secretariaat/instructeur/${input.personId}`);
+
+    return { success: true };
+  });
+
+export async function getNwdCPrograms() {
+  const user = await getUserOrThrow();
+
+  if (!isSystemAdmin(user.email)) {
+    throw new Error("Geen toegang tot deze functie");
+  }
+
+  const degree = await Course.Degree.fromHandle(Certificate.NWD_C_DEGREE_HANDLE);
+  if (!degree) {
+    return [];
+  }
+
+  const programs = await Course.Program.list({});
+  const nwdCPrograms = programs.filter(
+    (program) => program.degree.id === degree.id,
+  );
+
+  const programsWithCurriculum = await Promise.all(
+    nwdCPrograms.map(async (program) => {
+      const curricula = await Curriculum.list({
+        filter: { programId: program.id, onlyCurrentActive: true },
+      });
+
+      return {
+        id: program.id,
+        handle: program.handle,
+        title: program.title,
+        course: {
+          id: program.course.id,
+          handle: program.course.handle,
+          title: program.course.title,
+          discipline: program.course.discipline,
+        },
+        curriculum: curricula[0]
+          ? {
+              id: curricula[0].id,
+              revision: curricula[0].revision,
+            }
+          : null,
+      };
+    }),
+  );
+
+  return programsWithCurriculum
+    .filter((program) => program.curriculum)
+    .toSorted((a, b) =>
+      (a.course.discipline.title ?? a.course.handle).localeCompare(
+        b.course.discipline.title ?? b.course.handle,
+      ),
+    );
+}
+
+export async function getGearTypesForNwdCCurriculum(curriculumId: string) {
+  const user = await getUserOrThrow();
+
+  if (!isSystemAdmin(user.email)) {
+    throw new Error("Geen toegang tot deze functie");
+  }
+
+  return Curriculum.GearType.list({
+    filter: { curriculumId },
+  });
+}
+
+export async function listLocationsForNwdCRegistration() {
+  const user = await getUserOrThrow();
+
+  if (!isSystemAdmin(user.email)) {
+    throw new Error("Geen toegang tot deze functie");
+  }
+
+  const locations = await Location.list({
+    filters: { status: ["active"] },
+  });
+
+  return locations
+    .map((location) => ({
+      id: location.id,
+      handle: location.handle,
+      name: location.name,
+    }))
+    .toSorted((a, b) =>
+      (a.name ?? a.handle).localeCompare(b.name ?? b.handle),
+    );
+}
+
+export async function getExistingNwdCCertificateKeys(personId: string) {
+  const user = await getUserOrThrow();
+
+  if (!isSystemAdmin(user.email)) {
+    throw new Error("Geen toegang tot deze functie");
+  }
+
+  const certificates = await Certificate.list({
+    filter: { personId },
+  });
+
+  return certificates.items
+    .filter(
+      (certificate) =>
+        certificate.program.degree.handle === Certificate.NWD_C_DEGREE_HANDLE,
+    )
+    .map((certificate) => ({
+      curriculumId: certificate.curriculum.id,
+      gearTypeId: certificate.gearType.id,
+    }));
+}

--- a/apps/web/src/lib/generate-certificate-pdf.ts
+++ b/apps/web/src/lib/generate-certificate-pdf.ts
@@ -376,7 +376,7 @@ export async function generatePDF(
     doc.font("medium", 10);
     doc.strokeColor([0, 71, 171]);
 
-    if (isNwdC && modules.length === 0) {
+    if (isNwdC) {
       const nwdCLabel = "NWD-C eigenvaardigheid";
       const moduleOptions = {
         width: width * 2 + gapX,
@@ -404,39 +404,39 @@ export async function generatePDF(
         .stroke();
     } else {
       modules.forEach((module, index) => {
-      const options = {
-        width,
-        align: "left",
-      } as const;
+        const options = {
+          width,
+          align: "left",
+        } as const;
 
-      const textHeight = doc.heightOfString(module.title ?? "", options);
+        const textHeight = doc.heightOfString(module.title ?? "", options);
 
-      doc.text(
-        module.title ?? "",
-        x,
-        y + Math.max(height - textHeight, 0),
-        options,
-      );
+        doc.text(
+          module.title ?? "",
+          x,
+          y + Math.max(height - textHeight, 0),
+          options,
+        );
 
-      doc
-        .moveTo(x, y + height + 1.928)
-        .lineWidth(1)
-        .lineTo(x + width, y + height + 1.928)
-        .stroke();
+        doc
+          .moveTo(x, y + height + 1.928)
+          .lineWidth(1)
+          .lineTo(x + width, y + height + 1.928)
+          .stroke();
 
-      doc
-        .moveTo(x, y + height + 1.928 + 3)
-        .lineWidth(1)
-        .lineTo(x + width, y + height + 1.928 + 3)
-        .stroke();
+        doc
+          .moveTo(x, y + height + 1.928 + 3)
+          .lineWidth(1)
+          .lineTo(x + width, y + height + 1.928 + 3)
+          .stroke();
 
-      if ((index + 1) % 2 === 0) {
-        x = x - gapX - width;
-        y = y + gapY + height;
-      } else {
-        x = x + gapX + width;
-      }
-    });
+        if ((index + 1) % 2 === 0) {
+          x = x - gapX - width;
+          y = y + gapY + height;
+        } else {
+          x = x + gapX + width;
+        }
+      });
     }
 
     // Add page if needed

--- a/apps/web/src/lib/generate-certificate-pdf.ts
+++ b/apps/web/src/lib/generate-certificate-pdf.ts
@@ -159,6 +159,8 @@ export async function generatePDF(
       uniqueCompletedModules.includes(module.id),
     );
 
+    const isNwdC = certificate.program.degree.handle === "niveau-c";
+
     const studentFullName = [
       certificate.student.firstName,
       certificate.student.lastNamePrefix,
@@ -374,7 +376,34 @@ export async function generatePDF(
     doc.font("medium", 10);
     doc.strokeColor([0, 71, 171]);
 
-    modules.forEach((module, index) => {
+    if (isNwdC && modules.length === 0) {
+      const nwdCLabel = "NWD-C eigenvaardigheid";
+      const moduleOptions = {
+        width: width * 2 + gapX,
+        align: "left",
+      } as const;
+      const textHeight = doc.heightOfString(nwdCLabel, moduleOptions);
+
+      doc.text(
+        nwdCLabel,
+        x,
+        y + Math.max(height - textHeight, 0),
+        moduleOptions,
+      );
+
+      doc
+        .moveTo(x, y + height + 1.928)
+        .lineWidth(1)
+        .lineTo(x + width * 2 + gapX, y + height + 1.928)
+        .stroke();
+
+      doc
+        .moveTo(x, y + height + 1.928 + 3)
+        .lineWidth(1)
+        .lineTo(x + width * 2 + gapX, y + height + 1.928 + 3)
+        .stroke();
+    } else {
+      modules.forEach((module, index) => {
       const options = {
         width,
         align: "left",
@@ -408,6 +437,7 @@ export async function generatePDF(
         x = x + gapX + width;
       }
     });
+    }
 
     // Add page if needed
     if (data.indexOf(certificate) < data.length - 1) {

--- a/apps/web/src/lib/nwd.ts
+++ b/apps/web/src/lib/nwd.ts
@@ -920,7 +920,10 @@ export const listProgramsForLocation = async (locationId: string) => {
       filter: { locationId },
     });
 
-    return programs;
+    // NWD-C is secretariaat-only; locations must not start or issue it.
+    return programs.filter(
+      (program) => program.degree.handle !== Certificate.NWD_C_DEGREE_HANDLE,
+    );
   });
 };
 
@@ -1420,6 +1423,33 @@ export const createPersonForLocation = async (
   });
 };
 
+async function assertCurriculumIsNotNwdC(
+  curriculumId: string,
+  context: "cohort" | "location",
+) {
+  const [curriculum] = await Curriculum.list({
+    filter: { id: curriculumId, onlyCurrentActive: true },
+  });
+
+  if (!curriculum) {
+    throw new Error("Curriculum niet gevonden of niet actief");
+  }
+
+  const program = await Course.Program.fromId(curriculum.programId);
+
+  if (!program) {
+    throw new Error("Programma niet gevonden");
+  }
+
+  if (program.degree.handle === Certificate.NWD_C_DEGREE_HANDLE) {
+    throw new Error(
+      context === "cohort"
+        ? "NWD-C programma's kunnen niet via een cohort worden gestart"
+        : "NWD-C programma's kunnen alleen via het secretariaat worden geregistreerd",
+    );
+  }
+}
+
 export const createCompletedCertificate = async (
   locationId: string,
   personId: string,
@@ -1443,6 +1473,8 @@ export const createCompletedCertificate = async (
         locationId,
         personId: primaryPerson.id,
       });
+
+      await assertCurriculumIsNotNwdC(curriculumId, "location");
 
       // Start student curriculum
       const { id: studentCurriculumId } = await Student.Curriculum.start({
@@ -2742,6 +2774,8 @@ export const enrollStudentsInCurriculumForCohort = async ({
       // if (!availableLocations.some((l) => l.locationId === locationId)) {
       //   throw new Error("Location not found for person");
       // }
+
+      await assertCurriculumIsNotNwdC(curriculumId, "cohort");
 
       for await (const student of students) {
         const studentCurriculum = await Student.Curriculum.findOrEnroll({

--- a/apps/web/src/lib/nwd.ts
+++ b/apps/web/src/lib/nwd.ts
@@ -498,6 +498,25 @@ export const listCertificatesForPerson = cache(
   },
 );
 
+export const listCertificatesForPersonAsAdmin = cache(
+  async (personId: string) => {
+    return makeRequest(async () => {
+      const requestingUser = await getUserOrThrow();
+      const { isSystemAdmin } = await import("~/lib/authorization");
+
+      if (!isSystemAdmin(requestingUser.email)) {
+        throw new Error("Unauthorized");
+      }
+
+      const certificates = await Certificate.list({
+        filter: { personId },
+      });
+
+      return certificates.items;
+    });
+  },
+);
+
 export const listExternalCertificatesForPerson = cache(
   async (personId: string, locationId?: string) => {
     return makeRequest(async () => {

--- a/packages/core/src/models/certificate/certificate.ts
+++ b/packages/core/src/models/certificate/certificate.ts
@@ -509,6 +509,49 @@ export const withdraw = wrapCommand(
   }),
 );
 
+export const withdrawByAdmin = wrapCommand(
+  "certificate.withdrawByAdmin",
+  withZod(uuidSchema, async (input) => {
+    return withTransaction(async (tx) => {
+      const certificate = await tx
+        .select()
+        .from(s.certificate)
+        .where(
+          and(eq(s.certificate.id, input), isNull(s.certificate.deletedAt)),
+        )
+        .then(singleRow);
+
+      const withdrawnAt = new Date().toISOString();
+
+      await Promise.all([
+        tx
+          .update(s.certificate)
+          .set({ deletedAt: withdrawnAt })
+          .where(
+            and(
+              eq(s.certificate.id, certificate.id),
+              isNull(s.certificate.deletedAt),
+            ),
+          ),
+        tx
+          .update(s.studentCurriculum)
+          .set({ deletedAt: withdrawnAt })
+          .where(
+            and(
+              eq(s.studentCurriculum.id, certificate.studentCurriculumId),
+              isNull(s.studentCurriculum.deletedAt),
+            ),
+          ),
+        tx
+          .delete(s.studentCompletedCompetency)
+          .where(
+            eq(s.studentCompletedCompetency.certificateId, certificate.id),
+          ),
+      ]);
+    });
+  }),
+);
+
 export const storeHandles = wrapCommand(
   "certificate.storeHandles",
   withZod(

--- a/packages/core/src/models/certificate/certificate.ts
+++ b/packages/core/src/models/certificate/certificate.ts
@@ -14,6 +14,7 @@ import {
   isNull,
   lt,
   lte,
+  ne,
   type SQL,
   sql,
 } from "drizzle-orm";
@@ -523,7 +524,22 @@ export const withdrawByAdmin = wrapCommand(
 
       const withdrawnAt = new Date().toISOString();
 
-      await Promise.all([
+      const otherActiveCertificates = await tx
+        .select({ id: s.certificate.id })
+        .from(s.certificate)
+        .where(
+          and(
+            eq(
+              s.certificate.studentCurriculumId,
+              certificate.studentCurriculumId,
+            ),
+            ne(s.certificate.id, certificate.id),
+            isNull(s.certificate.deletedAt),
+          ),
+        )
+        .limit(1);
+
+      const updates: Promise<unknown>[] = [
         tx
           .update(s.certificate)
           .set({ deletedAt: withdrawnAt })
@@ -534,20 +550,27 @@ export const withdrawByAdmin = wrapCommand(
             ),
           ),
         tx
-          .update(s.studentCurriculum)
-          .set({ deletedAt: withdrawnAt })
-          .where(
-            and(
-              eq(s.studentCurriculum.id, certificate.studentCurriculumId),
-              isNull(s.studentCurriculum.deletedAt),
-            ),
-          ),
-        tx
           .delete(s.studentCompletedCompetency)
           .where(
             eq(s.studentCompletedCompetency.certificateId, certificate.id),
           ),
-      ]);
+      ];
+
+      if (otherActiveCertificates.length === 0) {
+        updates.push(
+          tx
+            .update(s.studentCurriculum)
+            .set({ deletedAt: withdrawnAt })
+            .where(
+              and(
+                eq(s.studentCurriculum.id, certificate.studentCurriculumId),
+                isNull(s.studentCurriculum.deletedAt),
+              ),
+            ),
+        );
+      }
+
+      await Promise.all(updates);
     });
   }),
 );

--- a/packages/core/src/models/certificate/index.ts
+++ b/packages/core/src/models/certificate/index.ts
@@ -1,2 +1,3 @@
 export * from "./certificate.js";
+export * from "./register-nwd-c.js";
 export * as External from "./external.js";

--- a/packages/core/src/models/certificate/register-nwd-c.ts
+++ b/packages/core/src/models/certificate/register-nwd-c.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { withTransaction } from "../../contexts/index.js";
 import {
   dateTimeSchema,
+  possibleSingleRow,
   successfulCreateResponse,
   uuidSchema,
   withZod,
@@ -125,6 +126,87 @@ export const registerNwdC = wrapCommand(
         });
 
         return { id: certificateId };
+      });
+    },
+  ),
+);
+
+export const withdrawNwdC = wrapCommand(
+  "certificate.withdrawNwdC",
+  withZod(
+    z.object({
+      certificateId: uuidSchema,
+      personId: uuidSchema,
+    }),
+    async (input) => {
+      return withTransaction(async (tx) => {
+        const certificate = await tx
+          .select({
+            id: s.certificate.id,
+            studentCurriculumId: s.certificate.studentCurriculumId,
+            personId: s.studentCurriculum.personId,
+            degreeHandle: s.degree.handle,
+          })
+          .from(s.certificate)
+          .innerJoin(
+            s.studentCurriculum,
+            eq(s.studentCurriculum.id, s.certificate.studentCurriculumId),
+          )
+          .innerJoin(
+            s.curriculum,
+            eq(s.curriculum.id, s.studentCurriculum.curriculumId),
+          )
+          .innerJoin(s.program, eq(s.program.id, s.curriculum.programId))
+          .innerJoin(s.degree, eq(s.degree.id, s.program.degreeId))
+          .where(
+            and(
+              eq(s.certificate.id, input.certificateId),
+              isNull(s.certificate.deletedAt),
+            ),
+          )
+          .then(possibleSingleRow);
+
+        if (!certificate) {
+          throw new Error("Certificaat niet gevonden");
+        }
+
+        if (certificate.personId !== input.personId) {
+          throw new Error("Certificaat hoort niet bij deze persoon");
+        }
+
+        if (certificate.degreeHandle !== NWD_C_DEGREE_HANDLE) {
+          throw new Error(
+            "Alleen NWD-C certificaten kunnen via het secretariaat worden ingetrokken",
+          );
+        }
+
+        const withdrawnAt = new Date().toISOString();
+
+        await Promise.all([
+          tx
+            .update(s.certificate)
+            .set({ deletedAt: withdrawnAt })
+            .where(
+              and(
+                eq(s.certificate.id, certificate.id),
+                isNull(s.certificate.deletedAt),
+              ),
+            ),
+          tx
+            .update(s.studentCurriculum)
+            .set({ deletedAt: withdrawnAt })
+            .where(
+              and(
+                eq(s.studentCurriculum.id, certificate.studentCurriculumId),
+                isNull(s.studentCurriculum.deletedAt),
+              ),
+            ),
+          tx
+            .delete(s.studentCompletedCompetency)
+            .where(
+              eq(s.studentCompletedCompetency.certificateId, certificate.id),
+            ),
+        ]);
       });
     },
   ),

--- a/packages/core/src/models/certificate/register-nwd-c.ts
+++ b/packages/core/src/models/certificate/register-nwd-c.ts
@@ -1,0 +1,131 @@
+import { schema as s } from "@nawadi/db";
+import { and, eq, isNotNull, isNull } from "drizzle-orm";
+import { z } from "zod";
+import { withTransaction } from "../../contexts/index.js";
+import {
+  dateTimeSchema,
+  successfulCreateResponse,
+  uuidSchema,
+  withZod,
+  wrapCommand,
+} from "../../utils/index.js";
+import { Curriculum, Course, Student } from "../index.js";
+
+export const NWD_C_DEGREE_HANDLE = "niveau-c";
+
+export const registerNwdC = wrapCommand(
+  "certificate.registerNwdC",
+  withZod(
+    z.object({
+      personId: uuidSchema,
+      curriculumId: uuidSchema,
+      gearTypeId: uuidSchema,
+      locationId: uuidSchema,
+      issuedAt: dateTimeSchema,
+      visibleFrom: dateTimeSchema.optional(),
+      opmerkingen: z.string().optional(),
+      toegevoegdDoor: uuidSchema.optional(),
+    }),
+    successfulCreateResponse,
+    async (input) => {
+      return withTransaction(async (tx) => {
+        const curricula = await Curriculum.list({
+          filter: { id: input.curriculumId, onlyCurrentActive: true },
+        });
+
+        const curriculum = curricula[0];
+        if (!curriculum) {
+          throw new Error("Curriculum niet gevonden of niet actief");
+        }
+
+        const program = await Course.Program.fromId(curriculum.programId);
+        if (!program || program.degree.handle !== NWD_C_DEGREE_HANDLE) {
+          throw new Error(
+            "Alleen NWD-C programma's kunnen via het secretariaat worden geregistreerd",
+          );
+        }
+
+        const gearTypes = await Curriculum.GearType.list({
+          filter: { curriculumId: input.curriculumId },
+        });
+
+        if (!gearTypes.some((gearType) => gearType.id === input.gearTypeId)) {
+          throw new Error("Vaartuig hoort niet bij dit curriculum");
+        }
+
+        const existingCertificates = await tx
+          .select({ id: s.certificate.id })
+          .from(s.certificate)
+          .innerJoin(
+            s.studentCurriculum,
+            eq(s.studentCurriculum.id, s.certificate.studentCurriculumId),
+          )
+          .where(
+            and(
+              eq(s.studentCurriculum.personId, input.personId),
+              eq(s.studentCurriculum.curriculumId, input.curriculumId),
+              eq(s.studentCurriculum.gearTypeId, input.gearTypeId),
+              isNull(s.certificate.deletedAt),
+              isNotNull(s.certificate.issuedAt),
+            ),
+          );
+
+        if (existingCertificates.length > 0) {
+          throw new Error(
+            "Deze persoon heeft al een actief NWD-C certificaat voor dit vaartuig in deze discipline",
+          );
+        }
+
+        const orphanedStudentCurriculum = await tx
+          .select({ id: s.studentCurriculum.id })
+          .from(s.studentCurriculum)
+          .where(
+            and(
+              eq(s.studentCurriculum.personId, input.personId),
+              eq(s.studentCurriculum.curriculumId, input.curriculumId),
+              eq(s.studentCurriculum.gearTypeId, input.gearTypeId),
+              isNull(s.studentCurriculum.deletedAt),
+            ),
+          );
+
+        if (orphanedStudentCurriculum.length > 0) {
+          const cleanedUpAt = new Date().toISOString();
+          await tx
+            .update(s.studentCurriculum)
+            .set({ deletedAt: cleanedUpAt })
+            .where(
+              and(
+                eq(s.studentCurriculum.personId, input.personId),
+                eq(s.studentCurriculum.curriculumId, input.curriculumId),
+                eq(s.studentCurriculum.gearTypeId, input.gearTypeId),
+                isNull(s.studentCurriculum.deletedAt),
+              ),
+            );
+        }
+
+        const { id: studentCurriculumId } = await Student.Curriculum.start({
+          personId: input.personId,
+          curriculumId: input.curriculumId,
+          gearTypeId: input.gearTypeId,
+          startedAt: input.issuedAt,
+        });
+
+        const { id: certificateId } =
+          await Student.Certificate.startCertificate({
+            locationId: input.locationId,
+            studentCurriculumId,
+          });
+
+        await Student.Certificate.completeCertificate({
+          certificateId,
+          issuedAt: input.issuedAt,
+          visibleFrom: input.visibleFrom ?? input.issuedAt,
+          opmerkingen: input.opmerkingen,
+          toegevoegdDoor: input.toegevoegdDoor,
+        });
+
+        return { id: certificateId };
+      });
+    },
+  ),
+);

--- a/packages/core/src/models/student/certificate.ts
+++ b/packages/core/src/models/student/certificate.ts
@@ -149,9 +149,12 @@ export const completeCertificate = wrapCommand(
     insertSchema
       .pick({
         visibleFrom: true,
+        opmerkingen: true,
+        toegevoegdDoor: true,
       })
       .extend({
         certificateId: uuidSchema,
+        issuedAt: z.string().datetime().optional(),
       }),
     z.void(),
     async (input) => {
@@ -160,8 +163,10 @@ export const completeCertificate = wrapCommand(
       const [res] = await query
         .update(s.certificate)
         .set({
-          issuedAt: new Date().toISOString(),
+          issuedAt: input.issuedAt ?? new Date().toISOString(),
           visibleFrom: input.visibleFrom,
+          opmerkingen: input.opmerkingen,
+          toegevoegdDoor: input.toegevoegdDoor,
         })
         .where(eq(s.certificate.id, input.certificateId))
         .returning({ id: s.certificate.id });

--- a/packages/db/migrations/0040_certificate_nwd_c_audit.sql
+++ b/packages/db/migrations/0040_certificate_nwd_c_audit.sql
@@ -1,3 +1,3 @@
 ALTER TABLE "certificate" ADD COLUMN "opmerkingen" text;--> statement-breakpoint
 ALTER TABLE "certificate" ADD COLUMN "toegevoegd_door" uuid;--> statement-breakpoint
-ALTER TABLE "certificate" ADD CONSTRAINT "certificate_toegevoegd_door_fk" FOREIGN KEY ("toegevoegd_door") REFERENCES "public"."actor"("id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "certificate" ADD CONSTRAINT "certificate_toegevoegd_door_fk" FOREIGN KEY ("toegevoegd_door") REFERENCES "public"."actor"("id") ON DELETE SET NULL ON UPDATE no action;

--- a/packages/db/migrations/0040_certificate_nwd_c_audit.sql
+++ b/packages/db/migrations/0040_certificate_nwd_c_audit.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "certificate" ADD COLUMN "opmerkingen" text;--> statement-breakpoint
+ALTER TABLE "certificate" ADD COLUMN "toegevoegd_door" uuid;--> statement-breakpoint
+ALTER TABLE "certificate" ADD CONSTRAINT "certificate_toegevoegd_door_fk" FOREIGN KEY ("toegevoegd_door") REFERENCES "public"."actor"("id") ON DELETE no action ON UPDATE no action;

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1780083278742,
       "tag": "0039_cuddly_alex_power",
       "breakpoints": false
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1780083278743,
+      "tag": "0040_certificate_nwd_c_audit",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/certificate.ts
+++ b/packages/db/src/schema/certificate.ts
@@ -134,7 +134,7 @@ export const certificate = pgTable(
       columns: [table.toegevoegdDoor],
       foreignColumns: [actor.id],
       name: "certificate_toegevoegd_door_fk",
-    }),
+    }).onDelete("set null"),
   ],
 );
 

--- a/packages/db/src/schema/certificate.ts
+++ b/packages/db/src/schema/certificate.ts
@@ -22,7 +22,7 @@ import {
 } from "./curriculum.js";
 import { location } from "./location.js";
 import { media } from "./media.js";
-import { person } from "./user.js";
+import { actor, person } from "./user.js";
 
 export const studentCurriculum = pgTable(
   "student_curriculum",
@@ -97,6 +97,8 @@ export const certificate = pgTable(
       withTimezone: true,
       mode: "string",
     }),
+    opmerkingen: text("opmerkingen"),
+    toegevoegdDoor: uuid("toegevoegd_door"),
     ...timestamps,
   },
   (table) => [
@@ -127,6 +129,11 @@ export const certificate = pgTable(
       columns: [table.cohortAllocationId],
       foreignColumns: [cohortAllocation.id],
       name: "certificate_cohort_allocation_id_fk",
+    }),
+    foreignKey({
+      columns: [table.toegevoegdDoor],
+      foreignColumns: [actor.id],
+      name: "certificate_toegevoegd_door_fk",
     }),
   ],
 );

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -13,7 +13,8 @@
     "test": "node --test ./out/**/*.test.js",
     "persons:duplicates:analyze": "tsx src/analyze-duplicate-persons.ts",
     "persons:duplicates:merge": "tsx src/batch-merge-duplicates.ts",
-    "dev:seed-bulk-import": "tsx src/seed-bulk-import-fixtures.ts"
+    "dev:seed-bulk-import": "tsx src/seed-bulk-import-fixtures.ts",
+    "curriculum:instructeur-c": "tsx src/seed/curriculum/instructeur-c-programs.ts"
   },
   "dependencies": {
     "@nawadi/core": "workspace:^",

--- a/packages/scripts/src/seed/curriculum/instructeur-c-programs.ts
+++ b/packages/scripts/src/seed/curriculum/instructeur-c-programs.ts
@@ -1,0 +1,140 @@
+import {
+  Course,
+  Curriculum,
+  withDatabase,
+  withTransaction,
+} from "@nawadi/core";
+import "dotenv/config";
+
+const NWD_C_DEGREE_HANDLE = "niveau-c";
+const VOLWASSENEN_CATEGORY_HANDLE = "volwassenen";
+
+const TARGET_DISCIPLINE_HANDLES = [
+  "zwaardboot-1-mans",
+  "zwaardboot-2-mans",
+  "kielboot",
+  "catamaran",
+  "windsurfen",
+  "jachtzeilen",
+] as const;
+
+async function main() {
+  const pgUri =
+    process.env.PGURI ??
+    "postgresql://postgres:postgres@127.0.0.1:54322/postgres";
+
+  await withDatabase(pgUri, async () => {
+    await withTransaction(async () => {
+      let degree = await Course.Degree.fromHandle(NWD_C_DEGREE_HANDLE);
+
+      if (!degree) {
+        const created = await Course.Degree.create({
+          handle: NWD_C_DEGREE_HANDLE,
+          title: "C",
+          rang: 7,
+        });
+        degree = (await Course.Degree.fromHandle(NWD_C_DEGREE_HANDLE))!;
+        console.log(`Created degree C (${created.id})`);
+      } else {
+        console.log(`Degree C already exists (${degree.id})`);
+      }
+
+      const [courses, programs] = await Promise.all([
+        Course.list({}),
+        Course.Program.list({}),
+      ]);
+
+      const volwassenenCourses = courses.filter(
+        (course) =>
+          TARGET_DISCIPLINE_HANDLES.includes(
+            course.discipline.handle as (typeof TARGET_DISCIPLINE_HANDLES)[number],
+          ) &&
+          course.categories.some(
+            (category) => category.handle === VOLWASSENEN_CATEGORY_HANDLE,
+          ),
+      );
+
+      console.log(`Found ${volwassenenCourses.length} volwassenen courses`);
+
+      for (const course of volwassenenCourses) {
+        const programHandle = `${course.handle}-c`;
+        const existingProgram = programs.find(
+          (program) => program.handle === programHandle,
+        );
+
+        if (existingProgram) {
+          console.log(`Program ${programHandle} already exists, skipping`);
+          continue;
+        }
+
+        const referencePrograms = programs
+          .filter((program) => program.course.id === course.id)
+          .toSorted((a, b) => b.degree.rang - a.degree.rang);
+
+        const referenceProgram = referencePrograms[0];
+        if (!referenceProgram) {
+          console.warn(
+            `No reference program for ${course.handle}, skipping C program`,
+          );
+          continue;
+        }
+
+        const referenceCurricula = await Curriculum.list({
+          filter: {
+            programId: referenceProgram.id,
+            onlyCurrentActive: true,
+          },
+        });
+        const referenceCurriculum = referenceCurricula[0];
+
+        if (!referenceCurriculum) {
+          console.warn(
+            `No active curriculum for reference program ${referenceProgram.handle}, skipping`,
+          );
+          continue;
+        }
+
+        const referenceGearTypes = await Curriculum.GearType.list({
+          filter: { curriculumId: referenceCurriculum.id },
+        });
+
+        if (referenceGearTypes.length === 0) {
+          console.warn(
+            `No gear types on reference curriculum ${referenceCurriculum.id}, skipping`,
+          );
+          continue;
+        }
+
+        const { id: programId } = await Course.Program.create({
+          handle: programHandle,
+          title: `${course.title ?? course.handle} C`,
+          courseId: course.id,
+          degreeId: degree.id,
+        });
+
+        const { id: curriculumId } = await Curriculum.create({
+          programId,
+          revision: "1",
+        });
+
+        for (const gearType of referenceGearTypes) {
+          await Curriculum.GearType.linkToCurriculum({
+            curriculumId,
+            gearTypeId: gearType.id,
+          });
+        }
+
+        await Curriculum.start({ curriculumId });
+
+        console.log(
+          `Created C program ${programHandle} with ${referenceGearTypes.length} gear type(s)`,
+        );
+      }
+    });
+  });
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/scripts/src/seed/curriculum/instructeur-c-programs.ts
+++ b/packages/scripts/src/seed/curriculum/instructeur-c-programs.ts
@@ -1,4 +1,5 @@
 import {
+  Certificate,
   Course,
   Curriculum,
   withDatabase,
@@ -6,7 +7,6 @@ import {
 } from "@nawadi/core";
 import "dotenv/config";
 
-const NWD_C_DEGREE_HANDLE = "niveau-c";
 const VOLWASSENEN_CATEGORY_HANDLE = "volwassenen";
 
 const TARGET_DISCIPLINE_HANDLES = [
@@ -25,18 +25,23 @@ async function main() {
 
   await withDatabase(pgUri, async () => {
     await withTransaction(async () => {
-      let degree = await Course.Degree.fromHandle(NWD_C_DEGREE_HANDLE);
+      let degreeId: string;
 
-      if (!degree) {
+      const existingDegree = await Course.Degree.fromHandle(
+        Certificate.NWD_C_DEGREE_HANDLE,
+      );
+
+      if (existingDegree) {
+        degreeId = existingDegree.id;
+        console.log(`Degree C already exists (${degreeId})`);
+      } else {
         const created = await Course.Degree.create({
-          handle: NWD_C_DEGREE_HANDLE,
+          handle: Certificate.NWD_C_DEGREE_HANDLE,
           title: "C",
           rang: 7,
         });
-        degree = (await Course.Degree.fromHandle(NWD_C_DEGREE_HANDLE))!;
-        console.log(`Created degree C (${created.id})`);
-      } else {
-        console.log(`Degree C already exists (${degree.id})`);
+        degreeId = created.id;
+        console.log(`Created degree C (${degreeId})`);
       }
 
       const [courses, programs] = await Promise.all([
@@ -47,7 +52,8 @@ async function main() {
       const volwassenenCourses = courses.filter(
         (course) =>
           TARGET_DISCIPLINE_HANDLES.includes(
-            course.discipline.handle as (typeof TARGET_DISCIPLINE_HANDLES)[number],
+            course.discipline
+              .handle as (typeof TARGET_DISCIPLINE_HANDLES)[number],
           ) &&
           course.categories.some(
             (category) => category.handle === VOLWASSENEN_CATEGORY_HANDLE,
@@ -109,7 +115,7 @@ async function main() {
           handle: programHandle,
           title: `${course.title ?? course.handle} C`,
           courseId: course.id,
-          degreeId: degree.id,
+          degreeId,
         });
 
         const { id: curriculumId } = await Curriculum.create({


### PR DESCRIPTION
<img width="1213" height="779" alt="Schermafbeelding 2026-06-08 234107" src="https://github.com/user-attachments/assets/5eb8a063-934c-427c-b399-1b6a5da9dd15" />

## Summary

Stacked on #426 

Adds **NWD-C eigenvaardigheid registration via the secretariat** on `/secretariaat/instructeur/[personId]`. A and B remain location-managed; C is admin-only and module-less.

### Database
- Migration `0040`: `certificate.opmerkingen` and `certificate.toegevoegd_door` (FK → `actor`) for audit trail on secretariat registrations

### Core
- `Certificate.registerNwdC` — admin registration for `niveau-c` programs only, duplicate check per person/curriculum/gear, completes certificate without competencies
- `Certificate.withdrawByAdmin` — intrekken without 72h limit; also soft-deletes the linked `student_curriculum` so re-registration works
- Orphaned active `student_curriculum` cleanup on register (fixes dev data from before withdraw fix)

### Web — secretariaat
- Add/remove NWD-C dialogs on the eigenvaardigheid overview (discipline, vaartuig, locatie, datum, opmerkingen)
- Server actions: `registerNwdCAction`, `removeNwdCAction` (system admin only)

### Web — display
- `/diploma` template, PDF export, and profiel certificates adapted for module-less NWD-C

### Guards — C not for locations
- Filter `niveau-c` from `listProgramsForLocation`
- Server-side block in cohort enrollment and location manual diploma creation (`assertCurriculumIsNotNwdC`)


## Notes

- Depends on #426 (eigenvaardigheid overview shell + `listCertificatesForPersonAsAdmin`)
- Penningmeester billing: C uses existing `degree.rang >= 5` instructor split (no change needed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/buchungapp/codesmith/nationaal-watersportdiploma/pr/472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783550092&installation_id=137554715&pr_number=472&repository=buchungapp%2Fnationaal-watersportdiploma&return_to=https%3A%2F%2Fgithub.com%2Fbuchungapp%2Fnationaal-watersportdiploma%2Fpull%2F472&signature=6e98f776fe3c39cabd6d74f39555620d6283a1a2d554821e2f1a4918c174769d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Creates and soft-deletes real certificate records with admin-only paths and new DB columns; incorrect guards or duplicate rules could affect instructor credentials or allow wrong issuance channels.
> 
> **Overview**
> Adds **secretariat-only NWD-C eigenvaardigheid** registration and withdrawal on `/secretariaat/instructeur/[personId]`, with an overview table (grouped by discipline), add/remove dialogs, and system-admin server actions backed by new core commands `registerNwdC` / `withdrawNwdC`.
> 
> **Data & core:** Migration `0040` adds `certificate.opmerkingen` and `certificate.toegevoegd_door` for audit on C registrations. Registration enforces `niveau-c` only, one active C per person/curriculum/vaartuig, completes without competencies, and cleans orphaned `student_curriculum` rows. `completeCertificate` accepts custom `issuedAt`, remarks, and actor. `withdrawByAdmin` is added for generic admin intrekken.
> 
> **Display:** Online diploma template, PDF export, profiel progress cards, and diploma advise text switch to module-less **NWD-C** copy when `degree.handle === "niveau-c"`.
> 
> **Guards:** `niveau-c` is excluded from location program lists and blocked in cohort enrollment and location manual diploma flows via `assertCurriculumIsNotNwdC`. A seed script creates C programs/curricula for selected volwassenen disciplines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5cb0d015e4eba9ecfd2e639044c5082d34f16b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instructors/admins can register and withdraw NWD‑C certifications via management UI (add/remove dialogs and overview).
  * NWD‑C certificates show specialized messaging across diploma, progress, profile, and PDF/print outputs.
  * Certificate registrations support optional remarks and record who added them (shown in overviews).

* **Chores**
  * Database migration to store remarks and registrar attribution for certificates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->