### PR TITLE
Fix program start for soft-deleted cohort actors

### DIFF
--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/[student-allocation]/_components/start-curriculum.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/[student-allocation]/_components/start-curriculum.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useAction } from "next-safe-action/hooks";
 import { useRouter } from "next/navigation";
+import { useAction } from "next-safe-action/hooks";
 import { useState } from "react";
 import { useFormStatus } from "react-dom";
 import { toast } from "sonner";

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/[student-allocation]/_components/start-curriculum.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/[student-allocation]/_components/start-curriculum.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useAction } from "next-safe-action/hooks";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useFormStatus } from "react-dom";
 import { toast } from "sonner";
@@ -38,6 +39,7 @@ export function StartStudentCurriculum({
   personId: string;
   locationId: string;
 }) {
+  const router = useRouter();
   const { execute, input, result } = useAction(
     enrollStudentsInCurriculumInCohortAction.bind(null, cohortId, [
       { allocationId, personId },
@@ -45,6 +47,7 @@ export function StartStudentCurriculum({
     {
       onSuccess: () => {
         toast.success("Programma gestart");
+        router.refresh();
       },
       onError: () => {
         toast.error("Er is iets misgegaan");

--- a/packages/core/src/models/cohort/allocation.test.ts
+++ b/packages/core/src/models/cohort/allocation.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert";
+import { randomUUID } from "node:crypto";
+import test from "node:test";
+import { schema as s } from "@nawadi/db";
+import { eq } from "drizzle-orm";
+import dayjs from "../../utils/dayjs.js";
+import { useQuery, withTestTransaction } from "../../contexts/index.js";
+import { Cohort, Course, Curriculum, Location, Student, User } from "../index.js";
+
+async function createCurriculumFixture(prefix: string) {
+  const [{ id: disciplineId }, { id: degreeId }] = await Promise.all([
+    Course.Discipline.create({
+      title: `${prefix}-discipline`,
+      handle: `${prefix}-discipline`,
+    }),
+    Course.Degree.create({
+      title: `${prefix}-degree`,
+      handle: `${prefix}-degree`,
+      rang: 1000 + Math.floor(Math.random() * 30_000),
+    }),
+  ]);
+
+  const { id: courseId } = await Course.create({
+    title: `${prefix}-course`,
+    handle: `${prefix}-course`,
+    disciplineId,
+  });
+
+  const { id: programId } = await Course.Program.create({
+    title: `${prefix}-program`,
+    handle: `${prefix}-program`,
+    degreeId,
+    courseId,
+  });
+
+  const { id: gearTypeId } = await Curriculum.GearType.create({
+    title: `${prefix}-gear`,
+    handle: `${prefix}-gear`,
+  });
+
+  const { id: curriculumId } = await Curriculum.create({
+    programId,
+    revision: "A",
+  });
+
+  await Promise.all([
+    Curriculum.start({
+      curriculumId,
+      startedAt: dayjs().subtract(1, "day").toISOString(),
+    }),
+    Curriculum.GearType.linkToCurriculum({ curriculumId, gearTypeId }),
+  ]);
+
+  return { curriculumId, gearTypeId };
+}
+
+async function createAllocationFixture() {
+  const query = useQuery();
+  const prefix = `allocation-${randomUUID().slice(0, 8)}`;
+
+  const { id: locationId } = await Location.create({
+    handle: `${prefix}-location`,
+    name: `${prefix} location`,
+  });
+
+  const { id: cohortId } = await Cohort.create({
+    label: `${prefix} cohort`,
+    handle: `${prefix}-cohort`,
+    locationId,
+    accessStartTime: dayjs().subtract(1, "day").toISOString(),
+    accessEndTime: dayjs().add(1, "day").toISOString(),
+  });
+
+  const { id: personId } = await User.Person.getOrCreate({
+    firstName: prefix,
+    lastName: "Student",
+  });
+
+  const [{ id: actorId }] = await query
+    .insert(s.actor)
+    .values({
+      personId,
+      locationId,
+      type: "student",
+    })
+    .returning({ id: s.actor.id });
+
+  assert.ok(actorId);
+
+  const { id: allocationId } = await Cohort.Allocation.create({
+    actorId,
+    cohortId,
+  });
+
+  const { curriculumId, gearTypeId } = await createCurriculumFixture(prefix);
+  const { id: studentCurriculumId } = await Student.Curriculum.start({
+    personId,
+    curriculumId,
+    gearTypeId,
+  });
+
+  await query
+    .update(s.actor)
+    .set({ deletedAt: dayjs().toISOString() })
+    .where(eq(s.actor.id, actorId));
+
+  return {
+    allocationId,
+    cohortId,
+    studentCurriculumId,
+  };
+}
+
+test("cohort allocation ignores allocations whose student actor is soft-deleted", () =>
+  withTestTransaction(async () => {
+    const { allocationId, cohortId } = await createAllocationFixture();
+
+    const allocation = await Cohort.Allocation.retrieveStudentWithCurriculum({
+      allocationId,
+      cohortId,
+    });
+
+    assert.equal(allocation, null);
+  }));
+
+test("cohort allocation cannot attach a curriculum to a soft-deleted student actor", () =>
+  withTestTransaction(async () => {
+    const { allocationId, cohortId, studentCurriculumId } =
+      await createAllocationFixture();
+
+    await assert.rejects(
+      Cohort.Allocation.setStudentCurriculum({
+        cohortId,
+        studentAllocationId: allocationId,
+        studentCurriculumId,
+      }),
+      /Expected 1 row, got 0/,
+    );
+  }));

--- a/packages/core/src/models/cohort/allocation.test.ts
+++ b/packages/core/src/models/cohort/allocation.test.ts
@@ -3,9 +3,16 @@ import { randomUUID } from "node:crypto";
 import test from "node:test";
 import { schema as s } from "@nawadi/db";
 import { eq } from "drizzle-orm";
-import dayjs from "../../utils/dayjs.js";
 import { useQuery, withTestTransaction } from "../../contexts/index.js";
-import { Cohort, Course, Curriculum, Location, Student, User } from "../index.js";
+import dayjs from "../../utils/dayjs.js";
+import {
+  Cohort,
+  Course,
+  Curriculum,
+  Location,
+  Student,
+  User,
+} from "../index.js";
 
 async function createCurriculumFixture(prefix: string) {
   const [{ id: disciplineId }, { id: degreeId }] = await Promise.all([
@@ -76,7 +83,7 @@ async function createAllocationFixture() {
     lastName: "Student",
   });
 
-  const [{ id: actorId }] = await query
+  const [actor] = await query
     .insert(s.actor)
     .values({
       personId,
@@ -85,7 +92,8 @@ async function createAllocationFixture() {
     })
     .returning({ id: s.actor.id });
 
-  assert.ok(actorId);
+  assert.ok(actor);
+  const actorId = actor.id;
 
   const { id: allocationId } = await Cohort.Allocation.create({
     actorId,

--- a/packages/core/src/models/cohort/allocation.ts
+++ b/packages/core/src/models/cohort/allocation.ts
@@ -469,6 +469,7 @@ export const setStudentCurriculum = wrapCommand(
           and(
             eq(s.cohortAllocation.id, input.studentAllocationId),
             eq(s.cohortAllocation.cohortId, input.cohortId),
+            isNull(s.cohortAllocation.deletedAt),
             exists(
               query
                 .select({ id: sql`1` })
@@ -483,7 +484,8 @@ export const setStudentCurriculum = wrapCommand(
             ),
           ),
         )
-        .returning({ id: s.cohortAllocation.id });
+        .returning({ id: s.cohortAllocation.id })
+        .then(singleRow);
     },
   ),
 );
@@ -677,6 +679,7 @@ export const listStudentsWithCurricula = wrapQuery(
           and(
             eq(s.actor.id, s.cohortAllocation.actorId),
             eq(s.actor.type, "student"),
+            isNull(s.actor.deletedAt),
           ),
         )
         .innerJoin(s.person, eq(s.person.id, s.actor.personId))

--- a/packages/core/src/models/cohort/allocation.ts
+++ b/packages/core/src/models/cohort/allocation.ts
@@ -880,6 +880,7 @@ export const retrieveStudentWithCurriculum = wrapQuery(
           and(
             eq(s.actor.id, s.cohortAllocation.actorId),
             eq(s.actor.type, "student"),
+            isNull(s.actor.deletedAt),
           ),
         )
         .innerJoin(s.cohort, eq(s.cohort.id, s.cohortAllocation.cohortId))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Hide cohort allocations whose student actor is soft-deleted from student detail reads.
- Make `setStudentCurriculum` fail when no live student allocation is updated instead of returning an empty success.
- Refresh the student detail route after a successful program start so the course card appears immediately.
- Add a DB-backed regression test for soft-deleted student actors.

### Investigation
- The reported allocation had a live `cohort_allocation` row but its linked `actor` was soft-deleted.
- The read path showed the allocation, while the write path required a non-deleted actor and silently updated zero rows.

### Testing
- `pnpm exec biome check packages/core/src/models/cohort/allocation.ts packages/core/src/models/cohort/allocation.test.ts "apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/[student-allocation]/_components/start-curriculum.tsx"` passed.
- `pnpm exec cspell packages/core/src/models/cohort/allocation.ts packages/core/src/models/cohort/allocation.test.ts "apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/[student-allocation]/_components/start-curriculum.tsx"` passed.
- `pnpm --filter @nawadi/lib build && pnpm --filter @nawadi/db build && pnpm --filter @nawadi/core build` passed.
- `pnpm --filter @nawadi/web exec eslint "src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/[student-allocation]/_components/start-curriculum.tsx"` passed.
- `node --test "packages/core/out/models/cohort/allocation.test.js"` is blocked locally because Supabase cannot start without Docker on this VM (`Cannot connect to the Docker daemon`).

### Babysit status
- Build/test/Vercel/api-docs/audit checks are passing.
- Repository-wide formatting and spelling checks are failing on files outside this PR diff; the branch is not behind `main`, so those are not PR-scoped changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62e9e5f5-67aa-4f57-8199-5acb20a0f36c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62e9e5f5-67aa-4f57-8199-5acb20a0f36c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/buchungapp/codesmith/nationaal-watersportdiploma/pr/474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784381799&installation_id=137554715&pr_number=474&repository=buchungapp%2Fnationaal-watersportdiploma&return_to=https%3A%2F%2Fgithub.com%2Fbuchungapp%2Fnationaal-watersportdiploma%2Fpull%2F474&signature=4564673e5dc02b6b6f5ed9d0dff175ab725fa61581fb98ced343fac828e617a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->