### PR TITLE
[codex] Fix bulk import column mapping

### DIFF
--- a/apps/web/src/app/_actions/person/bulk-import-actions.ts
+++ b/apps/web/src/app/_actions/person/bulk-import-actions.ts
@@ -4,15 +4,12 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { zfd } from "zod-form-data";
 import { commitBulkImport, previewBulkImport } from "~/lib/nwd";
-import { dateInput } from "../dates";
 import { actionClientWithMeta } from "../safe-action";
+import { type ParsedPersonRow, parseRowsTolerant } from "./bulk-import-parser";
 import {
-  COLUMN_MAPPING,
-  type CSVData,
   countriesSchema,
   csvColumnLiteral,
   csvDataSchema,
-  SELECT_LABEL,
 } from "./person-bulk-csv-mappings";
 
 // ─── Preview ──────────────────────────────────────────────────────────────
@@ -37,38 +34,6 @@ const previewArgsSchema: [
   countriesSchema,
   z.string().uuid().optional(),
 ];
-
-const personRowSchema = z
-  .tuple([
-    z.string().trim().toLowerCase().email(),
-    z.string().trim(),
-    z
-      .string()
-      .trim()
-      .transform((v) => v || null),
-    z.string(),
-    dateInput,
-    z.string(),
-    z
-      .preprocess((value) => (value === "" ? "nl" : value), z.string().min(2))
-      .default("nl"),
-  ])
-  .rest(z.string().nullish());
-
-type ParsedPersonRow = {
-  rowIndex: number;
-  email: string;
-  firstName: string;
-  lastNamePrefix: string | null;
-  lastName: string;
-  dateOfBirth: Date;
-  birthCity: string;
-  birthCountry: string;
-  // Tags collected from any columns the operator mapped to "Tag" — only
-  // populated when the dialog is using COLUMN_MAPPING_WITH_TAG (cohort
-  // variant). Empty when the column mapping has no Tag entry.
-  tags: string[];
-};
 
 type PreviewParseResult =
   | {
@@ -142,124 +107,6 @@ export const previewBulkImportAction = actionClientWithMeta
       };
     },
   );
-
-function parseRowsTolerant(
-  csvData: CSVData,
-  indexToColumnSelection: Record<string, string>,
-  countries: z.infer<typeof countriesSchema>,
-): {
-  parsedRows: ParsedPersonRow[];
-  parseErrors: { rowIndex: number; error: string; values: string[] }[];
-} {
-  if (!csvData || !csvData.rows) {
-    throw new Error("Geen data gevonden.");
-  }
-
-  // Operator may map any column to "Niet importeren" (skip), to one of
-  // the COLUMN_MAPPING targets, or to "Tag" (cohort variant only — N
-  // tag columns get collected as per-row tags[]).
-  const tagIndices = Object.entries(indexToColumnSelection)
-    .filter(([_, value]) => value === "Tag")
-    // biome-ignore lint/style/noNonNullAssertion: include-column-N format
-    .map(([key]) => Number.parseInt(key.split("-").pop()!, 10));
-
-  const selectedFields = Object.values(indexToColumnSelection).filter(
-    (item) => item !== SELECT_LABEL && item !== "Tag",
-  );
-  const skippedIndices = new Set(
-    Object.entries(indexToColumnSelection)
-      .filter(([_, value]) => value === SELECT_LABEL || value === "Tag")
-      // biome-ignore lint/style/noNonNullAssertion: include-column-N format
-      .map(([key]) => Number.parseInt(key.split("-").pop()!, 10)),
-  );
-
-  const filteredData = csvData.rows.map((item) =>
-    item.filter((_, index) => !skippedIndices.has(index)),
-  );
-
-  // Per-row tags pulled from the original CSV rows (before filtering),
-  // trimmed + non-empty + deduplicated. Empty when no Tag columns mapped.
-  const tagsPerRow: string[][] = csvData.rows.map((row) => {
-    const seen = new Set<string>();
-    const out: string[] = [];
-    for (const idx of tagIndices) {
-      const v = row[idx];
-      if (typeof v !== "string") continue;
-      const trimmed = v.trim();
-      if (!trimmed) continue;
-      if (seen.has(trimmed)) continue;
-      seen.add(trimmed);
-      out.push(trimmed);
-    }
-    return out;
-  });
-
-  const requiredColumns = COLUMN_MAPPING;
-  const missingFields = requiredColumns.filter(
-    (item) => !selectedFields.includes(item),
-  );
-
-  if (missingFields.length > 0) {
-    throw new Error(`Missende velden in data: ${missingFields.join(", ")}`);
-  }
-
-  const indices = selectedFields.map((columnName) =>
-    (COLUMN_MAPPING as readonly string[]).indexOf(columnName),
-  );
-
-  const allowedCountries = new Set(countries.map((c) => c.code));
-
-  const parsedRows: ParsedPersonRow[] = [];
-  const parseErrors: {
-    rowIndex: number;
-    error: string;
-    values: string[];
-  }[] = [];
-
-  filteredData.forEach((row, rowIndex) => {
-    const sortedRow = indices.map((index) => row[index]);
-    const rawValues = sortedRow.map((v) => v ?? "");
-    const parsed = personRowSchema.safeParse(sortedRow);
-    if (!parsed.success) {
-      parseErrors.push({
-        rowIndex,
-        error: JSON.stringify(parsed.error.flatten().fieldErrors),
-        values: rawValues,
-      });
-      return;
-    }
-    const [
-      email,
-      firstName,
-      lastNamePrefix,
-      lastName,
-      dateOfBirth,
-      birthCity,
-      birthCountry,
-    ] = parsed.data;
-    if (!allowedCountries.has(birthCountry)) {
-      parseErrors.push({
-        rowIndex,
-        error: `Ongeldige landcode: ${birthCountry}`,
-        values: rawValues,
-      });
-      return;
-    }
-    parsedRows.push({
-      rowIndex,
-      tags: tagsPerRow[rowIndex] ?? [],
-      email,
-      firstName,
-      lastNamePrefix,
-      lastName,
-      dateOfBirth,
-      birthCity,
-      birthCountry,
-    });
-  });
-
-  return { parsedRows, parseErrors };
-}
 
 // ─── Commit ───────────────────────────────────────────────────────────────
 

--- a/apps/web/src/app/_actions/person/bulk-import-parser.test.tsx
+++ b/apps/web/src/app/_actions/person/bulk-import-parser.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { parseRowsTolerant } from "./bulk-import-parser";
+import type { CSVData } from "./person-bulk-csv-mappings";
+
+const countries = [
+  { code: "nl", name: "Nederland" },
+  { code: "at", name: "Oostenrijk" },
+];
+
+describe("parseRowsTolerant", () => {
+  it("parses rows when tag columns are before and between mapped person fields", () => {
+    const csvData: CSVData = {
+      labels: null,
+      rows: [
+        [
+          "Jeugd",
+          "Renkema",
+          "02-01-2014",
+          "Wenen",
+          "AT",
+          "arne@example.com",
+          "Arne",
+          "Ochtend",
+          "",
+        ],
+      ],
+    };
+
+    const result = parseRowsTolerant(
+      csvData,
+      {
+        "include-column-0": "Tag",
+        "include-column-1": "Achternaam",
+        "include-column-2": "Geboortedatum",
+        "include-column-3": "Geboorteplaats",
+        "include-column-4": "Geboorteland",
+        "include-column-5": "E-mailadres",
+        "include-column-6": "Voornaam",
+        "include-column-7": "Tag",
+        "include-column-8": "Tussenvoegsels",
+      },
+      countries,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.parsedRows).toHaveLength(1);
+    expect(result.parsedRows[0]).toMatchObject({
+      rowIndex: 0,
+      email: "arne@example.com",
+      firstName: "Arne",
+      lastNamePrefix: null,
+      lastName: "Renkema",
+      birthCity: "Wenen",
+      birthCountry: "at",
+      tags: ["Jeugd", "Ochtend"],
+    });
+    expect(result.parsedRows[0]?.dateOfBirth.toISOString().slice(0, 10)).toBe(
+      "2014-01-02",
+    );
+  });
+});

--- a/apps/web/src/app/_actions/person/bulk-import-parser.test.tsx
+++ b/apps/web/src/app/_actions/person/bulk-import-parser.test.tsx
@@ -58,4 +58,49 @@ describe("parseRowsTolerant", () => {
       "2014-01-02",
     );
   });
+
+  it("accepts ISO birth dates", () => {
+    const csvData: CSVData = {
+      labels: null,
+      rows: [
+        [
+          "arne@example.com",
+          "Arne",
+          "",
+          "Renkema",
+          "2014-01-02",
+          "Wenen",
+          "AT",
+        ],
+      ],
+    };
+
+    const result = parseRowsTolerant(
+      csvData,
+      {
+        "include-column-0": "E-mailadres",
+        "include-column-1": "Voornaam",
+        "include-column-2": "Tussenvoegsels",
+        "include-column-3": "Achternaam",
+        "include-column-4": "Geboortedatum",
+        "include-column-5": "Geboorteplaats",
+        "include-column-6": "Geboorteland",
+      },
+      countries,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.parsedRows[0]).toMatchObject({
+      email: "arne@example.com",
+      firstName: "Arne",
+      lastNamePrefix: null,
+      lastName: "Renkema",
+      birthCity: "Wenen",
+      birthCountry: "at",
+      tags: [],
+    });
+    expect(result.parsedRows[0]?.dateOfBirth.toISOString().slice(0, 10)).toBe(
+      "2014-01-02",
+    );
+  });
 });

--- a/apps/web/src/app/_actions/person/bulk-import-parser.ts
+++ b/apps/web/src/app/_actions/person/bulk-import-parser.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 import {
   COLUMN_MAPPING,
   type CSVData,
-  type countriesSchema,
   SELECT_LABEL,
 } from "./person-bulk-csv-mappings";
 
@@ -66,6 +65,7 @@ const personRowSchema = z
   .rest(z.string().nullish());
 
 type PersonColumn = (typeof COLUMN_MAPPING)[number];
+type CountryOption = { code: string };
 
 export type ParsedPersonRow = {
   rowIndex: number;
@@ -96,7 +96,7 @@ function sourceIndexFromKey(key: string): number {
 export function parseRowsTolerant(
   csvData: CSVData,
   indexToColumnSelection: Record<string, string>,
-  countries: z.infer<typeof countriesSchema>,
+  countries: CountryOption[],
 ): {
   parsedRows: ParsedPersonRow[];
   parseErrors: BulkImportParseError[];
@@ -135,7 +135,9 @@ export function parseRowsTolerant(
     throw new Error(`Missende velden in data: ${missingFields.join(", ")}`);
   }
 
-  const allowedCountries = new Set(countries.map((c) => c.code));
+  const allowedCountries = new Set(
+    countries.map((c) => c.code.trim().toLowerCase()),
+  );
 
   const parsedRows: ParsedPersonRow[] = [];
   const parseErrors: BulkImportParseError[] = [];
@@ -164,7 +166,7 @@ export function parseRowsTolerant(
       birthCity,
       birthCountry,
     ] = parsed.data;
-    const normalizedBirthCountry = birthCountry.toLowerCase();
+    const normalizedBirthCountry = birthCountry.trim().toLowerCase();
     if (!allowedCountries.has(normalizedBirthCountry)) {
       parseErrors.push({
         rowIndex,

--- a/apps/web/src/app/_actions/person/bulk-import-parser.ts
+++ b/apps/web/src/app/_actions/person/bulk-import-parser.ts
@@ -1,0 +1,202 @@
+import { z } from "zod";
+import {
+  COLUMN_MAPPING,
+  type CSVData,
+  type countriesSchema,
+  SELECT_LABEL,
+} from "./person-bulk-csv-mappings";
+
+function validUtcDate(year: number, month: number, day: number): Date | null {
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return null;
+  }
+  return date;
+}
+
+function parseBirthDate(value: string): Date | null {
+  const trimmed = value.trim();
+  const iso = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed);
+  if (iso) {
+    return validUtcDate(Number(iso[1]), Number(iso[2]), Number(iso[3]));
+  }
+
+  const dutch = /^(\d{2})-(\d{2})-(\d{4})$/.exec(trimmed);
+  if (dutch) {
+    return validUtcDate(Number(dutch[3]), Number(dutch[2]), Number(dutch[1]));
+  }
+
+  return null;
+}
+
+const dateOfBirthInput = z
+  .string()
+  .trim()
+  .transform((value, ctx) => {
+    const date = parseBirthDate(value);
+    if (!date) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Ongeldige geboortedatum",
+      });
+      return z.NEVER;
+    }
+    return date;
+  });
+
+const personRowSchema = z
+  .tuple([
+    z.string().trim().toLowerCase().email(),
+    z.string().trim(),
+    z
+      .string()
+      .trim()
+      .transform((v) => v || null),
+    z.string(),
+    dateOfBirthInput,
+    z.string(),
+    z
+      .preprocess((value) => (value === "" ? "nl" : value), z.string().min(2))
+      .default("nl"),
+  ])
+  .rest(z.string().nullish());
+
+type PersonColumn = (typeof COLUMN_MAPPING)[number];
+
+export type ParsedPersonRow = {
+  rowIndex: number;
+  email: string;
+  firstName: string;
+  lastNamePrefix: string | null;
+  lastName: string;
+  dateOfBirth: Date;
+  birthCity: string;
+  birthCountry: string;
+  // Tags collected from any columns the operator mapped to "Tag" — only
+  // populated when the dialog is using COLUMN_MAPPING_WITH_TAG (cohort
+  // variant). Empty when the column mapping has no Tag entry.
+  tags: string[];
+};
+
+export type BulkImportParseError = {
+  rowIndex: number;
+  error: string;
+  values: string[];
+};
+
+function sourceIndexFromKey(key: string): number {
+  // biome-ignore lint/style/noNonNullAssertion: include-column-N format
+  return Number.parseInt(key.split("-").pop()!, 10);
+}
+
+export function parseRowsTolerant(
+  csvData: CSVData,
+  indexToColumnSelection: Record<string, string>,
+  countries: z.infer<typeof countriesSchema>,
+): {
+  parsedRows: ParsedPersonRow[];
+  parseErrors: BulkImportParseError[];
+} {
+  if (!csvData || !csvData.rows) {
+    throw new Error("Geen data gevonden.");
+  }
+
+  // Build a target -> source lookup. Operators may paste columns in any
+  // order, and cohort imports may place Tag columns before or between
+  // person fields.
+  const sourceIndexByTarget = new Map<PersonColumn, number>();
+  const tagIndices: number[] = [];
+
+  for (const [key, value] of Object.entries(indexToColumnSelection)) {
+    const sourceIndex = sourceIndexFromKey(key);
+    if (value === "Tag") {
+      tagIndices.push(sourceIndex);
+      continue;
+    }
+    if (value === SELECT_LABEL) {
+      continue;
+    }
+    if ((COLUMN_MAPPING as readonly string[]).includes(value)) {
+      sourceIndexByTarget.set(value as PersonColumn, sourceIndex);
+    }
+  }
+
+  tagIndices.sort((a, b) => a - b);
+
+  const missingFields = COLUMN_MAPPING.filter(
+    (field) => !sourceIndexByTarget.has(field),
+  );
+
+  if (missingFields.length > 0) {
+    throw new Error(`Missende velden in data: ${missingFields.join(", ")}`);
+  }
+
+  const allowedCountries = new Set(countries.map((c) => c.code));
+
+  const parsedRows: ParsedPersonRow[] = [];
+  const parseErrors: BulkImportParseError[] = [];
+
+  csvData.rows.forEach((row, rowIndex) => {
+    const sortedRow = COLUMN_MAPPING.map((field) => {
+      const sourceIndex = sourceIndexByTarget.get(field);
+      return sourceIndex === undefined ? undefined : row[sourceIndex];
+    });
+    const rawValues = sortedRow.map((v) => v ?? "");
+    const parsed = personRowSchema.safeParse(sortedRow);
+    if (!parsed.success) {
+      parseErrors.push({
+        rowIndex,
+        error: JSON.stringify(parsed.error.flatten().fieldErrors),
+        values: rawValues,
+      });
+      return;
+    }
+    const [
+      email,
+      firstName,
+      lastNamePrefix,
+      lastName,
+      dateOfBirth,
+      birthCity,
+      birthCountry,
+    ] = parsed.data;
+    const normalizedBirthCountry = birthCountry.toLowerCase();
+    if (!allowedCountries.has(normalizedBirthCountry)) {
+      parseErrors.push({
+        rowIndex,
+        error: `Ongeldige landcode: ${birthCountry}`,
+        values: rawValues,
+      });
+      return;
+    }
+
+    const seenTags = new Set<string>();
+    const tags: string[] = [];
+    for (const idx of tagIndices) {
+      const value = row[idx];
+      if (typeof value !== "string") continue;
+      const trimmed = value.trim();
+      if (!trimmed || seenTags.has(trimmed)) continue;
+      seenTags.add(trimmed);
+      tags.push(trimmed);
+    }
+
+    parsedRows.push({
+      rowIndex,
+      tags,
+      email,
+      firstName,
+      lastNamePrefix,
+      lastName,
+      dateOfBirth,
+      birthCity,
+      birthCountry: normalizedBirthCountry,
+    });
+  });
+
+  return { parsedRows, parseErrors };
+}


### PR DESCRIPTION
## Summary

Fixes the cohort bulk-import preview parser so mapped columns are read from their original source indexes instead of from a filtered/reindexed row. This prevents values from shifting when operators place Tag columns before or between person fields, or when pasted columns are not in the template order.

Also makes the parser accept explicit `YYYY-MM-DD` and Dutch `DD-MM-YYYY` birth dates, and normalizes birth country codes to lowercase before validation.

## Root Cause

The preview action removed skipped/Tag columns and then used target-field indexes against that filtered row. That meant source values could slide into the wrong target fields after Tag columns were filtered out, matching the support screenshot where email, date, country, and names appeared under the wrong labels.

## Validation

- `corepack pnpm --filter @nawadi/web exec vitest run src/app/_actions/person/bulk-import-parser.test.tsx`
- `corepack pnpm biome check apps/web/src/app/_actions/person/bulk-import-parser.ts apps/web/src/app/_actions/person/bulk-import-parser.test.tsx apps/web/src/app/_actions/person/bulk-import-actions.ts`

## Notes

Broader checks still have pre-existing unrelated failures:

- `corepack pnpm --filter @nawadi/web test:components` fails in `src/app/_components/ai-chat/use-sticky-scroll.test.tsx` with two scrollTop expectations.
- `corepack pnpm --filter @nawadi/web exec tsc --noEmit --pretty false` fails on existing static image module imports.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/buchungapp/codesmith/nationaal-watersportdiploma/pr/475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785324295&installation_id=137554715&pr_number=475&repository=buchungapp%2Fnationaal-watersportdiploma&return_to=https%3A%2F%2Fgithub.com%2Fbuchungapp%2Fnationaal-watersportdiploma%2Fpull%2F475&signature=6b6a126f1dd666bf1c35c62a1a09fd875801844a858265a82dba84287f6c7ff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how person bulk-import preview data is parsed; wrong mapping could still mis-import PII, but behavior is targeted bugfix with new unit tests.
> 
> **Overview**
> Fixes cohort/person **bulk import preview** parsing so mapped fields are read from each column’s **original source index** instead of a row with Tag/skip columns stripped and reindexed. That stops values (email, names, dates, country) from landing under the wrong fields when Tag columns sit before or between person columns or pasted order differs from the template.
> 
> Parsing moves into **`bulk-import-parser.ts`** (`parseRowsTolerant`, `ParsedPersonRow`); **`bulk-import-actions.ts`** only calls it for preview. Birth dates now accept **`YYYY-MM-DD`** and Dutch **`DD-MM-YYYY`** via dedicated UTC validation (replacing shared `dateInput` here). **Birth country** codes are trimmed and lowercased before allowlist checks. **Vitest** covers mixed Tag layouts and ISO dates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c9a7f353c8d2ca6fb20f2816cfab5fc808cb768. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Bulk person import now supports more flexible CSV parsing, including tag columns and both ISO (`YYYY-MM-DD`) and Dutch (`DD-MM-YYYY`) birth date formats.
  - Import results now separate successfully parsed rows from row-level errors, making it easier to review problematic entries without stopping the whole import.

- **Bug Fixes**
  - Improved validation for birth country values and date handling to reduce incorrect imports.
  - Added coverage for mixed column layouts to ensure tags and person data are parsed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->