### PR TITLE
[codex] Fix cohort certificate module counts

### DIFF
--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/module-counts.test.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/module-counts.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { countDisplayModules } from "./module-counts";
+
+function requiredModule({
+  newlyIssuable,
+  completedCompetenciesInCertificate,
+}: {
+  newlyIssuable: boolean;
+  completedCompetenciesInCertificate: number;
+}) {
+  return {
+    module: { type: "required" },
+    newlyIssuable,
+    completedCompetenciesInCertificate,
+  };
+}
+
+function optionalModule({
+  newlyIssuable,
+  completedCompetenciesInCertificate,
+}: {
+  newlyIssuable: boolean;
+  completedCompetenciesInCertificate: number;
+}) {
+  return {
+    module: { type: "optional" },
+    newlyIssuable,
+    completedCompetenciesInCertificate,
+  };
+}
+
+describe("countDisplayModules", () => {
+  it("counts newly issuable modules before a cohort certificate is issued", () => {
+    const moduleStatus = [
+      requiredModule({
+        newlyIssuable: false,
+        completedCompetenciesInCertificate: 0,
+      }),
+      requiredModule({
+        newlyIssuable: true,
+        completedCompetenciesInCertificate: 0,
+      }),
+      requiredModule({
+        newlyIssuable: true,
+        completedCompetenciesInCertificate: 0,
+      }),
+      requiredModule({
+        newlyIssuable: true,
+        completedCompetenciesInCertificate: 0,
+      }),
+    ];
+
+    expect(countDisplayModules(moduleStatus, "required", false)).toBe(3);
+  });
+
+  it("counts modules on the issued cohort certificate after issuance", () => {
+    const moduleStatus = [
+      requiredModule({
+        newlyIssuable: false,
+        completedCompetenciesInCertificate: 0,
+      }),
+      requiredModule({
+        newlyIssuable: false,
+        completedCompetenciesInCertificate: 1,
+      }),
+      requiredModule({
+        newlyIssuable: false,
+        completedCompetenciesInCertificate: 1,
+      }),
+      requiredModule({
+        newlyIssuable: false,
+        completedCompetenciesInCertificate: 1,
+      }),
+    ];
+
+    expect(countDisplayModules(moduleStatus, "required", true)).toBe(3);
+  });
+
+  it("keeps required and optional module counts separate", () => {
+    const moduleStatus = [
+      requiredModule({
+        newlyIssuable: true,
+        completedCompetenciesInCertificate: 0,
+      }),
+      optionalModule({
+        newlyIssuable: true,
+        completedCompetenciesInCertificate: 0,
+      }),
+      optionalModule({
+        newlyIssuable: false,
+        completedCompetenciesInCertificate: 1,
+      }),
+    ];
+
+    expect(countDisplayModules(moduleStatus, "required", false)).toBe(1);
+    expect(countDisplayModules(moduleStatus, "optional", false)).toBe(1);
+    expect(countDisplayModules(moduleStatus, "required", true)).toBe(0);
+    expect(countDisplayModules(moduleStatus, "optional", true)).toBe(1);
+  });
+});

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/module-counts.ts
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/module-counts.ts
@@ -1,0 +1,23 @@
+type ModuleType = "required" | "optional";
+
+type ModuleStatus = {
+  module: {
+    type: string;
+  };
+  newlyIssuable: boolean;
+  completedCompetenciesInCertificate: number;
+};
+
+export function countDisplayModules(
+  moduleStatus: ModuleStatus[],
+  type: ModuleType,
+  hasIssuedCertificate: boolean,
+) {
+  return moduleStatus.filter(
+    (status) =>
+      status.module.type === type &&
+      (hasIssuedCertificate
+        ? status.completedCompetenciesInCertificate > 0
+        : status.newlyIssuable),
+  ).length;
+}

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/students-table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/students-table.tsx
@@ -40,6 +40,7 @@ import dayjs from "~/lib/dayjs";
 import type { listCertificateOverviewByCohortId } from "~/lib/nwd";
 import { transformSelectionState } from "~/utils/table-state";
 import { FilterSelect } from "./filter";
+import { countDisplayModules } from "./module-counts";
 import { ActionButtons } from "./table-actions";
 export type Student = Awaited<
   ReturnType<typeof listCertificateOverviewByCohortId>
@@ -161,16 +162,11 @@ const columns = [
     (row) => {
       if (!row.studentCurriculum) return undefined;
 
-      // Count modules where issuing the certificate right now would
-      // mint at least one new canonical competency. A module that's
-      // already fully canonical from an earlier diploma doesn't count
-      // — there is nothing to issue for it. See option d.
-      const coreModulesIssuable = row.studentCurriculum.moduleStatus.filter(
-        ({ module: { type }, newlyIssuable }) =>
-          type === "required" && newlyIssuable,
-      ).length;
-
-      return coreModulesIssuable;
+      return countDisplayModules(
+        row.studentCurriculum.moduleStatus,
+        "required",
+        !!row.certificate?.issuedAt,
+      );
     },
     {
       id: "kernmodules",
@@ -188,7 +184,11 @@ const columns = [
         return (
           <div className="flex items-center gap-x-1.5">
             <span className="font-medium text-zinc-950">
-              {coreModules.filter((status) => status.newlyIssuable).length}
+              {countDisplayModules(
+                row.original.studentCurriculum.moduleStatus,
+                "required",
+                !!row.original.certificate?.issuedAt,
+              )}
             </span>
             <span className="text-zinc-500">/</span>
             <span className="text-zinc-950">{coreModules.length}</span>
@@ -201,12 +201,11 @@ const columns = [
     (row) => {
       if (!row.studentCurriculum) return undefined;
 
-      const electiveModulesIssuable = row.studentCurriculum.moduleStatus.filter(
-        ({ module: { type }, newlyIssuable }) =>
-          type === "optional" && newlyIssuable,
-      ).length;
-
-      return electiveModulesIssuable;
+      return countDisplayModules(
+        row.studentCurriculum.moduleStatus,
+        "optional",
+        !!row.certificate?.issuedAt,
+      );
     },
     {
       id: "keuzemodules",
@@ -225,7 +224,11 @@ const columns = [
         return (
           <div className="flex items-center gap-x-1.5">
             <span className="font-medium text-zinc-950">
-              {electiveModules.filter((status) => status.newlyIssuable).length}
+              {countDisplayModules(
+                row.original.studentCurriculum.moduleStatus,
+                "optional",
+                !!row.original.certificate?.issuedAt,
+              )}
             </span>
             <span className="text-zinc-500">/</span>
             <span className="text-zinc-950">{electiveModules.length}</span>

--- a/packages/core/src/models/cohort/certificate.ts
+++ b/packages/core/src/models/cohort/certificate.ts
@@ -109,8 +109,8 @@ export const listStatus = wrapQuery(
           // either at cohort-progress=100 or already canonical, AND at
           // least one competency is cohort-progress=100 but not yet
           // canonical (otherwise the issuance produces nothing new).
-          // Drives the `geblokkeerd` row state and the diplomas-tab
-          // count under option d.
+          // Drives the `geblokkeerd` row state and the pre-issuance
+          // diplomas-tab count under option d.
           newlyIssuable: sql<boolean>`(
               COUNT(${s.curriculumCompetency.id}) FILTER (
                 WHERE COALESCE(${latestProgress.progress}, 0) >= 100
@@ -121,6 +121,14 @@ export const listStatus = wrapQuery(
                   AND ${canonicalCompetency.competencyId} IS NULL
               ) > 0
             )`.mapWith(Boolean),
+          // Competencies on the certificate that was actually issued
+          // from this cohort allocation. After issuance, `newlyIssuable`
+          // correctly drops to false, so the UI must render from this
+          // certificate-local count instead of from "still issuable".
+          completedCompetenciesInCertificate:
+            sql<number>`COUNT(${s.studentCompletedCompetency.competencyId}) FILTER (WHERE ${s.studentCompletedCompetency.certificateId} IS NOT NULL)`.mapWith(
+              Number,
+            ),
         })
         .from(s.studentCurriculum)
         .innerJoin(
@@ -134,6 +142,30 @@ export const listStatus = wrapQuery(
         .innerJoin(
           s.cohortAllocation,
           eq(s.cohortAllocation.studentCurriculumId, s.studentCurriculum.id),
+        )
+        .leftJoin(
+          s.certificate,
+          and(
+            eq(s.certificate.cohortAllocationId, s.cohortAllocation.id),
+            isNull(s.certificate.deletedAt),
+            isNotNull(s.certificate.issuedAt),
+          ),
+        )
+        .leftJoin(
+          s.studentCompletedCompetency,
+          and(
+            eq(s.studentCompletedCompetency.certificateId, s.certificate.id),
+            eq(
+              s.studentCompletedCompetency.studentCurriculumId,
+              s.studentCurriculum.id,
+            ),
+            eq(
+              s.studentCompletedCompetency.competencyId,
+              s.curriculumCompetency.id,
+            ),
+            eq(s.studentCompletedCompetency.isMergeConflictDuplicate, false),
+            isNull(s.studentCompletedCompetency.deletedAt),
+          ),
         )
         .leftJoin(
           latestProgress,
@@ -319,6 +351,8 @@ export const listStatus = wrapQuery(
                   completedCompetencies: status.completedCompetencies,
                   uncompletedCompetencies: status.uncompletedCompetencies,
                   newlyIssuable: status.newlyIssuable,
+                  completedCompetenciesInCertificate:
+                    status.completedCompetenciesInCertificate,
                 })),
               }
             : null,

--- a/packages/core/src/models/user/person.test.ts
+++ b/packages/core/src/models/user/person.test.ts
@@ -1937,6 +1937,85 @@ test("cohort.certificate.listStatus exposes newlyIssuable per module (canonical 
       true,
       "Module 2 has a fresh competency at 100 with no canonical row — newly issuable",
     );
+
+    const { id: cohortCertificateId } =
+      await Student.Certificate.startCertificate({
+        locationId: location.id,
+        studentCurriculumId,
+      });
+
+    await Student.Certificate.completeCompetency({
+      certificateId: cohortCertificateId,
+      studentCurriculumId,
+      competencyId: fixture.curriculumCompetency2Id,
+    });
+    await Student.Certificate.completeCertificate({
+      certificateId: cohortCertificateId,
+      visibleFrom: dayjs().toISOString(),
+    });
+    await Certificate.assignToCohortAllocation({
+      certificateId: cohortCertificateId,
+      cohortAllocationId: studentRow.id,
+    });
+
+    const issuedStatus = await Cohort.Certificate.listStatus({ cohortId });
+    const issuedStudent = issuedStatus.find(
+      (row) => row.person.id === personId,
+    );
+    assert.ok(issuedStudent?.studentCurriculum);
+
+    const issuedModule1 = issuedStudent.studentCurriculum.moduleStatus.find(
+      (m) => m.module.id === fixture.module1Id,
+    );
+    const issuedModule2 = issuedStudent.studentCurriculum.moduleStatus.find(
+      (m) => m.module.id === fixture.module2Id,
+    );
+    assert.ok(issuedModule1);
+    assert.ok(issuedModule2);
+    assert.equal(
+      issuedModule1.completedCompetenciesInCertificate,
+      0,
+      "Earlier certificate competency must not count as part of the cohort-issued certificate",
+    );
+    assert.equal(
+      issuedModule2.completedCompetenciesInCertificate,
+      1,
+      "Newly issued cohort competency must remain visible after issuance",
+    );
+    assert.equal(
+      issuedModule2.newlyIssuable,
+      false,
+      "After issuance there is nothing left to issue, but the issued-certificate count remains",
+    );
+
+    await Certificate.withdraw(cohortCertificateId);
+
+    const withdrawnStatus = await Cohort.Certificate.listStatus({ cohortId });
+    const withdrawnStudent = withdrawnStatus.find(
+      (row) => row.person.id === personId,
+    );
+    assert.ok(withdrawnStudent?.studentCurriculum);
+    assert.equal(
+      withdrawnStudent.certificate,
+      null,
+      "Withdrawn certificate should not remain linked in cohort certificate status",
+    );
+
+    const withdrawnModule2 =
+      withdrawnStudent.studentCurriculum.moduleStatus.find(
+        (m) => m.module.id === fixture.module2Id,
+      );
+    assert.ok(withdrawnModule2);
+    assert.equal(
+      withdrawnModule2.completedCompetenciesInCertificate,
+      0,
+      "Withdrawn certificate competencies should no longer count in the diplomas table",
+    );
+    assert.equal(
+      withdrawnModule2.newlyIssuable,
+      true,
+      "After withdrawal, the cohort progress can issue the competency again",
+    );
   }));
 
 // REGRESSION (option d, fully-redundant cohort run): when every


### PR DESCRIPTION
## Summary
- Add a certificate-local `completedCompetenciesInCertificate` count to `Cohort.Certificate.listStatus`.
- Render the Diploma table counts from `newlyIssuable` before issuance, and from the linked issued certificate contents after issuance.
- Add regression coverage for the core cohort status query and the web count helper.

## Root cause
The Diploma table reused `newlyIssuable` for the visible count. That is correct before issuing, but after issuing the certificate those competencies become canonical, so `newlyIssuable` correctly drops to false and the UI showed `0 / N`.

## Validation
- Passed: `corepack pnpm exec biome check --write` on the touched files.
- Passed: exact web helper test with `cd apps/web && corepack pnpm exec vitest run .../module-counts.test.tsx`.
- Passed: focused core regression tests for `cohort.certificate.listStatus` against a disposable migrated database.
- Passed: `corepack pnpm --filter @nawadi/core typecheck`.
- Existing issue: `cd apps/web && corepack pnpm exec tsc --noEmit` is blocked by unrelated missing static asset module declarations across public/auth pages.
- Existing issue: `corepack pnpm --filter @nawadi/web test:components -- module-counts` runs the full component suite and fails unrelated ai-chat sticky scroll expectations (`1500` expected, `600`/`590` received).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/buchungapp/codesmith/nationaal-watersportdiploma/pr/480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785618053&installation_id=137554715&pr_number=480&repository=buchungapp%2Fnationaal-watersportdiploma&return_to=https%3A%2F%2Fgithub.com%2Fbuchungapp%2Fnationaal-watersportdiploma%2Fpull%2F480&signature=66cfba0401b68cdbf1ba7d3f458832debc67f7bb85aef0fdde3b3ef3248234b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cohort certificate status SQL and diploma UI counts; wrong joins or filters could misstate issued vs pre-issue modules, but scope is narrow with targeted regression tests.
> 
> **Overview**
> Fixes the cohort **Diploma** table showing **0 / N** kern- and keuzemodules after a certificate is issued, because the numerator reused `newlyIssuable`, which correctly becomes false once issued competencies are canonical.
> 
> **Core:** `Cohort.Certificate.listStatus` now exposes per-module `completedCompetenciesInCertificate` (competencies on the cohort’s **issued** certificate only), via joins to the allocation’s issued certificate and `studentCompletedCompetency`.
> 
> **Web:** Shared `countDisplayModules` uses `newlyIssuable` when there is no issued certificate, and modules with `completedCompetenciesInCertificate > 0` when `certificate.issuedAt` is set. **Kernmodules** and **Keuzemodules** columns (sort + display) use this helper.
> 
> **Tests:** Vitest for the helper; core regression for issue → count persists, withdraw → counts reset and `newlyIssuable` returns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b52aa24828c2e1c9d8c453c242703343e0dfa2e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diploma overview module counts for cohorts with issued certificates.
  * Required and optional module counts now accurately reflect completed competencies associated with the active certificate.
  * Module availability updates correctly when certificates are issued or withdrawn.

* **Tests**
  * Added coverage for module counting, certificate states, and required versus optional modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->