### PR TITLE
[codex] Add cohort certificate visibility controls

### DIFF
--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/students-table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/students-table.tsx
@@ -12,6 +12,7 @@ import { Badge } from "~/app/(dashboard)/_components/badge";
 import Breakout, {
   BreakoutCenter,
 } from "~/app/(dashboard)/_components/breakout";
+import { CertificateVisibility } from "~/app/(dashboard)/_components/certificate-visibility";
 import {
   Checkbox,
   CheckboxField,
@@ -290,6 +291,16 @@ const columns = [
     cell: ({ getValue }) => {
       const issuedAt = getValue();
       return issuedAt ? dayjs(issuedAt).tz().format("DD-MM-YYYY HH:mm") : null;
+    },
+  }),
+  columnHelper.accessor("certificate.visibleFrom", {
+    id: "zichtbaarVanaf",
+    header: "Diploma zichtbaar vanaf",
+    cell: ({ getValue }) => {
+      const visibleFrom = getValue();
+      return visibleFrom ? (
+        <CertificateVisibility visibleFrom={visibleFrom} />
+      ) : null;
     },
   }),
   columnHelper.accessor("progressVisibleForStudentUpUntil", {

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/table-actions.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/table-actions.tsx
@@ -13,6 +13,7 @@ import { useFormStatus } from "react-dom";
 import { toast } from "sonner";
 import { downloadCertificatesAction } from "~/app/_actions/certificate/download-certificates-action";
 import { issueCertificatesInCohortAction } from "~/app/_actions/cohort/certificate/issue-certificates-in-cohort-action";
+import { updateCertificatesVisibleFromInCohortAction } from "~/app/_actions/cohort/certificate/update-certificates-visible-from-in-cohort-action";
 import { withdrawCertificatesInCohortAction } from "~/app/_actions/cohort/certificate/withdraw-certificates-in-cohort-action";
 import { completeAllCoreCompetenciesForStudentInCohortAction } from "~/app/_actions/cohort/student/complete-all-core-competencies-for-student-in-cohort-action";
 import { CONFIRMATION_WORD } from "~/app/_actions/cohort/student/confirm-word";
@@ -110,7 +111,7 @@ export function ActionButtons(props: Props) {
                 : undefined
           }
         >
-          <DropdownLabel>Diploma's uitgeven</DropdownLabel>
+          <DropdownLabel>Diploma&apos;s uitgeven</DropdownLabel>
         </DropdownItem>
         <DropdownItem
           onClick={() => setIsDialogOpen("remove")}
@@ -121,7 +122,18 @@ export function ActionButtons(props: Props) {
               : undefined
           }
         >
-          <DropdownLabel>Diploma's verwijderen</DropdownLabel>
+          <DropdownLabel>Diploma&apos;s verwijderen</DropdownLabel>
+        </DropdownItem>
+        <DropdownItem
+          onClick={() => setIsDialogOpen("visibility")}
+          disabled={!allRowsHaveIssuedCertificates}
+          title={
+            !allRowsHaveIssuedCertificates
+              ? "Niet alle cursisten hebben een uitgegeven diploma"
+              : undefined
+          }
+        >
+          <DropdownLabel>Zichtbaarheid aanpassen</DropdownLabel>
         </DropdownItem>
         <DropdownItem
           onClick={() => setIsDialogOpen("download")}
@@ -132,7 +144,7 @@ export function ActionButtons(props: Props) {
               : undefined
           }
         >
-          <DropdownLabel>Diploma's downloaden</DropdownLabel>
+          <DropdownLabel>Diploma&apos;s downloaden</DropdownLabel>
         </DropdownItem>
         <DropdownItem
           onClick={() => setIsDialogOpen("complete-core-modules")}
@@ -156,6 +168,12 @@ export function ActionButtons(props: Props) {
       <RemoveCertificateDialog
         {...props}
         isOpen={isDialogOpen === "remove"}
+        close={() => setIsDialogOpen(null)}
+      />
+
+      <UpdateCertificateVisibilityDialog
+        {...props}
+        isOpen={isDialogOpen === "visibility"}
         close={() => setIsDialogOpen(null)}
       />
 
@@ -198,6 +216,10 @@ function fullName(person: {
   return [person.firstName, person.lastNamePrefix, person.lastName]
     .filter(Boolean)
     .join(" ");
+}
+
+function isDefined<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
 }
 
 export function IssueCertificateDialog({
@@ -270,7 +292,7 @@ export function IssueCertificateDialog({
   return (
     <Alert open={isOpen} onClose={closeDialog} size="lg">
       <form action={execute}>
-        <AlertTitle>Diploma's uitgeven</AlertTitle>
+        <AlertTitle>Diploma&apos;s uitgeven</AlertTitle>
 
         <AlertBody>
           {blocked.length > 0 ? (
@@ -282,7 +304,7 @@ export function IssueCertificateDialog({
               </Text>
               <Text className="mt-1 !text-xs !text-amber-800 dark:!text-amber-300">
                 Voor deze cursisten zijn alle af te ronden competenties al via
-                eerdere diploma's behaald. Controleer hun inschrijving na
+                eerdere diploma&apos;s behaald. Controleer hun inschrijving na
                 samenvoegen — meestal komt dit voor na het samenvoegen van
                 profielen.
               </Text>
@@ -377,6 +399,124 @@ export function IssueCertificateDialog({
   );
 }
 
+function updateCertificatesVisibleFromInCohortErrorMessage(
+  error: InferUseActionHookReturn<
+    typeof updateCertificatesVisibleFromInCohortAction
+  >["result"],
+) {
+  if (error.serverError) {
+    return "Zichtbaarheid aanpassen is niet gelukt. Controleer of alle diploma's bij dit cohort horen en minder dan 72 uur geleden zijn uitgegeven.";
+  }
+
+  if (error.validationErrors) {
+    return "Een van de velden is niet correct ingevuld.";
+  }
+
+  return null;
+}
+
+export function UpdateCertificateVisibilityDialog({
+  rows,
+  isOpen,
+  cohortId,
+  close,
+  resetSelection,
+  defaultVisibleFrom,
+}: Props & {
+  isOpen: boolean;
+  close: () => void;
+}) {
+  const fallbackVisibleFrom =
+    rows.find((row) => row.certificate?.visibleFrom)?.certificate
+      ?.visibleFrom ??
+    defaultVisibleFrom ??
+    dayjs().toISOString();
+  const certificateIds = rows
+    .map((row) => row.certificate?.id)
+    .filter(isDefined);
+
+  const { execute, isPending, result } = useAction(
+    updateCertificatesVisibleFromInCohortAction.bind(
+      null,
+      cohortId,
+      certificateIds,
+    ),
+    {
+      onSuccess: () => {
+        close();
+        resetSelection();
+        toast.success("Zichtbaarheid aangepast");
+      },
+      onError: () => {
+        toast.error(DEFAULT_SERVER_ERROR_MESSAGE);
+      },
+    },
+  );
+
+  const errorMessage =
+    updateCertificatesVisibleFromInCohortErrorMessage(result);
+
+  return (
+    <Alert open={isOpen} onClose={close} size="lg">
+      <form action={execute}>
+        <AlertTitle>Zichtbaarheid aanpassen</AlertTitle>
+        <AlertBody>
+          <Text className="!text-sm">
+            {rows.length === 1
+              ? "Je past de zichtbaarheid aan voor 1 diploma."
+              : `Je past de zichtbaarheid aan voor ${rows.length} diploma's.`}
+          </Text>
+
+          <Text className="mt-2">
+            Dit bepaalt wanneer het diploma zichtbaar wordt in de online
+            omgeving van de cursist. De QR-code op het diploma blijft altijd
+            werken.
+          </Text>
+
+          <Text className="mt-2">
+            Zichtbaarheid kan tot 72 uur na uitgifte worden aangepast. De nieuwe
+            datum mag maximaal 72 uur na het uitgeven van het diploma liggen.
+          </Text>
+
+          <Field className="relative mt-4">
+            <Label>Zichtbaar vanaf</Label>
+            <SmartDatetimePicker
+              name="visibleFrom"
+              required={true}
+              defaultValue={dayjs(fallbackVisibleFrom).toDate()}
+            />
+          </Field>
+
+          <CheckboxField className="mt-4">
+            <Checkbox name="updateDefaultVisibleFrom" defaultChecked={true} />
+            <Label>
+              Ook gebruiken als standaard voor nieuwe diploma&apos;s
+            </Label>
+            <Description>
+              Nieuwe uitgiftes in dit cohort krijgen deze datum alvast
+              voorgesteld.
+            </Description>
+          </CheckboxField>
+
+          {errorMessage ? <ErrorMessage>{errorMessage}</ErrorMessage> : null}
+        </AlertBody>
+        <AlertActions>
+          <Button plain onClick={close}>
+            Annuleren
+          </Button>
+          <Button
+            type="submit"
+            disabled={isPending || certificateIds.length !== rows.length}
+          >
+            {isPending ? <Spinner className="text-white" /> : null}
+            Opslaan
+          </Button>
+        </AlertActions>
+      </form>
+    </Alert>
+  );
+}
+
 function withdrawCertificatesInCohortErrorMessage(
   error: InferUseActionHookReturn<
     typeof withdrawCertificatesInCohortAction
@@ -403,14 +543,12 @@ export function RemoveCertificateDialog({
   isOpen: boolean;
   close: () => void;
 }) {
+  const certificateIds = rows
+    .map((row) => row.certificate?.id)
+    .filter(isDefined);
+
   const { execute, isPending, result } = useAction(
-    withdrawCertificatesInCohortAction.bind(
-      null,
-      cohortId,
-      // biome-ignore lint/suspicious/noNonNullAssertedOptionalChain: all rows have a certificate, when action is executed
-      // biome-ignore lint/style/noNonNullAssertion: all rows have a certificate, when action is executed
-      rows.map((row) => row.certificate?.id!),
-    ),
+    withdrawCertificatesInCohortAction.bind(null, cohortId, certificateIds),
     {
       onSuccess: () => {
         close();
@@ -423,7 +561,7 @@ export function RemoveCertificateDialog({
 
   return (
     <Alert open={isOpen} onClose={close} size="md">
-      <AlertTitle>Diploma's verwijderen</AlertTitle>
+      <AlertTitle>Diploma&apos;s verwijderen</AlertTitle>
       <AlertDescription>
         Tot 72 uur na het uitgeven van een diploma kan deze nog verwijderd
         worden.{" "}
@@ -431,7 +569,7 @@ export function RemoveCertificateDialog({
           Het verwijderen maakt het reeds uitgegeven diploma onbruikbaar!
         </strong>{" "}
         <br />
-        Weet je zeker dat je de diploma's wilt verwijderen?
+        Weet je zeker dat je de diploma&apos;s wilt verwijderen?
       </AlertDescription>
       {errorMessage ? <ErrorMessage>{errorMessage}</ErrorMessage> : null}
 
@@ -439,7 +577,11 @@ export function RemoveCertificateDialog({
         <Button plain onClick={close}>
           Annuleren
         </Button>
-        <Button color="red" disabled={isPending} onClick={() => execute()}>
+        <Button
+          color="red"
+          disabled={isPending || certificateIds.length !== rows.length}
+          onClick={() => execute()}
+        >
           {isPending ? <Spinner className="text-white" /> : null} Verwijderen
         </Button>
       </AlertActions>
@@ -536,14 +678,12 @@ function DownloadCertificatesDialog({
     close();
     reset();
   };
+  const certificateHandles = rows
+    .map((row) => row.certificate?.handle)
+    .filter(isDefined);
 
   const { execute, input, reset, result } = useAction(
-    downloadCertificatesAction.bind(
-      null,
-      // biome-ignore lint/suspicious/noNonNullAssertedOptionalChain: all rows have a certificate, when action is executed
-      // biome-ignore lint/style/noNonNullAssertion: all rows have a certificate, when action is executed
-      rows.map((row) => row.certificate?.handle!),
-    ),
+    downloadCertificatesAction.bind(null, certificateHandles),
     {
       onSuccess: (result) => {
         resetSelection();
@@ -568,7 +708,7 @@ function DownloadCertificatesDialog({
 
   return (
     <Alert open={isOpen} onClose={closeDialog} size="lg">
-      <AlertTitle>Diploma's downloaden</AlertTitle>
+      <AlertTitle>Diploma&apos;s downloaden</AlertTitle>
       {downloadUrl ? (
         <AlertDescription className="space-y-3">
           <p className="font-medium text-green-600">
@@ -588,7 +728,7 @@ function DownloadCertificatesDialog({
         </AlertDescription>
       ) : (
         <AlertDescription>
-          Download een PDF-bestand met de diploma's van de geselecteerde
+          Download een PDF-bestand met de diploma&apos;s van de geselecteerde
           cursisten.
         </AlertDescription>
       )}
@@ -616,7 +756,7 @@ function DownloadCertificatesDialog({
                 <Fieldset className="mt-6">
                   <Legend>Sortering</Legend>
                   <Text>
-                    Hoe moeten de diploma's in de PDF gesorteerd zijn?
+                    Hoe moeten de diploma&apos;s in de PDF gesorteerd zijn?
                   </Text>
                   <RadioGroup name="sort" defaultValue={getInputValue("sort")}>
                     <RadioField>
@@ -628,8 +768,9 @@ function DownloadCertificatesDialog({
                       <Radio value="instructor" />
                       <Label>Naam instructeur</Label>
                       <Description>
-                        Sortering op voornaam instructeur, A tot Z. Diploma's
-                        zonder instructeur worden als laatste getoond.
+                        Sortering op voornaam instructeur, A tot Z.
+                        Diploma&apos;s zonder instructeur worden als laatste
+                        getoond.
                       </Description>
                     </RadioField>
                   </RadioGroup>
@@ -645,7 +786,7 @@ function DownloadCertificatesDialog({
                     />
                     <Label>
                       Print ook de modules op het diploma die al via eerdere
-                      diploma's voor deze opleiding zijn behaald.
+                      diploma&apos;s voor deze opleiding zijn behaald.
                     </Label>
                   </CheckboxField>
                 </Fieldset>

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/[student-allocation]/_components/allocation-card.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/[student-allocation]/_components/allocation-card.tsx
@@ -2,6 +2,7 @@ import { ArrowTopRightOnSquareIcon } from "@heroicons/react/16/solid";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { Badge } from "~/app/(dashboard)/_components/badge";
+import { CertificateVisibility } from "~/app/(dashboard)/_components/certificate-visibility";
 import {
   DescriptionDetails,
   DescriptionList,
@@ -241,6 +242,17 @@ async function AllocationCardContent(props: AllocationCardProps) {
         </div>
       </DescriptionDetails>
 
+      <DescriptionTerm>Diploma zichtbaar vanaf</DescriptionTerm>
+      <DescriptionDetails>
+        {allocation.certificate ? (
+          <CertificateVisibility
+            visibleFrom={allocation.certificate.visibleFrom}
+          />
+        ) : (
+          <span className="text-zinc-500">Nog geen diploma</span>
+        )}
+      </DescriptionDetails>
+
       <DescriptionTerm>Tags</DescriptionTerm>
       <DescriptionDetails>
         <Suspense
@@ -292,6 +304,11 @@ export function AllocationCardFallback() {
       </DescriptionDetails>
 
       <DescriptionTerm>Voortgang zichtbaar tot</DescriptionTerm>
+      <DescriptionDetails>
+        <span className="bg-gray-200 rounded w-36 h-4 animate-pulse" />
+      </DescriptionDetails>
+
+      <DescriptionTerm>Diploma zichtbaar vanaf</DescriptionTerm>
       <DescriptionDetails>
         <span className="bg-gray-200 rounded w-36 h-4 animate-pulse" />
       </DescriptionDetails>

--- a/apps/web/src/app/(dashboard)/_components/certificate-visibility.tsx
+++ b/apps/web/src/app/(dashboard)/_components/certificate-visibility.tsx
@@ -1,0 +1,26 @@
+import { Badge } from "~/app/(dashboard)/_components/badge";
+import dayjs from "~/lib/dayjs";
+
+export function CertificateVisibility({
+  visibleFrom,
+}: {
+  visibleFrom?: string | null;
+}) {
+  if (!visibleFrom) {
+    return <span className="text-zinc-500">Niet ingesteld</span>;
+  }
+
+  const visibleFromDate = dayjs(visibleFrom).tz();
+  const isHidden = visibleFromDate.isAfter(dayjs());
+
+  return (
+    <div className="flex flex-col items-start gap-1">
+      <span className="whitespace-nowrap tabular-nums">
+        {visibleFromDate.format("DD-MM-YYYY HH:mm")}
+      </span>
+      <Badge color={isHidden ? "amber" : "green"}>
+        {isHidden ? "Nog verborgen" : "Zichtbaar"} - {visibleFromDate.fromNow()}
+      </Badge>
+    </div>
+  );
+}

--- a/apps/web/src/app/_actions/cohort/certificate/update-certificates-visible-from-in-cohort-action.ts
+++ b/apps/web/src/app/_actions/cohort/certificate/update-certificates-visible-from-in-cohort-action.ts
@@ -1,0 +1,46 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { zfd } from "zod-form-data";
+import { dateInputToIsoString } from "~/app/_actions/dates";
+import { actionClientWithMeta } from "~/app/_actions/safe-action";
+import { updateCertificatesVisibleFromInCohort } from "~/lib/nwd";
+
+const updateCertificatesVisibleFromInCohortSchema = zfd.formData({
+  visibleFrom: zfd.text(dateInputToIsoString(z.string().datetime())),
+  updateDefaultVisibleFrom: zfd.checkbox().optional(),
+});
+
+const updateCertificatesVisibleFromInCohortArgsSchema: [
+  cohortId: z.ZodString,
+  certificateIds: z.ZodArray<z.ZodString>,
+] = [z.string().uuid(), z.array(z.string().uuid()).min(1)];
+
+export const updateCertificatesVisibleFromInCohortAction = actionClientWithMeta
+  .metadata({
+    name: "update-certificates-visible-from-in-cohort",
+  })
+  .inputSchema(updateCertificatesVisibleFromInCohortSchema)
+  .bindArgsSchemas(updateCertificatesVisibleFromInCohortArgsSchema)
+  .action(
+    async ({
+      parsedInput: { visibleFrom, updateDefaultVisibleFrom },
+      bindArgsParsedInputs: [cohortId, certificateIds],
+    }) => {
+      await updateCertificatesVisibleFromInCohort({
+        cohortId,
+        certificateIds,
+        visibleFrom,
+        updateDefaultVisibleFrom: updateDefaultVisibleFrom ?? false,
+      });
+
+      revalidatePath("/locatie/[location]/diplomas", "page");
+      revalidatePath("/locatie/[location]/cohorten/[cohort]/diplomas", "page");
+      revalidatePath(
+        "/locatie/[location]/cohorten/[cohort]/[student-allocation]",
+        "page",
+      );
+      revalidatePath("/profiel/[handle]", "page");
+    },
+  );

--- a/apps/web/src/lib/nwd.ts
+++ b/apps/web/src/lib/nwd.ts
@@ -3149,6 +3149,67 @@ export const updateDefaultCertificateVisibleFromDate = async ({
     });
   });
 };
+
+export const updateCertificatesVisibleFromInCohort = async ({
+  cohortId,
+  certificateIds,
+  visibleFrom,
+  updateDefaultVisibleFrom,
+}: {
+  cohortId: string;
+  certificateIds: string[];
+  visibleFrom: string;
+  updateDefaultVisibleFrom?: boolean;
+}) => {
+  return makeRequest(async () => {
+    return withTransaction(async () => {
+      const [authUser, cohort] = await Promise.all([
+        getUserOrThrow(),
+        Cohort.byIdOrHandle({ id: cohortId }),
+      ]);
+
+      if (!cohort) {
+        throw new Error("Cohort not found");
+      }
+
+      const primaryPerson = await getPrimaryPerson(authUser);
+
+      const [isLocationAdmin, privileges] = await Promise.all([
+        isActiveActorTypeInLocation({
+          actorType: ["location_admin"],
+          locationId: cohort.locationId,
+          personId: primaryPerson.id,
+        }).catch(() => false),
+        Cohort.Allocation.listPrivilegesForPerson({
+          cohortId,
+          personId: primaryPerson.id,
+        }),
+      ]);
+
+      if (
+        !isLocationAdmin &&
+        !privileges.includes("manage_cohort_certificate")
+      ) {
+        throw new Error("Unauthorized");
+      }
+
+      const result = await Cohort.Certificate.updateVisibleFrom({
+        cohortId,
+        certificateIds,
+        visibleFrom,
+      });
+
+      if (updateDefaultVisibleFrom) {
+        await Cohort.setDefaultVisibleFromDate({
+          cohortId,
+          visibleFromDate: visibleFrom,
+        });
+      }
+
+      return result;
+    });
+  });
+};
 export const updateCohortDetails = async ({
   cohortId,
   label,

--- a/packages/core/src/models/certificate/visibility.test.ts
+++ b/packages/core/src/models/certificate/visibility.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert";
+import test from "node:test";
+import dayjs from "dayjs";
+import {
+  assertCertificateVisibilityStillMutable,
+  assertVisibleFromWithinAllowedDelay,
+} from "./visibility.ts";
+
+test("certificate visibility can be delayed by at most 72 hours", () => {
+  const issuedAt = dayjs("2026-07-02T12:00:00.000Z");
+
+  assert.doesNotThrow(() =>
+    assertVisibleFromWithinAllowedDelay({
+      issuedAt: issuedAt.toISOString(),
+      visibleFrom: issuedAt.add(72, "hour").toISOString(),
+    }),
+  );
+
+  assert.throws(
+    () =>
+      assertVisibleFromWithinAllowedDelay({
+        issuedAt: issuedAt.toISOString(),
+        visibleFrom: issuedAt
+          .add(72, "hour")
+          .add(1, "millisecond")
+          .toISOString(),
+      }),
+    /at most 72 hours/,
+  );
+});
+
+test("certificate visibility can only be changed within 72 hours after issuance", () => {
+  assert.doesNotThrow(() =>
+    assertCertificateVisibilityStillMutable({
+      issuedAt: dayjs().subtract(71, "hour").toISOString(),
+    }),
+  );
+
+  assert.throws(
+    () =>
+      assertCertificateVisibilityStillMutable({
+        issuedAt: dayjs().subtract(73, "hour").toISOString(),
+      }),
+    /only be changed within 72 hours/,
+  );
+});

--- a/packages/core/src/models/certificate/visibility.ts
+++ b/packages/core/src/models/certificate/visibility.ts
@@ -1,0 +1,39 @@
+import dayjs from "dayjs";
+
+export const CERTIFICATE_VISIBILITY_DELAY_HOURS = 72;
+
+export function assertVisibleFromWithinAllowedDelay({
+  issuedAt,
+  visibleFrom,
+}: {
+  issuedAt: string;
+  visibleFrom: string;
+}) {
+  const latestVisibleFrom = dayjs(issuedAt).add(
+    CERTIFICATE_VISIBILITY_DELAY_HOURS,
+    "hour",
+  );
+
+  if (dayjs(visibleFrom).isAfter(latestVisibleFrom)) {
+    throw new Error(
+      `Certificate visibility can be delayed by at most ${CERTIFICATE_VISIBILITY_DELAY_HOURS} hours after issuance`,
+    );
+  }
+}
+
+export function assertCertificateVisibilityStillMutable({
+  issuedAt,
+}: {
+  issuedAt: string;
+}) {
+  const mutableUntil = dayjs(issuedAt).add(
+    CERTIFICATE_VISIBILITY_DELAY_HOURS,
+    "hour",
+  );
+
+  if (dayjs().isAfter(mutableUntil)) {
+    throw new Error(
+      `Certificate visibility can only be changed within ${CERTIFICATE_VISIBILITY_DELAY_HOURS} hours after issuance`,
+    );
+  }
+}

--- a/packages/core/src/models/cohort/certificate.ts
+++ b/packages/core/src/models/cohort/certificate.ts
@@ -4,6 +4,7 @@ import {
   asc,
   eq,
   getTableColumns,
+  inArray,
   isNotNull,
   isNull,
   sql,
@@ -11,7 +12,17 @@ import {
 import { alias } from "drizzle-orm/pg-core";
 import { z } from "zod";
 import { useQuery } from "../../contexts/index.ts";
-import { uuidSchema, withZod, wrapQuery } from "../../utils/index.ts";
+import {
+  dateTimeSchema,
+  uuidSchema,
+  withZod,
+  wrapCommand,
+  wrapQuery,
+} from "../../utils/index.ts";
+import {
+  assertCertificateVisibilityStillMutable,
+  assertVisibleFromWithinAllowedDelay,
+} from "../certificate/visibility.ts";
 
 // TODO: There will come a day that I will simplify this query
 export const listStatus = wrapQuery(
@@ -334,6 +345,79 @@ export const listStatus = wrapQuery(
             : null,
         };
       });
+    },
+  ),
+);
+
+export const updateVisibleFrom = wrapCommand(
+  "cohort.certificate.updateVisibleFrom",
+  withZod(
+    z.object({
+      cohortId: uuidSchema,
+      certificateIds: z.array(uuidSchema).min(1),
+      visibleFrom: dateTimeSchema,
+    }),
+    z.object({
+      updatedCount: z.number().int().nonnegative(),
+    }),
+    async (input) => {
+      const query = useQuery();
+      const certificateIds = Array.from(new Set(input.certificateIds));
+
+      const certificates = await query
+        .select({
+          id: s.certificate.id,
+          issuedAt: s.certificate.issuedAt,
+        })
+        .from(s.certificate)
+        .innerJoin(
+          s.cohortAllocation,
+          eq(s.cohortAllocation.id, s.certificate.cohortAllocationId),
+        )
+        .where(
+          and(
+            inArray(s.certificate.id, certificateIds),
+            eq(s.cohortAllocation.cohortId, input.cohortId),
+            isNull(s.cohortAllocation.deletedAt),
+            isNull(s.certificate.deletedAt),
+            isNotNull(s.certificate.issuedAt),
+          ),
+        );
+
+      if (certificates.length !== certificateIds.length) {
+        throw new Error("Invalid certificate selection for cohort");
+      }
+
+      for (const certificate of certificates) {
+        if (!certificate.issuedAt) {
+          throw new Error("Certificate is not issued");
+        }
+
+        assertCertificateVisibilityStillMutable({
+          issuedAt: certificate.issuedAt,
+        });
+        assertVisibleFromWithinAllowedDelay({
+          issuedAt: certificate.issuedAt,
+          visibleFrom: input.visibleFrom,
+        });
+      }
+
+      const updated = await query
+        .update(s.certificate)
+        .set({ visibleFrom: input.visibleFrom })
+        .where(
+          and(
+            inArray(s.certificate.id, certificateIds),
+            isNull(s.certificate.deletedAt),
+          ),
+        )
+        .returning({ id: s.certificate.id });
+
+      if (updated.length !== certificateIds.length) {
+        throw new Error("Failed to update certificate visibility");
+      }
+
+      return { updatedCount: updated.length };
     },
   ),
 );

--- a/packages/core/src/models/student/certificate.ts
+++ b/packages/core/src/models/student/certificate.ts
@@ -3,6 +3,7 @@ import { and, eq, inArray, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { useQuery } from "../../contexts/index.ts";
 import {
+  dateTimeSchema,
   generateCertificateID,
   singleOrArray,
   successfulCreateResponse,
@@ -10,6 +11,7 @@ import {
   withZod,
   wrapCommand,
 } from "../../utils/index.ts";
+import { assertVisibleFromWithinAllowedDelay } from "../certificate/visibility.ts";
 import { insertSchema } from "./certificate.schema.ts";
 
 export const startCertificate = wrapCommand(
@@ -146,21 +148,24 @@ export const completeCompetency = wrapCommand(
 export const completeCertificate = wrapCommand(
   "student.certificate.complete",
   withZod(
-    insertSchema
-      .pick({
-        visibleFrom: true,
-      })
-      .extend({
-        certificateId: uuidSchema,
-      }),
+    z.object({
+      certificateId: uuidSchema,
+      visibleFrom: dateTimeSchema,
+    }),
     z.void(),
     async (input) => {
       const query = useQuery();
+      const issuedAt = new Date().toISOString();
+
+      assertVisibleFromWithinAllowedDelay({
+        issuedAt,
+        visibleFrom: input.visibleFrom,
+      });
 
       const [res] = await query
         .update(s.certificate)
         .set({
-          issuedAt: new Date().toISOString(),
+          issuedAt,
           visibleFrom: input.visibleFrom,
         })
         .where(eq(s.certificate.id, input.certificateId))

--- a/packages/core/src/models/user/person.test.ts
+++ b/packages/core/src/models/user/person.test.ts
@@ -136,6 +136,73 @@ async function createCurriculumFixture(prefix: string) {
   };
 }
 
+async function createIssuedCohortCertificateFixture(prefix: string) {
+  const location = await Location.create({
+    handle: `${prefix}-location`,
+    name: `${prefix} Location`,
+  });
+
+  const fixture = await createCurriculumFixture(prefix);
+
+  const { id: personId } = await User.Person.getOrCreate({
+    firstName: `${prefix} Student`,
+    lastName: "Certificate",
+  });
+  await User.Person.createLocationLink({
+    personId,
+    locationId: location.id,
+  });
+
+  const { id: studentCurriculumId } = await Student.Curriculum.start({
+    personId,
+    curriculumId: fixture.curriculumId,
+    gearTypeId: fixture.gearTypeId,
+  });
+
+  const { id: cohortId } = await Cohort.create({
+    label: `${prefix} Cohort`,
+    handle: `${prefix}-cohort`,
+    locationId: location.id,
+    accessStartTime: dayjs().subtract(1, "day").toISOString(),
+    accessEndTime: dayjs().add(30, "day").toISOString(),
+  });
+
+  const { id: studentActorId } = await User.Actor.upsert({
+    personId,
+    locationId: location.id,
+    type: "student",
+  });
+  const { id: cohortAllocationId } = await Cohort.Allocation.create({
+    cohortId,
+    actorId: studentActorId,
+    studentCurriculumId,
+  });
+
+  const { id: certificateId } = await Student.Certificate.startCertificate({
+    locationId: location.id,
+    studentCurriculumId,
+  });
+  await Student.Certificate.completeCompetency({
+    certificateId,
+    studentCurriculumId,
+    competencyId: fixture.curriculumCompetency1Id,
+  });
+  await Student.Certificate.completeCertificate({
+    certificateId,
+    visibleFrom: dayjs().toISOString(),
+  });
+  await Certificate.assignToCohortAllocation({
+    certificateId,
+    cohortAllocationId,
+  });
+
+  return {
+    certificateId,
+    cohortId,
+    locationId: location.id,
+  };
+}
+
 test("student.certificate.completeCompetency prevents duplicate completion in normal flow", () =>
   withTestTransaction(async () => {
     const location = await Location.create({
@@ -185,6 +252,48 @@ test("student.certificate.completeCompetency prevents duplicate completion in no
         competencyId: curriculumCompetency1Id,
       }),
       /already completed for this student curriculum/,
+    );
+  }));
+
+test("student.certificate.completeCertificate rejects visibility more than 72 hours after issuance", () =>
+  withTestTransaction(async () => {
+    const location = await Location.create({
+      handle: "visibility-delay-location",
+      name: "Visibility Delay Location",
+    });
+
+    const { id: personId } = await User.Person.getOrCreate({
+      firstName: "Visibility",
+      lastName: "Delay",
+    });
+
+    const { curriculumId, gearTypeId, curriculumCompetency1Id } =
+      await createCurriculumFixture("visibility-delay");
+
+    const { id: studentCurriculumId } = await Student.Curriculum.start({
+      personId,
+      curriculumId,
+      gearTypeId,
+    });
+
+    const { id: certificateId } = await Student.Certificate.startCertificate({
+      locationId: location.id,
+      studentCurriculumId,
+    });
+
+    await Student.Certificate.completeCompetency({
+      certificateId,
+      studentCurriculumId,
+      competencyId: curriculumCompetency1Id,
+    });
+
+    await assert.rejects(
+      () =>
+        Student.Certificate.completeCertificate({
+          certificateId,
+          visibleFrom: dayjs().add(73, "hour").toISOString(),
+        }),
+      /at most 72 hours/,
     );
   }));
 
@@ -2039,6 +2148,106 @@ test("cohort.certificate.listStatus newlyIssuable=false for all modules when ful
         `Module ${module.module.id} should be fully redundant — every comp already canonical`,
       );
     }
+  }));
+
+test("cohort.certificate.updateVisibleFrom updates issued certificates in the cohort", () =>
+  withTestTransaction(async () => {
+    const query = useQuery();
+    const { certificateId, cohortId } =
+      await createIssuedCohortCertificateFixture("visible-update");
+    const visibleFrom = dayjs().add(2, "hour").toISOString();
+
+    const result = await Cohort.Certificate.updateVisibleFrom({
+      cohortId,
+      certificateIds: [certificateId],
+      visibleFrom,
+    });
+
+    assert.equal(result.updatedCount, 1);
+
+    const [certificate] = await query
+      .select({ visibleFrom: s.certificate.visibleFrom })
+      .from(s.certificate)
+      .where(eq(s.certificate.id, certificateId));
+
+    assert.equal(certificate?.visibleFrom, visibleFrom);
+  }));
+
+test("cohort.certificate.updateVisibleFrom rejects certificates outside the cohort", () =>
+  withTestTransaction(async () => {
+    const query = useQuery();
+    const { certificateId } = await createIssuedCohortCertificateFixture(
+      "visible-cross-source",
+    );
+    const other = await createIssuedCohortCertificateFixture(
+      "visible-cross-target",
+    );
+
+    const before = await query
+      .select({ visibleFrom: s.certificate.visibleFrom })
+      .from(s.certificate)
+      .where(eq(s.certificate.id, certificateId))
+      .then(([row]) => row?.visibleFrom);
+
+    await assert.rejects(
+      () =>
+        Cohort.Certificate.updateVisibleFrom({
+          cohortId: other.cohortId,
+          certificateIds: [certificateId],
+          visibleFrom: dayjs().add(2, "hour").toISOString(),
+        }),
+      /Invalid certificate selection/,
+    );
+
+    const after = await query
+      .select({ visibleFrom: s.certificate.visibleFrom })
+      .from(s.certificate)
+      .where(eq(s.certificate.id, certificateId))
+      .then(([row]) => row?.visibleFrom);
+
+    assert.equal(after, before);
+  }));
+
+test("cohort.certificate.updateVisibleFrom enforces the 72-hour visibility window", () =>
+  withTestTransaction(async () => {
+    const { certificateId, cohortId } =
+      await createIssuedCohortCertificateFixture("visible-window");
+
+    await assert.rejects(
+      () =>
+        Cohort.Certificate.updateVisibleFrom({
+          cohortId,
+          certificateIds: [certificateId],
+          visibleFrom: dayjs().add(73, "hour").toISOString(),
+        }),
+      /at most 72 hours/,
+    );
+  }));
+
+test("cohort.certificate.updateVisibleFrom rejects certificates issued more than 72 hours ago", () =>
+  withTestTransaction(async () => {
+    const query = useQuery();
+    const { certificateId, cohortId } =
+      await createIssuedCohortCertificateFixture("visible-old");
+    const oldIssuedAt = dayjs().subtract(4, "day").toISOString();
+
+    await query
+      .update(s.certificate)
+      .set({
+        issuedAt: oldIssuedAt,
+        visibleFrom: oldIssuedAt,
+      })
+      .where(eq(s.certificate.id, certificateId));
+
+    await assert.rejects(
+      () =>
+        Cohort.Certificate.updateVisibleFrom({
+          cohortId,
+          certificateIds: [certificateId],
+          visibleFrom: dayjs().toISOString(),
+        }),
+      /only be changed within 72 hours/,
+    );
   }));
 
 // REGRESSION (Bugbot review on PR #461 — round 4): listCompletedCompetenciesById


### PR DESCRIPTION
## Summary

Adds visibility timing controls for issued cohort certificates, so operators can see when diplomas become visible and adjust that timestamp in bulk after issuance.

## What changed

- Shows diploma visibility status in the cohort diploma table and individual allocation page.
- Adds a shared `CertificateVisibility` component with absolute time and relative status.
- Adds a bulk `Zichtbaarheid aanpassen` action for selected issued diplomas.
- Adds a server action and `nwd` service wrapper for updating selected certificate visibility.
- Adds core guardrails that enforce:
  - selected certificates must belong to the cohort
  - certificates must already be issued
  - visibility can only be adjusted within 72 hours after issuance
  - the chosen visible-from timestamp may be at most 72 hours after issuance
- Applies the same max 72-hour delay guard when initially completing a certificate.
- Adds unit and integration-style tests around the new visibility rules.

## Validation

- `corepack pnpm exec biome check ...` on touched files passed.
- `corepack pnpm --filter @nawadi/core typecheck` passed.
- `corepack pnpm --filter @nawadi/web exec eslint ...` on touched files passed with existing warnings only.
- `corepack pnpm exec tsx --tsconfig ../../tsconfig.source-runtime.json --test --test-concurrency=1 ./src/models/certificate/visibility.test.ts` passed.

## Notes

- Direct web `tsc --noEmit` currently fails before reaching this feature because static asset imports elsewhere are unresolved in this local environment.
- The new DB-backed integration tests could not be executed locally because `PGURI` / local Postgres points at a different schema (`relation "location" does not exist`). I did not reset that database because it contains unrelated schemas.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/buchungapp/codesmith/nationaal-watersportdiploma/pr/481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785618537&installation_id=137554715&pr_number=481&repository=buchungapp%2Fnationaal-watersportdiploma&return_to=https%3A%2F%2Fgithub.com%2Fbuchungapp%2Fnationaal-watersportdiploma%2Fpull%2F481&signature=5ac124b412a959843259ff8f31bef7d5296b4ce370b34e5602895e0768f3d5e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when students see diplomas online and who can alter that timing; rules are constrained but affect certificate visibility behavior in production.
> 
> **Overview**
> Operators can see **when issued diplomas become visible** in the student online environment and **bulk-adjust** `visibleFrom` for selected issued certificates in a cohort.
> 
> The dashboard adds a **Diploma zichtbaar vanaf** column and allocation detail field via a shared `CertificateVisibility` component (timestamp plus hidden/visible status). A new **Zichtbaarheid aanpassen** bulk action opens a dialog that can optionally update the cohort default for future issuances.
> 
> Backend support includes a server action, `nwd` wrapper with `manage_cohort_certificate` auth, and `Cohort.Certificate.updateVisibleFrom` with cohort membership and issued-certificate checks. Shared **72-hour rules** apply: visibility may be delayed at most 72 hours after issuance, and changes are only allowed within 72 hours after issue—enforced on initial `completeCertificate` as well. Bulk remove/download actions now filter undefined certificate IDs instead of using non-null assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07c2d20b4946dcb04dbd1dd9de8c7b7ce418693b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->