### PR TITLE
Explicit acting profile for staff dashboards (phases 1-2)

### DIFF
--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/_components/dashboard-toggle-wrapper.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/_components/dashboard-toggle-wrapper.tsx
@@ -11,10 +11,9 @@ async function DecideDashboardToggle({
   const person = await getPersonByHandle(personHandle);
   const rolesForPerson = await listActiveActorTypesForPerson(person.id);
 
-  const hasInstructorView =
-    (["instructor", "pvb_beoordelaar", "location_admin"] as const).some(
-      (role) => rolesForPerson.includes(role),
-    ) && person.isPrimary;
+  const hasInstructorView = (
+    ["instructor", "pvb_beoordelaar", "location_admin"] as const
+  ).some((role) => rolesForPerson.includes(role));
 
   if (hasInstructorView) {
     return <DashboardToggle />;

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/_lib/require-instructor-person.ts
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/_lib/require-instructor-person.ts
@@ -8,10 +8,9 @@ import {
 
 // Role gate for instructor-only features under /profiel/[handle]/*.
 //
-// Matches the hasInstructorView logic used on the main profiel page:
-//   - person must be one of the user's actor_types: instructor,
-//     pvb_beoordelaar, or location_admin
-//   - AND person.isPrimary must be true
+// The gate is: the handle resolves to a person owned by the current
+// user (ownership enforced by getPersonByHandle) with an active
+// instructor-ish role — instructor, pvb_beoordelaar, or location_admin.
 //
 // Returns the loaded user + person so pages can reuse them without
 // a second roundtrip. Calls notFound() on any failure — we don't
@@ -23,9 +22,9 @@ export type InstructorPersonContext = {
 };
 
 /**
- * Require that the current authenticated user is viewing their own
- * primary person, and that person has an active instructor-ish role.
- * Any failure → notFound().
+ * Require that the handle resolves to a person owned by the current
+ * user (ownership enforced by getPersonByHandle) with an active
+ * instructor-ish role. Any failure → notFound().
  */
 export async function requireInstructorPerson(
   handle: string,
@@ -41,10 +40,9 @@ export async function requireInstructorPerson(
   }
 
   const roles = await listActiveActorTypesForPerson(person.id);
-  const isActiveInstructor =
-    (["instructor", "pvb_beoordelaar", "location_admin"] as const).some(
-      (role) => roles.includes(role),
-    ) && person.isPrimary;
+  const isActiveInstructor = (
+    ["instructor", "pvb_beoordelaar", "location_admin"] as const
+  ).some((role) => roles.includes(role));
 
   if (!isActiveInstructor) {
     notFound();

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/page.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/page.tsx
@@ -85,10 +85,9 @@ async function DecideDashboard({
   const [person, params] = await Promise.all([personPromise, searchParams]);
   const rolesForPerson = await listActiveActorTypesForPerson(person.id);
 
-  const hasInstructorView =
-    (["instructor", "pvb_beoordelaar", "location_admin"] as const).some(
-      (role) => rolesForPerson.includes(role),
-    ) && person.isPrimary;
+  const hasInstructorView = (
+    ["instructor", "pvb_beoordelaar", "location_admin"] as const
+  ).some((role) => rolesForPerson.includes(role));
 
   // Parse the view from search params
   const view = (params.view as DashboardView) || "instructor";

--- a/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/pvb-aanvraag/[pvbHandle]/page.tsx
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/[handle]/pvb-aanvraag/[pvbHandle]/page.tsx
@@ -3,10 +3,8 @@ import { Heading, Subheading } from "~/app/(dashboard)/_components/heading";
 import { RouterPreviousButton } from "~/app/(dashboard)/_components/navigation";
 import {
   getPersonByHandle,
-  getPrimaryPerson,
   getPvbBeoordelingsCriteria,
   getPvbToetsdocumenten,
-  getUserOrThrow,
   retrievePvbAanvraagByHandle,
 } from "~/lib/nwd";
 import { AanvraagCard } from "./_components/aanvraag-card";
@@ -44,20 +42,14 @@ export default async function Page(props: {
 }) {
   const params = await props.params;
 
-  // Get current user, person from handle, and PVB aanvraag in parallel
-  const [primaryPerson, person, aanvraag] = await Promise.all([
-    getUserOrThrow().then((user) => getPrimaryPerson(user)),
+  // Get person from handle and PVB aanvraag in parallel
+  const [person, aanvraag] = await Promise.all([
     getPersonByHandle(params.handle),
     retrievePvbAanvraagByHandle(params.pvbHandle),
   ]);
 
-  // Check if the user is viewing their own profile
-  if (primaryPerson.id !== person.id) {
-    notFound();
-  }
-
   // Determine user's role
-  const role = await getUserRole(primaryPerson.id, aanvraag);
+  const role = await getUserRole(person.id, aanvraag);
 
   if (!role) {
     notFound();
@@ -209,7 +201,7 @@ export default async function Page(props: {
               <ToetsdocumentenCard
                 aanvraag={aanvraag}
                 role={role}
-                personId={primaryPerson.id}
+                personId={person.id}
               />
             </div>
           </div>

--- a/apps/web/src/app/(dashboard)/(management)/@sidebar/locatie/[location]/_components/acting-profile-switcher-client.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/@sidebar/locatie/[location]/_components/acting-profile-switcher-client.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useAction } from "next-safe-action/hooks";
+import { toast } from "sonner";
+import { setActingProfileForLocationAction } from "~/app/_actions/location/set-acting-profile-action";
+import { DEFAULT_SERVER_ERROR_MESSAGE } from "~/app/_actions/utils";
+import { Avatar } from "../../../../../_components/avatar";
+import {
+  Dropdown,
+  DropdownButton,
+  DropdownItem,
+  DropdownLabel,
+  DropdownMenu,
+} from "../../../../../_components/dropdown";
+import { SidebarItem, SidebarLabel } from "../../../../../_components/sidebar";
+
+type SwitchOption = {
+  personId: string;
+  fullName: string;
+  initials: string;
+  roleLabels: string[];
+};
+
+export function ActingProfileSwitcherDropdown({
+  locationId,
+  actingName,
+  actingRoleLabels,
+  actingInitials,
+  options,
+}: {
+  locationId: string;
+  actingName: string;
+  actingRoleLabels: string[];
+  actingInitials: string;
+  options: SwitchOption[];
+}) {
+  const router = useRouter();
+
+  const { execute, status } = useAction(setActingProfileForLocationAction, {
+    onSuccess: () => {
+      router.refresh();
+    },
+    onError: ({ error }) => {
+      toast.error(error.serverError ?? DEFAULT_SERVER_ERROR_MESSAGE);
+    },
+  });
+
+  const pending = status === "executing";
+
+  return (
+    <Dropdown>
+      <DropdownButton
+        as={SidebarItem}
+        className="lg:mb-2.5"
+        title={`Handelt als ${actingName}`}
+        disabled={pending}
+      >
+        <Avatar className="size-6 shrink-0" initials={actingInitials} />
+        <SidebarLabel>
+          <span className="block text-xs/4 text-zinc-500 dark:text-zinc-400">
+            Handelt als
+          </span>
+          <span className="block truncate">{actingName}</span>
+          {actingRoleLabels.length > 0 ? (
+            <span className="block truncate text-xs/4 text-zinc-500 dark:text-zinc-400">
+              {actingRoleLabels.join(", ")}
+            </span>
+          ) : null}
+        </SidebarLabel>
+      </DropdownButton>
+
+      <DropdownMenu className="min-w-80 lg:min-w-64" anchor="bottom start">
+        {options.map((option) => (
+          <DropdownItem
+            key={option.personId}
+            onClick={() => execute({ locationId, personId: option.personId })}
+          >
+            <Avatar
+              slot="icon"
+              initials={option.initials}
+              className="bg-purple-500 text-white"
+            />
+            <DropdownLabel>
+              {option.fullName}
+              {option.roleLabels.length > 0 ? (
+                <span className="text-zinc-500">
+                  {" "}
+                  · {option.roleLabels.join(", ")}
+                </span>
+              ) : null}
+            </DropdownLabel>
+          </DropdownItem>
+        ))}
+      </DropdownMenu>
+    </Dropdown>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/@sidebar/locatie/[location]/_components/acting-profile-switcher.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/@sidebar/locatie/[location]/_components/acting-profile-switcher.tsx
@@ -1,0 +1,136 @@
+import { UserIcon } from "@heroicons/react/16/solid";
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+import {
+  type EligiblePerson,
+  listLocationsForPerson,
+  resolveActingContextForLocation,
+} from "~/lib/nwd";
+import { Avatar } from "../../../../../_components/avatar";
+import { SidebarItem, SidebarLabel } from "../../../../../_components/sidebar";
+import { ActingProfileSwitcherDropdown } from "./acting-profile-switcher-client";
+
+const ROLE_LABELS = {
+  location_admin: "Beheerder",
+  instructor: "Instructeur",
+} as const;
+
+function fullName(person: EligiblePerson["person"]): string {
+  return [person.firstName, person.lastNamePrefix, person.lastName]
+    .filter((part) => part != null && part !== "")
+    .join(" ");
+}
+
+function initialsFor(person: EligiblePerson["person"]): string {
+  return `${person.firstName?.[0] ?? ""}${
+    person.lastName?.[0] ?? person.firstName?.[1] ?? ""
+  }`.toUpperCase();
+}
+
+function roleLabelsFor(entry: EligiblePerson): string[] {
+  return entry.roles.map((role) => ROLE_LABELS[role]);
+}
+
+async function ActingProfileSwitcherContent(props: {
+  params: Promise<{ location: string }>;
+}) {
+  const [params, locations] = await Promise.all([
+    props.params,
+    listLocationsForPerson(),
+  ]);
+
+  const currentLocation = locations.find(
+    (location) => location.handle === params.location,
+  );
+
+  if (!currentLocation) {
+    return notFound();
+  }
+
+  const context = await resolveActingContextForLocation(currentLocation.id);
+
+  if (context.status === "unauthorized") {
+    return null;
+  }
+
+  if (context.status === "choose") {
+    return (
+      <SidebarItem
+        href={`/locatie/${params.location}/kies-profiel`}
+        className="lg:mb-2.5"
+      >
+        <UserIcon />
+        <SidebarLabel>Kies profiel</SidebarLabel>
+      </SidebarItem>
+    );
+  }
+
+  const acting = context.person;
+  const actingName = fullName(acting.person);
+  const actingRoleLabels = roleLabelsFor(acting);
+
+  const others = context.eligiblePersons.filter(
+    (entry) => entry.person.id !== acting.person.id,
+  );
+
+  // Single eligible profile: static, non-interactive indicator.
+  if (others.length === 0) {
+    return (
+      <div className="mb-2.5 flex items-center gap-3 rounded-lg px-2 py-2.5 sm:py-2">
+        <Avatar
+          className="size-6 shrink-0"
+          initials={initialsFor(acting.person)}
+        />
+        <div className="min-w-0">
+          <span className="block text-xs/4 text-zinc-500 dark:text-zinc-400">
+            Handelt als
+          </span>
+          <span className="block truncate text-sm/5 font-medium text-zinc-950 dark:text-white">
+            {actingName}
+          </span>
+          {actingRoleLabels.length > 0 ? (
+            <span className="block truncate text-xs/4 text-zinc-500 dark:text-zinc-400">
+              {actingRoleLabels.join(", ")}
+            </span>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <ActingProfileSwitcherDropdown
+      locationId={currentLocation.id}
+      actingName={actingName}
+      actingRoleLabels={actingRoleLabels}
+      actingInitials={initialsFor(acting.person)}
+      options={others.map((entry) => ({
+        personId: entry.person.id,
+        fullName: fullName(entry.person),
+        initials: initialsFor(entry.person),
+        roleLabels: roleLabelsFor(entry),
+      }))}
+    />
+  );
+}
+
+function ActingProfileSwitcherFallback() {
+  return (
+    <div className="mb-2.5 flex items-center gap-3 rounded-lg px-2 py-2.5 sm:py-2">
+      <Avatar className="size-6 shrink-0" initials={"..."} />
+      <SidebarLabel className="w-full">
+        <span className="inline-block h-4.5 w-full animate-pulse rounded bg-gray-300 align-middle" />
+      </SidebarLabel>
+    </div>
+  );
+}
+
+export function ActingProfileSwitcher(props: {
+  params: Promise<{ location: string }>;
+}) {
+  return (
+    <Suspense fallback={<ActingProfileSwitcherFallback />}>
+      <ActingProfileSwitcherContent params={props.params} />
+    </Suspense>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/@sidebar/locatie/[location]/layout.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/@sidebar/locatie/[location]/layout.tsx
@@ -8,6 +8,7 @@ import {
   SidebarSpacer,
 } from "~/app/(dashboard)/_components/sidebar";
 import LatestNews from "../../_components/latest-news";
+import { ActingProfileSwitcher } from "./_components/acting-profile-switcher";
 import Feedback from "./_components/feedback";
 import { LocationSelector } from "./_components/location-selector";
 import { LocationSidebarMenu } from "./_components/sidebar-menu";
@@ -24,6 +25,7 @@ export default function SidebarLayout({ children, params }: LayoutProps) {
       {children}
       <SidebarHeader>
         <LocationSelector params={params} />
+        <ActingProfileSwitcher params={params} />
       </SidebarHeader>
       <SidebarBody>
         <LocationSidebarMenu params={params} />

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import { Heading } from "~/app/(dashboard)/_components/heading";
 import {
   listCertificatesWithPagination,
+  requireActingPersonForLocationPage,
   retrieveLocationByHandle,
 } from "~/lib/nwd";
 import Search from "../../../_components/search";
@@ -37,12 +38,20 @@ async function CertificatesTable(props: {
   );
 }
 
-export default function Page(props: {
+export default async function Page(props: {
   params: Promise<{
     location: string;
   }>;
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
+  const params = await props.params;
+  const location = await retrieveLocationByHandle(params.location);
+  await requireActingPersonForLocationPage(
+    params.location,
+    location.id,
+    `/locatie/${params.location}/diplomas`,
+  );
+
   return (
     <>
       <div className="flex flex-wrap justify-between items-end gap-4">

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/instellingen/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/instellingen/page.tsx
@@ -5,6 +5,7 @@ import {
   listDisciplines,
   listGearTypes,
   listResourcesForLocation,
+  requireActingPersonForLocationPage,
   retrieveLocationByHandle,
 } from "~/lib/nwd";
 import LogosForm from "./_components/logos-form";
@@ -41,6 +42,12 @@ export default async function Page(props: {
   } = location;
 
   const { gearTypes, disciplines } = resources;
+
+  await requireActingPersonForLocationPage(
+    params.location,
+    location.id,
+    `/locatie/${params.location}/instellingen`,
+  );
 
   return (
     <div className="mx-auto max-w-4xl">

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/instructeurskwalificaties/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/instructeurskwalificaties/page.tsx
@@ -4,13 +4,22 @@ import { Heading } from "~/app/(dashboard)/_components/heading";
 import {
   listCourses,
   listPersonsForLocationWithPagination,
+  requireActingPersonForLocationPage,
   retrieveLocationByHandle,
 } from "~/lib/nwd";
 import { KwalificatiesTable } from "./_components/kwalificaties-table";
 
-export default function InstructeurskwalificatiesPage(props: {
+export default async function InstructeurskwalificatiesPage(props: {
   params: Promise<{ location: string }>;
 }) {
+  const params = await props.params;
+  const location = await retrieveLocationByHandle(params.location);
+  await requireActingPersonForLocationPage(
+    params.location,
+    location.id,
+    `/locatie/${params.location}/instructeurskwalificaties`,
+  );
+
   return (
     <div className="mx-auto max-w-7xl">
       <Heading>Instructeurskwalificaties</Heading>

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/inzichten/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/inzichten/page.tsx
@@ -3,18 +3,30 @@ import weekOfYear from "dayjs/plugin/weekOfYear";
 import { Label } from "~/app/(dashboard)/_components/fieldset";
 import { Heading, Subheading } from "~/app/(dashboard)/_components/heading";
 import dayjs from "~/lib/dayjs";
+import {
+  requireActingPersonForLocationPage,
+  retrieveLocationByHandle,
+} from "~/lib/nwd";
 import { CertificatesPerDiscipline } from "./_components/certificates-per-discipline";
 import { DateSelector, FixedDateSelector } from "./_components/date-selector";
 import { Persons } from "./_components/persons";
 
 dayjs.extend(weekOfYear);
 
-export default function Page(props: {
+export default async function Page(props: {
   params: Promise<{
     location: string;
   }>;
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
+  const params = await props.params;
+  const location = await retrieveLocationByHandle(params.location);
+  await requireActingPersonForLocationPage(
+    params.location,
+    location.id,
+    `/locatie/${params.location}/inzichten`,
+  );
+
   const defaultFrom = dayjs().startOf("year").format("YYYY-MM-DD");
   const defaultTo = dayjs().endOf("year").format("YYYY-MM-DD");
 

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/kennisbank/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/kennisbank/page.tsx
@@ -1,13 +1,25 @@
 import { Heading } from "~/app/(dashboard)/_components/heading";
 import { Text, TextLink } from "~/app/(dashboard)/_components/text";
+import {
+  requireActingPersonForLocationPage,
+  retrieveLocationByHandle,
+} from "~/lib/nwd";
 import { FilesTable } from "./_components/files-table";
 
-export default function Page(props: {
+export default async function Page(props: {
   params: Promise<{
     location: string;
   }>;
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
+  const params = await props.params;
+  const location = await retrieveLocationByHandle(params.location);
+  await requireActingPersonForLocationPage(
+    params.location,
+    location.id,
+    `/locatie/${params.location}/kennisbank`,
+  );
+
   return (
     <>
       <div className="flex justify-between items-end gap-4">

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/kies-profiel/_components/profile-chooser.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/kies-profiel/_components/profile-chooser.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useAction } from "next-safe-action/hooks";
+import { useState } from "react";
+import { toast } from "sonner";
+import { setActingProfileForLocationAction } from "~/app/_actions/location/set-acting-profile-action";
+import { DEFAULT_SERVER_ERROR_MESSAGE } from "~/app/_actions/utils";
+import Spinner from "~/app/_components/spinner";
+import { Badge } from "~/app/(dashboard)/_components/badge";
+
+const ROLE_LABELS = {
+  location_admin: "Beheerder",
+  instructor: "Instructeur",
+} as const;
+
+type EligiblePerson = {
+  personId: string;
+  firstName: string;
+  lastNamePrefix: string | null;
+  lastName: string | null;
+  roles: Array<keyof typeof ROLE_LABELS>;
+};
+
+function fullName(person: EligiblePerson): string {
+  return [person.firstName, person.lastNamePrefix, person.lastName]
+    .filter((part) => part != null && part !== "")
+    .join(" ");
+}
+
+export function ProfileChooser({
+  locationId,
+  next,
+  eligiblePersons,
+}: {
+  locationId: string;
+  next: string;
+  eligiblePersons: EligiblePerson[];
+}) {
+  const router = useRouter();
+  const [pendingPersonId, setPendingPersonId] = useState<string | null>(null);
+
+  const { execute } = useAction(setActingProfileForLocationAction, {
+    onSuccess: () => {
+      router.push(next);
+    },
+    onError: ({ error }) => {
+      setPendingPersonId(null);
+      toast.error(error.serverError ?? DEFAULT_SERVER_ERROR_MESSAGE);
+    },
+  });
+
+  return (
+    <ul className="mt-6 space-y-3">
+      {eligiblePersons.map((person) => {
+        const isPending = pendingPersonId === person.personId;
+        const disabled = pendingPersonId !== null;
+
+        return (
+          <li key={person.personId}>
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={() => {
+                setPendingPersonId(person.personId);
+                execute({ locationId, personId: person.personId });
+              }}
+              className="flex w-full items-center justify-between gap-4 rounded-lg border border-zinc-950/10 bg-white px-4 py-3 text-left transition hover:border-zinc-950/20 hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-white/10 dark:bg-zinc-900/30 dark:hover:bg-zinc-800/40"
+            >
+              <div className="flex flex-col gap-1.5">
+                <span className="font-medium text-zinc-900 dark:text-white">
+                  {fullName(person)}
+                </span>
+                <div className="flex flex-wrap gap-1.5">
+                  {person.roles.map((role) => (
+                    <Badge key={role} color="branding-orange">
+                      {ROLE_LABELS[role]}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+              {isPending ? <Spinner /> : null}
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/kies-profiel/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/kies-profiel/page.tsx
@@ -1,0 +1,77 @@
+import { notFound, redirect } from "next/navigation";
+import { Heading } from "~/app/(dashboard)/_components/heading";
+import { Text } from "~/app/(dashboard)/_components/text";
+import {
+  resolveActingContextForLocation,
+  retrieveLocationByHandle,
+} from "~/lib/nwd";
+import { ProfileChooser } from "./_components/profile-chooser";
+
+// Only accept a relative path that stays inside this location's dashboard
+// tree. Rejects protocol-relative (`//host`), absolute URLs (schemes), and
+// anything not under `/locatie/`. Callers fall back to the location root.
+function validateNext(
+  next: string | string[] | undefined,
+  handle: string,
+): string {
+  const fallback = `/locatie/${handle}`;
+
+  if (typeof next !== "string") {
+    return fallback;
+  }
+
+  if (
+    !next.startsWith("/locatie/") ||
+    next.startsWith("//") ||
+    next.includes("://")
+  ) {
+    return fallback;
+  }
+
+  return next;
+}
+
+export default async function Page(props: {
+  params: Promise<{ location: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const [params, searchParams] = await Promise.all([
+    props.params,
+    props.searchParams,
+  ]);
+
+  const location = await retrieveLocationByHandle(params.location);
+  const safeNext = validateNext(searchParams.next, params.location);
+
+  const context = await resolveActingContextForLocation(location.id);
+
+  if (context.status === "ok") {
+    redirect(safeNext);
+  }
+
+  if (context.status === "unauthorized") {
+    notFound();
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <Heading>Namens welk profiel wil je handelen?</Heading>
+      <Text className="mt-2">
+        Je account heeft meerdere profielen met een actieve rol op deze locatie.
+        Kies namens welk profiel je wilt werken. Je kunt later altijd wisselen.
+      </Text>
+
+      <ProfileChooser
+        locationId={location.id}
+        next={safeNext}
+        eligiblePersons={context.eligiblePersons.map((entry) => ({
+          personId: entry.person.id,
+          firstName: entry.person.firstName,
+          lastNamePrefix: entry.person.lastNamePrefix,
+          lastName: entry.person.lastName,
+          roles: entry.roles,
+        }))}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/personen/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/personen/[id]/page.tsx
@@ -1,18 +1,30 @@
 import { Divider } from "~/app/(dashboard)/_components/divider";
 import { Subheading } from "~/app/(dashboard)/_components/heading";
 import { RouterPreviousButton } from "~/app/(dashboard)/_components/navigation";
+import {
+  requireActingPersonForLocationPage,
+  retrieveLocationByHandle,
+} from "~/lib/nwd";
 import { EditPerson } from "./_components/edit-person";
 import { PersonCertificates } from "./_components/person-certificates";
 import { PersonName } from "./_components/person-name";
 import { PersonSummary } from "./_components/person-summary";
 import { Roles } from "./_components/roles";
 
-export default function Page(props: {
+export default async function Page(props: {
   params: Promise<{
     location: string;
     id: string;
   }>;
 }) {
+  const params = await props.params;
+  const location = await retrieveLocationByHandle(params.location);
+  await requireActingPersonForLocationPage(
+    params.location,
+    location.id,
+    `/locatie/${params.location}/personen/${params.id}`,
+  );
+
   return (
     <>
       <div className="max-lg:hidden">

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/personen/duplicaten/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/personen/duplicaten/page.tsx
@@ -5,6 +5,7 @@ import { Text } from "~/app/(dashboard)/_components/text";
 import { operatorIdentityWorkflowEnabled } from "~/lib/flags";
 import {
   listLocationDuplicatePairs,
+  requireActingPersonForLocationPage,
   retrieveLocationByHandle,
 } from "~/lib/nwd";
 import { DuplicatePairsList } from "./_components/DuplicatePairsList";
@@ -30,6 +31,13 @@ export default async function Page(props: {
   if (!(await operatorIdentityWorkflowEnabled())) notFound();
 
   const { location: locationHandle } = await props.params;
+  const location = await retrieveLocationByHandle(locationHandle);
+  await requireActingPersonForLocationPage(
+    locationHandle,
+    location.id,
+    `/locatie/${locationHandle}/personen/duplicaten`,
+  );
+
   return (
     <div>
       <Heading>Mogelijke duplicaten</Heading>

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/personen/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/personen/page.tsx
@@ -11,6 +11,7 @@ import { TextLink } from "~/app/(dashboard)/_components/text";
 import { operatorIdentityWorkflowEnabled } from "~/lib/flags";
 import {
   listPersonsForLocationWithPagination,
+  requireActingPersonForLocationPage,
   retrieveLocationByHandle,
 } from "~/lib/nwd";
 import Search from "../../../_components/search";
@@ -58,12 +59,20 @@ async function PersonsTable(props: {
   return <Table persons={persons.items} totalItems={persons.count} />;
 }
 
-export default function Page(props: {
+export default async function Page(props: {
   params: Promise<{
     location: string;
   }>;
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
+  const params = await props.params;
+  const location = await retrieveLocationByHandle(params.location);
+  await requireActingPersonForLocationPage(
+    params.location,
+    location.id,
+    `/locatie/${params.location}/personen`,
+  );
+
   return (
     <DialogWrapper>
       <div className="flex flex-wrap justify-between items-end gap-4">

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/pvb-aanvragen/[handle]/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/pvb-aanvragen/[handle]/page.tsx
@@ -1,7 +1,11 @@
 import { Divider } from "~/app/(dashboard)/_components/divider";
 import { Subheading } from "~/app/(dashboard)/_components/heading";
 import { RouterPreviousButton } from "~/app/(dashboard)/_components/navigation";
-import { retrievePvbAanvraagByHandle } from "~/lib/nwd";
+import {
+  requireActingPersonForLocationPage,
+  retrieveLocationByHandle,
+  retrievePvbAanvraagByHandle,
+} from "~/lib/nwd";
 import { AanvraagActions } from "./_components/aanvraag-actions";
 import { AanvraagCard } from "./_components/aanvraag-card";
 import PvbTimeline from "./_components/pvb-timeline";
@@ -14,6 +18,13 @@ export default async function Page(props: {
   }>;
 }) {
   const params = await props.params;
+
+  const location = await retrieveLocationByHandle(params.location);
+  await requireActingPersonForLocationPage(
+    params.location,
+    location.id,
+    `/locatie/${params.location}/pvb-aanvragen/${params.handle}`,
+  );
 
   // Fetch the PVB aanvraag details
   const aanvraag = await retrievePvbAanvraagByHandle(params.handle);

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/pvb-aanvragen/nieuw/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/pvb-aanvragen/nieuw/page.tsx
@@ -3,6 +3,7 @@ import { Heading } from "~/app/(dashboard)/_components/heading";
 import {
   listCourses,
   listKssNiveaus,
+  requireActingPersonForLocationPage,
   retrieveLocationByHandle,
 } from "~/lib/nwd";
 import CreatePvbForm from "./_components/create-pvb-form";
@@ -51,13 +52,21 @@ async function CreatePvbContent(props: {
   );
 }
 
-export default function Page(props: {
+export default async function Page(props: {
   params: Promise<{ location: string }>;
   searchParams: Promise<{
     niveau?: string;
     [key: string]: string | undefined;
   }>;
 }) {
+  const params = await props.params;
+  const location = await retrieveLocationByHandle(params.location);
+  await requireActingPersonForLocationPage(
+    params.location,
+    location.id,
+    `/locatie/${params.location}/pvb-aanvragen/nieuw`,
+  );
+
   return (
     <>
       <div className="flex flex-wrap justify-between items-end gap-4">

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/pvb-aanvragen/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/pvb-aanvragen/page.tsx
@@ -2,7 +2,11 @@ import { PlusIcon } from "@heroicons/react/16/solid";
 import { Suspense } from "react";
 import { Button } from "~/app/(dashboard)/_components/button";
 import { Heading } from "~/app/(dashboard)/_components/heading";
-import { listPvbsWithPagination, retrieveLocationByHandle } from "~/lib/nwd";
+import {
+  listPvbsWithPagination,
+  requireActingPersonForLocationPage,
+  retrieveLocationByHandle,
+} from "~/lib/nwd";
 import Search from "../../../_components/search";
 import PvbTable from "./_components/table";
 import { loadSearchParams } from "./_search-params";
@@ -49,12 +53,20 @@ async function CreateButton(props: { params: Promise<{ location: string }> }) {
   );
 }
 
-export default function Page(props: {
+export default async function Page(props: {
   params: Promise<{
     location: string;
   }>;
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
+  const params = await props.params;
+  const location = await retrieveLocationByHandle(params.location);
+  await requireActingPersonForLocationPage(
+    params.location,
+    location.id,
+    `/locatie/${params.location}/pvb-aanvragen`,
+  );
+
   return (
     <>
       <div className="flex flex-wrap justify-between items-end gap-4">

--- a/apps/web/src/app/_actions/location/set-acting-profile-action.ts
+++ b/apps/web/src/app/_actions/location/set-acting-profile-action.ts
@@ -1,0 +1,48 @@
+"use server";
+
+import { User } from "@nawadi/core";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { zfd } from "zod-form-data";
+import { getUserOrThrow } from "~/lib/nwd";
+import { actionClientWithMeta } from "../safe-action";
+
+const setActingProfileSchema = z.object({
+  locationId: zfd.text(z.string().uuid()),
+  personId: zfd.text(z.string().uuid()),
+});
+
+export const setActingProfileForLocationAction = actionClientWithMeta
+  .metadata({ name: "set-acting-profile-for-location" })
+  .inputSchema(setActingProfileSchema)
+  .action(async ({ parsedInput: { locationId, personId } }) => {
+    const user = await getUserOrThrow();
+
+    // Re-derive eligibility directly — never trust the client, and never
+    // rely on the (request-scoped) resolver here. The person must be owned
+    // by the user AND have an active location_admin/instructor actor at the
+    // location.
+    const owned = user.persons.some((p) => p.id === personId);
+    if (!owned) {
+      throw new Error("Unauthorized");
+    }
+
+    const roles = await User.Person.listActiveRolesForLocation({
+      personId,
+      locationId,
+    });
+
+    const isEligible =
+      roles.includes("location_admin") || roles.includes("instructor");
+    if (!isEligible) {
+      throw new Error("Unauthorized");
+    }
+
+    await User.ActingProfile.setActingProfilePreference({
+      userId: user.authUserId,
+      locationId,
+      personId,
+    });
+
+    revalidatePath("/locatie", "layout");
+  });

--- a/apps/web/src/lib/nwd.ts
+++ b/apps/web/src/lib/nwd.ts
@@ -137,10 +137,7 @@ export async function getPrimaryPerson<T extends boolean = true>(
       : null;
   }
 
-  if (!primaryPerson.isPrimary) {
-    await User.Person.setPrimary({ personId: primaryPerson.id });
-  }
-
+  // This helper is a read-only default and must never write.
   return primaryPerson;
 }
 
@@ -177,6 +174,144 @@ export async function isActiveActorTypeInLocationServerHelper(args: {
   actorType: Exclude<ActorType, "pvb_beoordelaar">[];
 }) {
   return isActiveActorTypeInLocation(args);
+}
+
+// Roles that make an owned profile eligible to act on a location's
+// staff dashboard. Matches today's isActiveActorTypeInLocation usage
+// across the /locatie tree (location_admin + instructor).
+const LOCATION_ELIGIBLE_ROLES = ["location_admin", "instructor"] as const;
+
+type OwnedPerson = Awaited<
+  ReturnType<typeof getUserOrThrow>
+>["persons"][number];
+
+// An owned profile that has at least one active eligible role for the
+// location, together with those roles.
+export type EligiblePerson = {
+  person: OwnedPerson;
+  roles: Array<(typeof LOCATION_ELIGIBLE_ROLES)[number]>;
+};
+
+export type ActingContextForLocation =
+  | { status: "unauthorized" }
+  | { status: "choose"; eligiblePersons: EligiblePerson[] }
+  | { status: "ok"; person: EligiblePerson; eligiblePersons: EligiblePerson[] };
+
+/**
+ * Request-scoped resolver for "which owned profile is acting on this
+ * location". Read-only; keyed by locationId so the sidebar switcher, the
+ * layout, and the page all share one execution per flight request.
+ *
+ * HAZARD: plain React cache() only. Never call this inside a "use cache"
+ * scope (cross-request/cross-user), never write from it, and never
+ * consult getPrimaryPerson — the whole point is to replace the primary
+ * fallback with explicit, per-location eligibility + remembered choice.
+ */
+export const resolveActingContextForLocation = cache(
+  async (locationId: string): Promise<ActingContextForLocation> => {
+    return makeRequest(async () => {
+      const user = await getUserOrThrow();
+
+      // Determine active eligible roles for every owned profile at this
+      // location, in parallel (one query per owned person).
+      const eligiblePersons: EligiblePerson[] = (
+        await Promise.all(
+          user.persons.map(async (person) => {
+            const roles = await User.Person.listActiveRolesForLocation({
+              personId: person.id,
+              locationId,
+            });
+
+            const eligibleRoles = roles.filter(
+              (role): role is (typeof LOCATION_ELIGIBLE_ROLES)[number] =>
+                (LOCATION_ELIGIBLE_ROLES as readonly string[]).includes(role),
+            );
+
+            if (eligibleRoles.length === 0) {
+              return null;
+            }
+
+            return { person, roles: eligibleRoles } satisfies EligiblePerson;
+          }),
+        )
+      ).filter((entry): entry is EligiblePerson => entry !== null);
+
+      if (eligiblePersons.length === 0) {
+        return { status: "unauthorized" } as const;
+      }
+
+      const [onlyEligible] = eligiblePersons;
+      if (eligiblePersons.length === 1 && onlyEligible) {
+        return {
+          status: "ok",
+          person: onlyEligible,
+          eligiblePersons,
+        } as const;
+      }
+
+      // Multiple eligible profiles: honour a remembered preference if it
+      // still points at an eligible profile, otherwise ask the user.
+      const rememberedPersonId =
+        await User.ActingProfile.getActingProfilePreference({
+          userId: user.authUserId,
+          locationId,
+        });
+
+      const remembered = rememberedPersonId
+        ? eligiblePersons.find((e) => e.person.id === rememberedPersonId)
+        : undefined;
+
+      if (remembered) {
+        return { status: "ok", person: remembered, eligiblePersons } as const;
+      }
+
+      return { status: "choose", eligiblePersons } as const;
+    });
+  },
+);
+
+/**
+ * Page-side guard: resolve the acting person for a location page, or
+ * redirect/notFound. `next` is the relative path to return to after
+ * choosing (RSC helpers cannot cheaply read the current URL, so the
+ * caller passes it explicitly).
+ */
+export async function requireActingPersonForLocationPage(
+  locationHandle: string,
+  locationId: string,
+  next: string,
+): Promise<EligiblePerson> {
+  const context = await resolveActingContextForLocation(locationId);
+
+  if (context.status === "unauthorized") {
+    notFound();
+  }
+
+  if (context.status === "choose") {
+    redirect(
+      `/locatie/${locationHandle}/kies-profiel?next=${encodeURIComponent(next)}`,
+    );
+  }
+
+  return context.person;
+}
+
+/**
+ * Data-side guard: resolve the acting person for a location, or fail closed.
+ * Any status other than "ok" throws "Unauthorized" — reaching a data function
+ * in "choose" state means the page did not gate, so we must not leak data.
+ * Use inside location-scoped READ functions in place of getPrimaryPerson.
+ */
+export async function requireActingPersonForLocation(
+  locationId: string,
+): Promise<EligiblePerson> {
+  const context = await resolveActingContextForLocation(locationId);
+
+  if (context.status !== "ok") {
+    throw new Error("Unauthorized");
+  }
+
+  return context.person;
 }
 
 async function makeRequest<T>(cb: () => Promise<T>) {
@@ -370,13 +505,12 @@ export const findCertificate = async ({
 
 export const listCertificates = cache(async (locationId: string) => {
   return makeRequest(async () => {
-    const user = await getUserOrThrow();
-    const person = await getPrimaryPerson(user);
+    const acting = await requireActingPersonForLocation(locationId);
 
     await isActiveActorTypeInLocation({
       actorType: ["location_admin"],
       locationId,
-      personId: person.id,
+      personId: acting.person.id,
     });
 
     const certificates = await Certificate.list({
@@ -393,13 +527,12 @@ export const listCertificatesWithPagination = cache(
     { q, limit, offset }: { q: string; limit: number; offset: number },
   ) => {
     return makeRequest(async () => {
-      const user = await getUserOrThrow();
-      const person = await getPrimaryPerson(user);
+      const acting = await requireActingPersonForLocation(locationId);
 
       await isActiveActorTypeInLocation({
         actorType: ["location_admin"],
         locationId,
-        personId: person.id,
+        personId: acting.person.id,
       });
 
       return await Certificate.list({
@@ -1051,13 +1184,12 @@ export const listResourcesForLocation = async (locationId: string) => {
 
 export const listPersonsForLocation = cache(async (locationId: string) => {
   return makeRequest(async () => {
-    const user = await getUserOrThrow();
-    const person = await getPrimaryPerson(user);
+    const acting = await requireActingPersonForLocation(locationId);
 
     const isLocationAdmin = await isActiveActorTypeInLocation({
       actorType: ["location_admin"],
       locationId,
-      personId: person.id,
+      personId: acting.person.id,
     }).catch(() => false);
 
     if (!isLocationAdmin) {
@@ -1084,13 +1216,12 @@ export const listPersonsForLocationWithPagination = cache(
     } = {},
   ) => {
     return makeRequest(async () => {
-      const user = await getUserOrThrow();
-      const person = await getPrimaryPerson(user);
+      const acting = await requireActingPersonForLocation(locationId);
 
       const isLocationAdmin = await isActiveActorTypeInLocation({
         actorType: ["location_admin"],
         locationId,
-        personId: person.id,
+        personId: acting.person.id,
       }).catch(() => false);
 
       if (!isLocationAdmin) {
@@ -1119,13 +1250,12 @@ export const listPersonsForLocationWithPagination = cache(
 
 export const listBeoordelaarsForLocation = cache(async (locationId: string) => {
   return makeRequest(async () => {
-    const user = await getUserOrThrow();
-    const person = await getPrimaryPerson(user);
+    const acting = await requireActingPersonForLocation(locationId);
 
     const isLocationAdmin = await isActiveActorTypeInLocation({
       actorType: ["location_admin"],
       locationId,
-      personId: person.id,
+      personId: acting.person.id,
     }).catch(() => false);
 
     if (!isLocationAdmin) {
@@ -1188,13 +1318,12 @@ export const listPersonsForUser = cache(async () => {
 export const listPersonsForLocationByRole = cache(
   async (locationId: string, role: Exclude<ActorType, "pvb_beoordelaar">) => {
     return makeRequest(async () => {
-      const user = await getUserOrThrow();
-      const person = await getPrimaryPerson(user);
+      const acting = await requireActingPersonForLocation(locationId);
 
       const isLocationAdmin = await isActiveActorTypeInLocation({
         actorType: ["location_admin"],
         locationId,
-        personId: person.id,
+        personId: acting.person.id,
       }).catch(() => false);
 
       if (!isLocationAdmin) {
@@ -1218,37 +1347,60 @@ export const listLocationsForPerson = cache(
   ) => {
     return makeRequest(async () => {
       const user = await getUserOrThrow();
-      const person = await getPrimaryPerson(user);
 
-      if (personId && person.id !== personId) {
+      // If an explicit personId is passed it must be one the user owns.
+      if (personId && !user.persons.some((p) => p.id === personId)) {
         throw new Error("Unauthorized");
       }
 
-      const locations = await User.Person.listLocationsByRole({
-        personId: person.id,
-        roles,
-      });
+      // Union across every owned profile (or the single requested one), so
+      // the location dropdown surfaces every location any owned profile can
+      // staff. Deduped by location id.
+      const personIds = personId ? [personId] : user.persons.map((p) => p.id);
+
+      const locationIdSet = new Set<string>();
+      await Promise.all(
+        personIds.map(async (id) => {
+          const locations = await User.Person.listLocationsByRole({
+            personId: id,
+            roles,
+          });
+          for (const loc of locations) {
+            locationIdSet.add(loc.locationId);
+          }
+        }),
+      );
 
       return await Location.list().then((locs) =>
-        locs.filter((l) => locations.some((loc) => loc.locationId === l.id)),
+        locs.filter((l) => locationIdSet.has(l.id)),
       );
     });
   },
 );
 
+// NOTE: name kept for phase 2b; the rename (drop "Primary") lands with phase 3.
 export const listLocationsWherePrimaryPersonHasManagementRole = cache(
   async () => {
     return makeRequest(async () => {
       const user = await getUserOrThrow();
-      const person = await getPrimaryPerson(user);
 
-      const locations = await User.Person.listLocationsByRole({
-        personId: person.id,
-        roles: ["instructor", "location_admin"],
-      });
+      // Union management-role locations across ALL owned profiles (deduped by
+      // location id), so every location any owned profile can manage surfaces.
+      const locationIdSet = new Set<string>();
+      await Promise.all(
+        user.persons.map(async (person) => {
+          const locations = await User.Person.listLocationsByRole({
+            personId: person.id,
+            roles: ["instructor", "location_admin"],
+          });
+          for (const loc of locations) {
+            locationIdSet.add(loc.locationId);
+          }
+        }),
+      );
 
       return await Location.list().then((locs) =>
-        locs.filter((l) => locations.some((loc) => loc.locationId === l.id)),
+        locs.filter((l) => locationIdSet.has(l.id)),
       );
     });
   },
@@ -2607,20 +2759,35 @@ export const isInstructorInCohort = cache(async (cohortId: string) => {
 export const listRolesForLocation = cache(
   async (locationId: string, personId?: string) => {
     return makeRequest(async () => {
-      const authUser = await getUserOrThrow();
-      const primaryPerson = await getPrimaryPerson(authUser);
-
+      // Explicit personId (e.g. inspecting another person's roles) keeps
+      // the original access-checked path.
       if (personId) {
+        const authUser = await getUserOrThrow();
+
         await validatePersonAccessCheck({
           locationId,
           requestedPersonId: personId,
           requestingUser: authUser,
         });
+
+        return await User.Person.listActiveRolesForLocation({
+          locationId,
+          personId,
+        });
+      }
+
+      // No explicit person: return the roles of the acting profile. The
+      // sidebar calls this, so ambiguous/unauthorized cases return [] and
+      // must not throw.
+      const context = await resolveActingContextForLocation(locationId);
+
+      if (context.status !== "ok") {
+        return [];
       }
 
       return await User.Person.listActiveRolesForLocation({
         locationId,
-        personId: personId ?? primaryPerson.id,
+        personId: context.person.person.id,
       });
     });
   },
@@ -3596,13 +3763,12 @@ export const updateCurrentUserDisplayName = async (displayName: string) => {
 
 export const listPvbs = cache(async (locationId: string) => {
   return makeRequest(async () => {
-    const user = await getUserOrThrow();
-    const person = await getPrimaryPerson(user);
+    const acting = await requireActingPersonForLocation(locationId);
 
     await isActiveActorTypeInLocation({
       actorType: ["location_admin"],
       locationId,
-      personId: person.id,
+      personId: acting.person.id,
     });
 
     const pvbs = await Pvb.Aanvraag.list({
@@ -3619,13 +3785,12 @@ export const listPvbsWithPagination = cache(
     { q, limit, offset }: { q: string; limit: number; offset: number },
   ) => {
     return makeRequest(async () => {
-      const user = await getUserOrThrow();
-      const person = await getPrimaryPerson(user);
+      const acting = await requireActingPersonForLocation(locationId);
 
       await isActiveActorTypeInLocation({
         actorType: ["location_admin"],
         locationId,
-        personId: person.id,
+        personId: acting.person.id,
       });
 
       return await Pvb.Aanvraag.list({
@@ -3784,22 +3949,35 @@ export const getActiveActorTypes = async () => {
 export const retrievePvbAanvraagByHandle = async (handle: string) => {
   return makeRequest(async () => {
     const authUser = await getUserOrThrow();
-    const primaryPerson = await getPrimaryPerson(authUser);
+    const ownedPersonIds = new Set(authUser.persons.map((p) => p.id));
 
     const aanvraag = await Pvb.Aanvraag.retrieveByHandle({ handle });
 
-    // Check if user has access to this PVB aanvraag
-    const isLocationAdmin = await isActiveActorTypeInLocation({
-      actorType: ["location_admin"],
-      locationId: aanvraag.locatie.id,
-      personId: primaryPerson.id,
-    }).catch(() => false);
-
-    const isLeercoach = aanvraag.leercoach?.id === primaryPerson.id;
+    // Check if any of the user's persons has direct access to this PVB
+    // aanvraag (cheap, in-memory checks first).
+    const isKandidaat =
+      aanvraag.kandidaat != null && ownedPersonIds.has(aanvraag.kandidaat.id);
+    const isLeercoach =
+      aanvraag.leercoach != null && ownedPersonIds.has(aanvraag.leercoach.id);
     const isBeoordelaar = aanvraag.onderdelen.some(
-      (o) => o.beoordelaar?.id === primaryPerson.id,
+      (o) => o.beoordelaar != null && ownedPersonIds.has(o.beoordelaar.id),
     );
-    const isKandidaat = aanvraag.kandidaat?.id === primaryPerson.id;
+
+    let isLocationAdmin = false;
+    if (!isKandidaat && !isLeercoach && !isBeoordelaar) {
+      // Only fall back to the location-admin check when no direct role
+      // matched, and run it across all of the user's persons.
+      const results = await Promise.all(
+        [...ownedPersonIds].map((personId) =>
+          isActiveActorTypeInLocation({
+            actorType: ["location_admin"],
+            locationId: aanvraag.locatie.id,
+            personId,
+          }).catch(() => false),
+        ),
+      );
+      isLocationAdmin = results.some(Boolean);
+    }
 
     // User must be either a location admin, the assigned leercoach, or a beoordelaar
     if (!isLocationAdmin && !isLeercoach && !isBeoordelaar && !isKandidaat) {
@@ -4884,12 +5062,11 @@ export async function listLocationDuplicatePairs({
   limit?: number;
 }) {
   return makeRequest(async () => {
-    const authUser = await getUserOrThrow();
-    const operator = await getPrimaryPerson(authUser);
+    const acting = await requireActingPersonForLocation(locationId);
     await isActiveActorTypeInLocation({
       actorType: ["location_admin"],
       locationId,
-      personId: operator.id,
+      personId: acting.person.id,
     });
 
     return User.Person.listDuplicatePairsInLocation({

--- a/docs/designs/explicit-acting-profile.md
+++ b/docs/designs/explicit-acting-profile.md
@@ -1,0 +1,262 @@
+# Explicit Acting Profile for Staff Dashboards
+
+Status: DRAFT (post fable review; plumbing decision verified against vendored Next.js 16.1.6 source)
+Owner: Maurits (Buchung)
+Date: 2026-07-04
+Related: docs/designs/operator-identity-workflow.md (operator identity for merges/imports)
+
+## Problem
+
+Recurring support cases: an instructor cannot see staff tabs because their account
+has no or the wrong "main profile". The current design makes `person.isPrimary` do
+too much — it is simultaneously a profile default, a UI gate, an authorization
+identity, and an audit identity.
+
+## Verified facts (code evidence)
+
+All claims below were verified against the codebase; paths are repo-relative.
+
+- `getPrimaryPerson` (`apps/web/src/lib/nwd.ts:117-145`) silently falls back to
+  `user.persons[0]` when no person is primary, and **writes** `isPrimary` during the
+  read (`User.Person.setPrimary`, called at nwd.ts:141). Every one of its ~80 call
+  sites uses the default `force = true`, so the write path is live everywhere.
+- The write path uses `User.Person.setPrimary` (`packages/core/src/models/user/person.ts:2223`),
+  which sets without unsetting siblings — only the partial unique index
+  `unq_primary_person` (`packages/db/src/schema/user.ts:94-96`) prevents double
+  primaries, by throwing. The transactional unset-then-set variant is
+  `User.setPrimaryPerson` (`packages/core/src/models/user/user.ts:207-239`).
+- The multi-profile ambiguity is real: the `actor` uniqueness constraint is
+  `(type, personId, locationId)` with no reference to `userId`
+  (`packages/db/src/schema/user.ts:133-135`), so one user can own two persons that
+  are both instructors at the same location.
+- `isPrimary` gates instructor UI in four places:
+  `apps/web/src/app/(dashboard)/(account)/profiel/[handle]/page.tsx:88-91`, the
+  dashboard-toggle wrapper, `require-instructor-person.ts:44-47`, and the PVB page
+  `profiel/[handle]/pvb-aanvraag/[pvbHandle]/page.tsx:55` (which blocks a
+  non-primary person from seeing their *own* PVB on their own handle).
+- Attribution: `studentCohortProgress.createdBy` (`packages/db/src/schema/progress.ts:21`)
+  and `bulkImportPreview.createdByPersonId` are the real audit fields — there is no
+  `aangemaaktDoor` field anywhere in the repo. Both `updateCompetencyProgress`
+  (nwd.ts:2274) and `completeAllCoreCompetencies` (nwd.ts:2305) write
+  `createdBy: primaryPerson.id`. `updateStudentInstructorAssignment` (nwd.ts:2668)
+  silently defaults the claiming instructor to the primary person.
+- Cohort eligibility model: the access window lives **on the cohort**
+  (`cohort.accessStartTime`/`accessEndTime`), not on the allocation. The only cohort
+  privileges are `manage_cohort_certificate`, `manage_cohort_students`,
+  `manage_cohort_instructors` (`packages/lib/src/enums.ts:3-7`). There is no
+  "assess" privilege — PVB assessment is a separate `pvb_beoordelaar` actor type.
+- There is no existing preference storage (no settings table, no
+  location/profile cookie). The only identity-adjacent cookie is
+  `impersonated_user_id` (nwd.ts:227,301).
+
+## Architecture decision: how acting identity flows
+
+Verified against the vendored Next.js source at tag `v16.1.6` (the exact version in
+`apps/web/package.json`) and the compiled React 19.2.4 server runtime in
+`apps/web/node_modules/next/dist/compiled/`:
+
+1. **React `cache()` memoizes per flight-render request.** The cache store is a Map
+   on the flight request object (`DefaultAsyncDispatcher.getCacheForType` →
+   `request.cache`). Next renders the entire App Router tree — layouts, pages, and
+   parallel route slots like `@sidebar` — in **one** `renderToReadableStream` call
+   per HTTP request (`app-render.tsx:738`). A `cache()`-wrapped resolver keyed by
+   `locationId` is therefore computed once per request and shared by the sidebar
+   switcher, the layout, and the page.
+2. **`cache()` is a silent no-op inside server actions.** Actions execute inside
+   Next's `workUnitAsyncStorage.run(...)` (`action-handler.ts:1222`), which is not
+   React's flight-request scope; without an active flight request,
+   `getCacheForType` returns a fresh Map per call. There is no such thing as
+   request-scoped memoization in an action.
+3. **The post-action re-render is a fresh flight request with a fresh cache**
+   (`executeActionAndPrepareForRender` switches the store to the render phase and
+   re-renders in the same HTTP request). A choose-profile action that writes the
+   preference and revalidates is automatically picked up by the re-render — no
+   manual cache invalidation needed.
+
+Consequences:
+
+- **Reads: request-scoped resolution via React `cache()`.**
+  `resolveActingContextForLocation = cache(async (locationId) => …)` plus a cohort
+  variant that composes it. Existing `nwd.ts` functions swap
+  `getPrimaryPerson(user)` for `resolveActingPersonForLocation(locationId)` using
+  the `locationId`/`cohortId` they already receive. No signature threading through
+  pages, no route-param plumbing. This is idiomatic here — `nwd.ts` already wraps
+  ~all reads in `cache()`.
+- **Mutations: explicit `actingPersonId` argument, fully revalidated per action.**
+  Not a style preference: fact 2 means the read-side resolver cannot memoize in an
+  action, so each action does exactly one explicit resolve-and-validate anyway.
+- **Rejected — userland `AsyncLocalStorage`:** userland cannot wrap Next's render
+  pipeline, and an `als.run()` around a layout's body does not extend to children
+  or sibling parallel slots (RSC renders them later, outside the synchronous
+  scope). Any ALS design collapses back into "call a function with the key".
+- **Rejected — threading `actingPersonId` through every `nwd.ts` signature:**
+  touches every call site (~80 in nwd.ts alone) for zero semantic gain over
+  `cache()` on the read side.
+
+## Key Changes
+
+- In `apps/web/src/lib/nwd.ts`, split identity helpers:
+  - `getDefaultPerson`: **truly read-only** default profile for `/profiel` landing.
+    Deletes the write-during-read; never falls back by writing.
+  - `getPersonByHandle`: profile routes; the handle determines the acting person.
+  - `resolveActingContextForLocation` / `resolveActingContextForCohort`:
+    `cache()`-wrapped read-side resolvers keyed by resource id.
+  - `requireActingPersonForLocation` / `requireActingPersonForCohort`: mutation-side
+    validators taking an explicit `actingPersonId`.
+- Add `userActingProfilePreference` table: `userId`, `locationId`, `personId`,
+  timestamps, unique on `(userId, locationId)`. Convenience only — every read and
+  action revalidates ownership and active role/privilege. Cross-device by design
+  (a cookie was considered and rejected: per-device memory reproduces the support
+  problem on every new device).
+- Remove `person.isPrimary` from all four instructor-UI gates listed above. Active
+  owned roles decide visibility; on `/profiel/[handle]` the handle decides identity.
+- Acting-profile switcher in the location sidebar layout
+  (`apps/web/src/app/(dashboard)/(management)/@sidebar/locatie/[location]/layout.tsx`).
+  Note: this layout currently renders only the `LocationSelector`; the account
+  selector lives in the parent `@sidebar/layout.tsx`. The switcher shows
+  "Handelt als [name]", role badges, and a switch action when multiple profiles
+  qualify.
+
+## Acting Identity Rules
+
+- `/profiel/[handle]/...`: acting person is derived only from the owned profile
+  handle. No fallback to the default profile. This includes the PVB page under
+  `pvb-aanvraag/[pvbHandle]` (currently blocked by a `primaryPerson.id` check).
+- `/locatie/[location]/...`: eligible profiles are owned profiles with active roles
+  for that location/page.
+- `/locatie/[location]/cohorten/[cohort]/...`: eligible profiles are owned profiles
+  that are location admin, **or** have a cohort allocation while the cohort's
+  access window (`accessStartTime`/`accessEndTime`, on the cohort) is open —
+  optionally narrowed by the three `manage_cohort_*` privileges the page needs.
+- Zero eligible profiles: deny/not found. Zero persons on the account at all
+  (today `getPrimaryPerson` throws "Expected at least one person"): redirect to
+  onboarding, defined behavior instead of a 500.
+- One eligible profile: use it automatically, show the acting indicator.
+- Multiple eligible profiles + valid remembered preference for the location: use
+  it, show the switcher.
+- Multiple eligible profiles, no valid preference: **redirect to a chooser route**
+  (`/locatie/[location]/kies-profiel?next=…`) before any student/cohort data is
+  fetched. A redirect, not an in-place blocking render: the dashboard uses parallel
+  route slots that fetch independently, so an in-place gate would have to be
+  re-implemented in every segment. Choosing stores the preference (server action)
+  and redirects back to the canonical URL; per architecture fact 3 the fresh render
+  picks it up with no extra invalidation.
+- `?actingPersonId=` is never authority. Links from `/profiel/[handle]` into
+  management pages set acting context via a server action or transition route,
+  then redirect to the canonical resource URL.
+- **Impersonation:** acting-profile resolution composes with the existing
+  `impersonated_user_id` cookie — resolve profiles from the impersonated user's
+  persons, and key/write preferences against the impersonated user only.
+
+## Surfaces in scope
+
+The migration list is larger than `/profiel` + `/locatie`:
+
+- **PVB server actions** (`apps/web/src/app/_actions/pvb/assessment-action.ts` — 5
+  `getPrimaryPerson` call sites deriving the beoordelaar actor —
+  `leercoach-permission-action.ts`, `course-management-action.ts`): squarely inside
+  the support-bug class; migrate with the cohort actions.
+- **API routes** used by dashboards (`api/persons/list/[location]`,
+  `api/beoordelaars/list/[location]`, certificate PDF exports): authorize per
+  request via the same resolve-for-location logic (they have a `location` param;
+  `cache()` works per request in route handlers the same way).
+- **`secretariaat/`** (org-wide, no `locationId` — the preference key cannot
+  represent it): resolve by the `secretariaat` actor type across owned profiles; if
+  multiple qualify this is a data error to surface, not a chooser case. Explicitly
+  phase 4; until then it stays on the read-only `getDefaultPerson` (bug class does
+  not apply: secretariaat users are Buchung-managed).
+- **`penningmeester/`**: same treatment as secretariaat.
+
+## Mutation Rules
+
+- Staff actions receive a server-rendered `actingPersonId` and revalidate it
+  against the current user (ownership) and the resource (role/privilege/window).
+  Reject missing, stale, cross-account, or underprivileged values.
+- Audit fields (`createdBy` on `studentCohortProgress`,
+  `createdByPersonId` on bulk import) and the instructor default in
+  `updateStudentInstructorAssignment` use the acting profile.
+- Authorization holes are fixed in the same pass as each function is migrated —
+  acting identity must not be layered over missing authorization. **Scope includes
+  unauthorized reads, not just TODO mutations:**
+  - `updateStudentInstructorAssignment` (nwd.ts:2641): **no authorization at all**
+    today, plus the primary-person attribution default. Worst offender; fix first.
+  - `enrollStudentsInCurriculumForCohort` (nwd.ts:2712) and
+    `withdrawStudentFromCurriculumInCohort` (nwd.ts:2756): auth checks are
+    commented out.
+  - `updateCompetencyProgress` (nwd.ts:2293) and `completeAllCoreCompetencies`
+    (nwd.ts:2319): "TODO: check instructor for cohort" — no real check.
+  - Unauthorized reads: `listInstructorsByCohortId` (nwd.ts:2130),
+    `listCurriculaByPersonId` (2201), `listCurriculaProgressByPersonId` (2215),
+    `listStudentCohortProgressByPersonId` (2234),
+    `listCompletedCompetenciesByStudentCurriculumId` (2251),
+    `listCompetencyProgressInCohortForStudent` (2262).
+  - `listAllocationHistory` (nwd.ts:3347): never verifies the allocation belongs to
+    the passed cohort.
+  - `removeAllocationById` / `moveAllocationById` (nwd.ts:2508,2555): conflate
+    `manage_cohort_students` and `manage_cohort_instructors`;
+    `remove-instructor-from-cohort-action` can remove a student allocation.
+
+## Hazards (review checklist)
+
+- **Never call the acting resolver (or pass its result) inside a `"use cache"`
+  scope.** `"use cache"` is cross-request and cross-user — it is live in this
+  codebase today (`nwd.ts:710-821`, cohort overview page). `cache()` (per-request)
+  and `"use cache"` (cross-request) look similar in this file; a leak here serves
+  one user's acting identity to another.
+- Do not "fix" the unmemoized-in-actions behavior with module-global caching —
+  that is a cross-request leak by construction.
+- `cache()` memoizes thrown errors per request (consistent within a request; fine).
+- If any code path still sets a primary person, use the transactional
+  `User.setPrimaryPerson`, never `User.Person.setPrimary` (set-without-unset).
+
+## Phasing
+
+1. **Quick win (kills most support cases):** make the default-person lookup truly
+   read-only (delete the write-during-read — which today can fire repeatedly per
+   action invocation, since `cache()` does not dedupe there), and switch the four
+   `/profiel/[handle]` gates to handle-derived identity. Also widen
+   `retrievePvbAanvraagByHandle` from primary-person to any-owned-person
+   authorization so the PVB page fix is effective (the explicit acting-person
+   parameter lands in phase 3). Small diff, immediately shippable.
+2. **Location tree:** `resolveActingContextForLocation`, chooser route, preference
+   table, sidebar switcher, migrate `/locatie/[location]` pages.
+3. **Cohorts + mutations + auth fixes:** `resolveActingContextForCohort`, migrate
+   cohort pages/actions and PVB actions, fix the enumerated authorization holes,
+   route audit fields through the acting profile.
+4. **Remaining surfaces:** API routes, secretariaat, penningmeester.
+
+## Test Plan
+
+- Non-primary instructor profile shows staff tabs, staff profile pages, and their
+  own PVB pages under their own handle.
+- Account with no primary profile can access eligible staff dashboards; account
+  with zero persons gets the defined onboarding redirect, not a 500.
+- Shared cohort URL with one eligible profile opens directly with the indicator.
+- Shared cohort URL with two eligible profiles redirects to the chooser before any
+  student data is fetched (assert on the redirect, not just the rendered page).
+- After choosing, the same-request re-render uses the new preference (no stale
+  acting context); revisits reuse it; the switcher changes it.
+- Stale or unauthorized remembered profile prompts again or denies.
+- Server actions reject missing, stale, cross-account, or underprivileged
+  `actingPersonId`.
+- Audit records (`createdBy`) and the claim-instructor default attribute to the
+  selected acting profile.
+- Previously unauthorized reads/mutations (list above) now deny for
+  non-eligible users.
+- Impersonated sessions resolve and store preferences against the impersonated
+  user.
+- Sidebar slot and page resolve the same acting person within one request (single
+  resolver execution per request).
+
+## Tradeoffs
+
+- No `actingPersonId` in canonical URLs: brittle for shared links, leaks identity
+  selection into resource URLs, and never authority anyway.
+- No main/default-profile fallback for staff resources: recreates today's bug.
+- Choose-before-view on ambiguous staff URLs (no read-only preview): safer for
+  student/cohort data.
+- Preference is per location, not account-global: switching in one location must
+  not affect another. Table over cookie: cross-device memory is the point.
+- Main/default profile survives only as `/profiel` landing behavior, renamed
+  "default profile"; removing the concept entirely is larger than this problem
+  needs.

--- a/packages/core/src/models/user/acting-profile.ts
+++ b/packages/core/src/models/user/acting-profile.ts
@@ -1,0 +1,84 @@
+import { schema as s } from "@nawadi/db";
+import { and, eq, isNull, sql } from "drizzle-orm";
+import { z } from "zod";
+import { useQuery } from "../../contexts/index.ts";
+import {
+  possibleSingleRow,
+  successfulCreateResponse,
+  uuidSchema,
+  withZod,
+  wrapCommand,
+  wrapQuery,
+} from "../../utils/index.ts";
+
+export const getActingProfilePreference = wrapQuery(
+  "user.actingProfile.getPreference",
+  withZod(
+    z.object({
+      userId: uuidSchema,
+      locationId: uuidSchema,
+    }),
+    uuidSchema.nullable(),
+    async (input) => {
+      const query = useQuery();
+
+      const row = await query
+        .select({ personId: s.userActingProfilePreference.personId })
+        .from(s.userActingProfilePreference)
+        .where(
+          and(
+            eq(s.userActingProfilePreference.userId, input.userId),
+            eq(s.userActingProfilePreference.locationId, input.locationId),
+            isNull(s.userActingProfilePreference.deletedAt),
+          ),
+        )
+        .then(possibleSingleRow);
+
+      return row?.personId ?? null;
+    },
+  ),
+);
+
+export const setActingProfilePreference = wrapCommand(
+  "user.actingProfile.setPreference",
+  withZod(
+    z.object({
+      userId: uuidSchema,
+      locationId: uuidSchema,
+      personId: uuidSchema,
+    }),
+    successfulCreateResponse,
+    async (input) => {
+      const query = useQuery();
+
+      const result = await query
+        .insert(s.userActingProfilePreference)
+        .values({
+          userId: input.userId,
+          locationId: input.locationId,
+          personId: input.personId,
+        })
+        .onConflictDoUpdate({
+          target: [
+            s.userActingProfilePreference.userId,
+            s.userActingProfilePreference.locationId,
+          ],
+          set: {
+            personId: input.personId,
+            deletedAt: null,
+            updatedAt: sql`NOW()`,
+          },
+        })
+        .returning({ id: s.userActingProfilePreference.id })
+        .then((rows) => {
+          const row = rows[0];
+          if (!row) {
+            throw new Error("Failed to upsert acting profile preference");
+          }
+          return row;
+        });
+
+      return result;
+    },
+  ),
+);

--- a/packages/core/src/models/user/index.ts
+++ b/packages/core/src/models/user/index.ts
@@ -1,3 +1,4 @@
+export * as ActingProfile from "./acting-profile.ts";
 export * as Actor from "./actor.ts";
 export * as Person from "./person.ts";
 export * from "./user.ts";

--- a/packages/db/migrations/0040_gifted_changeling.sql
+++ b/packages/db/migrations/0040_gifted_changeling.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "user_acting_profile_preference" (
+	"id" uuid PRIMARY KEY DEFAULT extensions.uuid_generate_v4() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"location_id" uuid NOT NULL,
+	"person_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone,
+	CONSTRAINT "unq_acting_profile_user_location" UNIQUE("user_id","location_id")
+);
+
+ALTER TABLE "user_acting_profile_preference" ADD CONSTRAINT "user_acting_profile_preference_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("auth_user_id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "user_acting_profile_preference" ADD CONSTRAINT "user_acting_profile_preference_location_id_fk" FOREIGN KEY ("location_id") REFERENCES "public"."location"("id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "user_acting_profile_preference" ADD CONSTRAINT "user_acting_profile_preference_person_id_fk" FOREIGN KEY ("person_id") REFERENCES "public"."person"("id") ON DELETE no action ON UPDATE no action;

--- a/packages/db/migrations/0041_productive_joshua_kane.sql
+++ b/packages/db/migrations/0041_productive_joshua_kane.sql
@@ -1,0 +1,14 @@
+-- Custom SQL migration file, put your code below! --DO $$
+DECLARE t text;
+BEGIN
+    FOR t IN
+        SELECT table_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+    LOOP
+        EXECUTE format('
+            ALTER TABLE %I ENABLE ROW LEVEL SECURITY;
+        ', t, t);
+    END loop;
+END;
+$$ LANGUAGE plpgsql;

--- a/packages/db/migrations/meta/0040_snapshot.json
+++ b/packages/db/migrations/meta/0040_snapshot.json
@@ -1,0 +1,8413 @@
+{
+  "id": "2c7ac624-9e4e-481e-b064-a82a43cd7d01",
+  "prevId": "9c37c395-d728-4fad-a198-c5c8b58b3e9a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "ai_corpus.chunk": {
+      "name": "chunk",
+      "schema": "ai_corpus",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "criterium_id": {
+          "name": "criterium_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "werkproces_id": {
+          "name": "werkproces_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chunk_criterium_quality_idx": {
+          "name": "chunk_criterium_quality_idx",
+          "columns": [
+            {
+              "expression": "criterium_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quality_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chunk_source_idx": {
+          "name": "chunk_source_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chunk_source_id_source_id_fk": {
+          "name": "chunk_source_id_source_id_fk",
+          "tableFrom": "chunk",
+          "tableTo": "source",
+          "schemaTo": "ai_corpus",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chunk_criterium_id_beoordelingscriterium_id_fk": {
+          "name": "chunk_criterium_id_beoordelingscriterium_id_fk",
+          "tableFrom": "chunk",
+          "tableTo": "beoordelingscriterium",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "criterium_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chunk_werkproces_id_werkproces_id_fk": {
+          "name": "chunk_werkproces_id_werkproces_id_fk",
+          "tableFrom": "chunk",
+          "tableTo": "werkproces",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "werkproces_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ai_corpus.outline_template": {
+      "name": "outline_template",
+      "schema": "ai_corpus",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "profiel_id": {
+          "name": "profiel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sections": {
+          "name": "sections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "outline_template_profiel_version_unique": {
+          "name": "outline_template_profiel_version_unique",
+          "columns": [
+            {
+              "expression": "profiel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outline_template_profiel_id_kwalificatieprofiel_id_fk": {
+          "name": "outline_template_profiel_id_kwalificatieprofiel_id_fk",
+          "tableFrom": "outline_template",
+          "tableTo": "kwalificatieprofiel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "profiel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ai_corpus.source": {
+      "name": "source",
+      "schema": "ai_corpus",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "domain": {
+          "name": "domain",
+          "type": "domain",
+          "typeSchema": "ai_corpus",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_identifier": {
+          "name": "source_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_level": {
+          "name": "consent_level",
+          "type": "consent_level",
+          "typeSchema": "ai_corpus",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contributed_by_user_id": {
+          "name": "contributed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profiel_id": {
+          "name": "profiel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "richting": {
+          "name": "richting",
+          "type": "richting",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "niveau_rang": {
+          "name": "niveau_rang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "char_count": {
+          "name": "char_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_storage_path": {
+          "name": "original_storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "source_domain_hash_unique": {
+          "name": "source_domain_hash_unique",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_chat_created_idx": {
+          "name": "source_chat_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_profiel_id_kwalificatieprofiel_id_fk": {
+          "name": "source_profiel_id_kwalificatieprofiel_id_fk",
+          "tableFrom": "source",
+          "tableTo": "kwalificatieprofiel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "profiel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_chat_id_chat_id_fk": {
+          "name": "source_chat_id_chat_id_fk",
+          "tableFrom": "source",
+          "tableTo": "chat",
+          "schemaTo": "leercoach",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bulk_import_preview": {
+      "name": "bulk_import_preview",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_person_id": {
+          "name": "created_by_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_cohort_id": {
+          "name": "target_cohort_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detection_snapshot": {
+          "name": "detection_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rows_parsed": {
+          "name": "rows_parsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "bulk_import_preview_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bulk_import_preview_expires_at_idx": {
+          "name": "bulk_import_preview_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bulk_import_preview_location_id_fk": {
+          "name": "bulk_import_preview_location_id_fk",
+          "tableFrom": "bulk_import_preview",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bulk_import_preview_created_by_person_id_fk": {
+          "name": "bulk_import_preview_created_by_person_id_fk",
+          "tableFrom": "bulk_import_preview",
+          "tableTo": "person",
+          "columnsFrom": [
+            "created_by_person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bulk_import_preview_target_cohort_id_fk": {
+          "name": "bulk_import_preview_target_cohort_id_fk",
+          "tableFrom": "bulk_import_preview",
+          "tableTo": "cohort",
+          "columnsFrom": [
+            "target_cohort_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_merge_audit": {
+      "name": "person_merge_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "performed_by_person_id": {
+          "name": "performed_by_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_person_id": {
+          "name": "source_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_person_id": {
+          "name": "target_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_kind": {
+          "name": "decision_kind",
+          "type": "person_merge_audit_decision_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "presented_candidate_person_ids": {
+          "name": "presented_candidate_person_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "person_merge_audit_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bulk_import_preview_token": {
+          "name": "bulk_import_preview_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_audit_target_person_id_idx": {
+          "name": "person_merge_audit_target_person_id_idx",
+          "columns": [
+            {
+              "expression": "target_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_merge_audit_location_id_idx": {
+          "name": "person_merge_audit_location_id_idx",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_merge_audit_performed_at_idx": {
+          "name": "person_merge_audit_performed_at_idx",
+          "columns": [
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_merge_audit_location_id_fk": {
+          "name": "person_merge_audit_location_id_fk",
+          "tableFrom": "person_merge_audit",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "person_merge_audit_bulk_import_preview_token_fk": {
+          "name": "person_merge_audit_bulk_import_preview_token_fk",
+          "tableFrom": "person_merge_audit",
+          "tableTo": "bulk_import_preview",
+          "columnsFrom": [
+            "bulk_import_preview_token"
+          ],
+          "columnsTo": [
+            "token"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.token": {
+      "name": "token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partial_key": {
+          "name": "partial_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "token_hashed_key_index": {
+          "name": "token_hashed_key_index",
+          "columns": [
+            {
+              "expression": "hashed_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "token_user_id_fk": {
+          "name": "token_user_id_fk",
+          "tableFrom": "token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "auth_user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.token_usage": {
+      "name": "token_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "token_usage_token_id_used_at_index": {
+          "name": "token_usage_token_id_used_at_index",
+          "columns": [
+            {
+              "expression": "token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "used_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "token_usage_token_id_fk": {
+          "name": "token_usage_token_id_fk",
+          "tableFrom": "token_usage",
+          "tableTo": "token",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cohort_allocation_role": {
+      "name": "cohort_allocation_role",
+      "schema": "",
+      "columns": {
+        "cohort_allocation_id": {
+          "name": "cohort_allocation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cohort_allocation_role_allocation_id_fk": {
+          "name": "cohort_allocation_role_allocation_id_fk",
+          "tableFrom": "cohort_allocation_role",
+          "tableTo": "cohort_allocation",
+          "columnsFrom": [
+            "cohort_allocation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_role_role_id_fk": {
+          "name": "user_role_role_id_fk",
+          "tableFrom": "cohort_allocation_role",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "cohort_allocation_role_cohort_allocation_id_role_id_pk": {
+          "name": "cohort_allocation_role_cohort_allocation_id_role_id_pk",
+          "columns": [
+            "cohort_allocation_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_role": {
+      "name": "person_role",
+      "schema": "",
+      "columns": {
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "person_role_person_id_fk": {
+          "name": "person_role_person_id_fk",
+          "tableFrom": "person_role",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_role_role_id_fk": {
+          "name": "user_role_role_id_fk",
+          "tableFrom": "person_role",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "person_role_person_id_role_id_pk": {
+          "name": "person_role_person_id_role_id_pk",
+          "columns": [
+            "person_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.privilege": {
+      "name": "privilege",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "privilege_handle_index": {
+          "name": "privilege_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "role_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "role_handle_index": {
+          "name": "role_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_location_id_fk": {
+          "name": "role_location_id_fk",
+          "tableFrom": "role",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_privilege": {
+      "name": "role_privilege",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privilege_id": {
+          "name": "privilege_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_privilege_role_id_fk": {
+          "name": "role_privilege_role_id_fk",
+          "tableFrom": "role_privilege",
+          "tableTo": "role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "role_privilege_privilege_id_fk": {
+          "name": "role_privilege_privilege_id_fk",
+          "tableFrom": "role_privilege",
+          "tableTo": "privilege",
+          "columnsFrom": [
+            "privilege_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_privilege_pk": {
+          "name": "role_privilege_pk",
+          "columns": [
+            "role_id",
+            "privilege_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.token_privilege": {
+      "name": "token_privilege",
+      "schema": "",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privilege_id": {
+          "name": "privilege_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "token_privilege_token_id_fk": {
+          "name": "token_privilege_token_id_fk",
+          "tableFrom": "token_privilege",
+          "tableTo": "token",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "token_privilege_privilege_id_fk": {
+          "name": "token_privilege_privilege_id_fk",
+          "tableFrom": "token_privilege",
+          "tableTo": "privilege",
+          "columnsFrom": [
+            "privilege_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "token_privilege_pk": {
+          "name": "token_privilege_pk",
+          "columns": [
+            "token_id",
+            "privilege_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certificate": {
+      "name": "certificate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_curriculum_id": {
+          "name": "student_curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort_allocation_id": {
+          "name": "cohort_allocation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visible_from": {
+          "name": "visible_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "certificate_unq_handle": {
+          "name": "certificate_unq_handle",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_idx_location": {
+          "name": "certificate_idx_location",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_idx_issued_at": {
+          "name": "certificate_idx_issued_at",
+          "columns": [
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_idx_visible_from": {
+          "name": "certificate_idx_visible_from",
+          "columns": [
+            {
+              "expression": "visible_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_idx_deleted_at": {
+          "name": "certificate_idx_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_idx_location_issued_at": {
+          "name": "certificate_idx_location_issued_at",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_idx_handle_search": {
+          "name": "certificate_idx_handle_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', \"handle\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "certificate_student_curriculum_link_id_fk": {
+          "name": "certificate_student_curriculum_link_id_fk",
+          "tableFrom": "certificate",
+          "tableTo": "student_curriculum",
+          "columnsFrom": [
+            "student_curriculum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "certificate_location_id_fk": {
+          "name": "certificate_location_id_fk",
+          "tableFrom": "certificate",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "certificate_cohort_allocation_id_fk": {
+          "name": "certificate_cohort_allocation_id_fk",
+          "tableFrom": "certificate",
+          "tableTo": "cohort_allocation",
+          "columnsFrom": [
+            "cohort_allocation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_certificate": {
+      "name": "external_certificate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuing_authority": {
+          "name": "issuing_authority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuing_location": {
+          "name": "issuing_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awarded_at": {
+          "name": "awarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_comments": {
+          "name": "additional_comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "external_certificate_media_id_media_id_fk": {
+          "name": "external_certificate_media_id_media_id_fk",
+          "tableFrom": "external_certificate",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "external_certificate_person_id_fk": {
+          "name": "external_certificate_person_id_fk",
+          "tableFrom": "external_certificate",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "external_certificate_location_id_fk": {
+          "name": "external_certificate_location_id_fk",
+          "tableFrom": "external_certificate",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_completed_competency": {
+      "name": "student_completed_competency",
+      "schema": "",
+      "columns": {
+        "student_curriculum_id": {
+          "name": "student_curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "curriculum_module_competency_id": {
+          "name": "curriculum_module_competency_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "certificate_id": {
+          "name": "certificate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_merge_conflict_duplicate": {
+          "name": "is_merge_conflict_duplicate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "student_completed_competency_unq_active_non_merge": {
+          "name": "student_completed_competency_unq_active_non_merge",
+          "columns": [
+            {
+              "expression": "student_curriculum_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "curriculum_module_competency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"student_completed_competency\".\"is_merge_conflict_duplicate\" = false AND \"student_completed_competency\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_completed_competency_student_curriculum_link_id_fk": {
+          "name": "student_completed_competency_student_curriculum_link_id_fk",
+          "tableFrom": "student_completed_competency",
+          "tableTo": "student_curriculum",
+          "columnsFrom": [
+            "student_curriculum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "curriculum_competency_competency_id_fk": {
+          "name": "curriculum_competency_competency_id_fk",
+          "tableFrom": "student_completed_competency",
+          "tableTo": "curriculum_competency",
+          "columnsFrom": [
+            "curriculum_module_competency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_completed_competency_certificate_id_fk": {
+          "name": "student_completed_competency_certificate_id_fk",
+          "tableFrom": "student_completed_competency",
+          "tableTo": "certificate",
+          "columnsFrom": [
+            "certificate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "student_completed_competency_pk": {
+          "name": "student_completed_competency_pk",
+          "columns": [
+            "student_curriculum_id",
+            "curriculum_module_competency_id",
+            "certificate_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_curriculum": {
+      "name": "student_curriculum",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "curriculum_id": {
+          "name": "curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_type_id": {
+          "name": "gear_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "student_curriculum_unq_identity_gear_curriculum": {
+          "name": "student_curriculum_unq_identity_gear_curriculum",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "curriculum_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gear_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"student_curriculum\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "student_curriculum_idx_person": {
+          "name": "student_curriculum_idx_person",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_curriculum_link_curriculum_id_gear_type_id_fk": {
+          "name": "student_curriculum_link_curriculum_id_gear_type_id_fk",
+          "tableFrom": "student_curriculum",
+          "tableTo": "curriculum_gear_link",
+          "columnsFrom": [
+            "curriculum_id",
+            "gear_type_id"
+          ],
+          "columnsTo": [
+            "curriculum_id",
+            "gear_type_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_curriculum_link_curriculum_id_fk": {
+          "name": "student_curriculum_link_curriculum_id_fk",
+          "tableFrom": "student_curriculum",
+          "tableTo": "curriculum",
+          "columnsFrom": [
+            "curriculum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_curriculum_link_gear_type_id_fk": {
+          "name": "student_curriculum_link_gear_type_id_fk",
+          "tableFrom": "student_curriculum",
+          "tableTo": "gear_type",
+          "columnsFrom": [
+            "gear_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_curriculum_link_person_id_fk": {
+          "name": "student_curriculum_link_person_id_fk",
+          "tableFrom": "student_curriculum",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cohort": {
+      "name": "cohort",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_start_time": {
+          "name": "access_start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_end_time": {
+          "name": "access_end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "certificates_visible_from": {
+          "name": "certificates_visible_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cohort_handle_location_id_index": {
+          "name": "cohort_handle_location_id_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cohort_location_id_fk": {
+          "name": "cohort_location_id_fk",
+          "tableFrom": "cohort",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cohort_allocation": {
+      "name": "cohort_allocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "cohort_id": {
+          "name": "cohort_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_curriculum_id": {
+          "name": "student_curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructor_id": {
+          "name": "instructor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "progress_visible_up_until": {
+          "name": "progress_visible_up_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cohort_allocation_cohort_id_actor_id_student_curriculum_id_index": {
+          "name": "cohort_allocation_cohort_id_actor_id_student_curriculum_id_index",
+          "columns": [
+            {
+              "expression": "cohort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_curriculum_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cohort_allocation\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cohort_allocation_cohort_id_tags_index": {
+          "name": "cohort_allocation_cohort_id_tags_index",
+          "columns": [
+            {
+              "expression": "cohort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cohort_allocation_cohort_id_fk": {
+          "name": "cohort_allocation_cohort_id_fk",
+          "tableFrom": "cohort_allocation",
+          "tableTo": "cohort",
+          "columnsFrom": [
+            "cohort_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cohort_allocation_actor_id_fk": {
+          "name": "cohort_allocation_actor_id_fk",
+          "tableFrom": "cohort_allocation",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cohort_allocation_student_curriculum_id_fk": {
+          "name": "cohort_allocation_student_curriculum_id_fk",
+          "tableFrom": "cohort_allocation",
+          "tableTo": "student_curriculum",
+          "columnsFrom": [
+            "student_curriculum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cohort_allocation_instructor_id_fk": {
+          "name": "cohort_allocation_instructor_id_fk",
+          "tableFrom": "cohort_allocation",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "instructor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category": {
+      "name": "category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "parent_category_id": {
+          "name": "parent_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "category_handle_index": {
+          "name": "category_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "category_parent_category_id_fk": {
+          "name": "category_parent_category_id_fk",
+          "tableFrom": "category",
+          "tableTo": "category",
+          "columnsFrom": [
+            "parent_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competency": {
+      "name": "competency",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "competency_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "competency_handle_index": {
+          "name": "competency_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course": {
+      "name": "course",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discipline_id": {
+          "name": "discipline_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "course_handle_index": {
+          "name": "course_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_discipline_id_fk": {
+          "name": "course_discipline_id_fk",
+          "tableFrom": "course",
+          "tableTo": "discipline",
+          "columnsFrom": [
+            "discipline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_category": {
+      "name": "course_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "course_category_category_id_course_id_index": {
+          "name": "course_category_category_id_course_id_index",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_category_course_id_fk": {
+          "name": "course_category_course_id_fk",
+          "tableFrom": "course_category",
+          "tableTo": "course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "course_category_category_id_fk": {
+          "name": "course_category_category_id_fk",
+          "tableFrom": "course_category",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.degree": {
+      "name": "degree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rang": {
+          "name": "rang",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "degree_handle_index": {
+          "name": "degree_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "degree_rang_index": {
+          "name": "degree_rang_index",
+          "columns": [
+            {
+              "expression": "rang",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discipline": {
+      "name": "discipline",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "discipline_handle_index": {
+          "name": "discipline_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gear_type": {
+      "name": "gear_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gear_type_handle_index": {
+          "name": "gear_type_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.module": {
+      "name": "module",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "module_handle_index": {
+          "name": "module_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.program": {
+      "name": "program",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degree_id": {
+          "name": "degree_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "program_handle_index": {
+          "name": "program_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "program_course_id_fk": {
+          "name": "program_course_id_fk",
+          "tableFrom": "program",
+          "tableTo": "course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "program_degree_id_fk": {
+          "name": "program_degree_id_fk",
+          "tableFrom": "program",
+          "tableTo": "degree",
+          "columnsFrom": [
+            "degree_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curriculum": {
+      "name": "curriculum",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "curriculum_program_id_revision_index": {
+          "name": "curriculum_program_id_revision_index",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curriculum_program_id_fk": {
+          "name": "curriculum_program_id_fk",
+          "tableFrom": "curriculum",
+          "tableTo": "program",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curriculum_competency": {
+      "name": "curriculum_competency",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "curriculum_id": {
+          "name": "curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competency_id": {
+          "name": "competency_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement": {
+          "name": "requirement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "curriculum_competency_unq_set": {
+          "name": "curriculum_competency_unq_set",
+          "columns": [
+            {
+              "expression": "curriculum_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "module_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curriculum_competency_curriculum_module_id_fk": {
+          "name": "curriculum_competency_curriculum_module_id_fk",
+          "tableFrom": "curriculum_competency",
+          "tableTo": "curriculum_module",
+          "columnsFrom": [
+            "curriculum_id",
+            "module_id"
+          ],
+          "columnsTo": [
+            "curriculum_id",
+            "module_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "curriculum_competency_competency_id_fk": {
+          "name": "curriculum_competency_competency_id_fk",
+          "tableFrom": "curriculum_competency",
+          "tableTo": "competency",
+          "columnsFrom": [
+            "competency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curriculum_gear_link": {
+      "name": "curriculum_gear_link",
+      "schema": "",
+      "columns": {
+        "curriculum_id": {
+          "name": "curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_type_id": {
+          "name": "gear_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "curriculum_gear_link_curriculum_id_fk": {
+          "name": "curriculum_gear_link_curriculum_id_fk",
+          "tableFrom": "curriculum_gear_link",
+          "tableTo": "curriculum",
+          "columnsFrom": [
+            "curriculum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "curriculum_gear_link_gear_type_id_fk": {
+          "name": "curriculum_gear_link_gear_type_id_fk",
+          "tableFrom": "curriculum_gear_link",
+          "tableTo": "gear_type",
+          "columnsFrom": [
+            "gear_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curriculum_gear_link_curriculum_id_gear_type_id_pk": {
+          "name": "curriculum_gear_link_curriculum_id_gear_type_id_pk",
+          "columns": [
+            "curriculum_id",
+            "gear_type_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curriculum_module": {
+      "name": "curriculum_module",
+      "schema": "",
+      "columns": {
+        "curriculum_id": {
+          "name": "curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "curriculum_module_curriculum_id_module_id_index": {
+          "name": "curriculum_module_curriculum_id_module_id_index",
+          "columns": [
+            {
+              "expression": "curriculum_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "module_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "curriculum_module_curriculum_id_fk": {
+          "name": "curriculum_module_curriculum_id_fk",
+          "tableFrom": "curriculum_module",
+          "tableTo": "curriculum",
+          "columnsFrom": [
+            "curriculum_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "curriculum_module_module_id_fk": {
+          "name": "curriculum_module_module_id_fk",
+          "tableFrom": "curriculum_module",
+          "tableTo": "module",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curriculum_module_curriculum_id_module_id_pk": {
+          "name": "curriculum_module_curriculum_id_module_id_pk",
+          "columns": [
+            "curriculum_id",
+            "module_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.instructie_groep": {
+      "name": "instructie_groep",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "richting": {
+          "name": "richting",
+          "type": "richting",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.instructie_groep_cursus": {
+      "name": "instructie_groep_cursus",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "instructie_groep_id": {
+          "name": "instructie_groep_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "instructie_groep_cursus_instructie_groep_id_course_id_index": {
+          "name": "instructie_groep_cursus_instructie_groep_id_course_id_index",
+          "columns": [
+            {
+              "expression": "instructie_groep_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instructie_groep_cursus_instructie_groep_id_instructie_groep_id_fk": {
+          "name": "instructie_groep_cursus_instructie_groep_id_instructie_groep_id_fk",
+          "tableFrom": "instructie_groep_cursus",
+          "tableTo": "instructie_groep",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "instructie_groep_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "instructie_groep_cursus_course_id_course_id_fk": {
+          "name": "instructie_groep_cursus_course_id_course_id_fk",
+          "tableFrom": "instructie_groep_cursus",
+          "tableTo": "course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.persoon_kwalificatie": {
+      "name": "persoon_kwalificatie",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "direct_behaalde_pvb_onderdeel_id": {
+          "name": "direct_behaalde_pvb_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "afgeleide_pvb_onderdeel_id": {
+          "name": "afgeleide_pvb_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_onderdeel_id": {
+          "name": "kerntaak_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verkregen_reden": {
+          "name": "verkregen_reden",
+          "type": "kwalificatie_verkregen_reden",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'onbekend'"
+        },
+        "toegevoegd_op": {
+          "name": "toegevoegd_op",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toegevoegd_door": {
+          "name": "toegevoegd_door",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "unique_person_course_kerntaak_onderdeel": {
+          "name": "unique_person_course_kerntaak_onderdeel",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kerntaak_onderdeel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "persoon_kwalificatie_direct_behaalde_pvb_onderdeel_id_kerntaak_onderdeel_id_pvb_onderdeel_id_kerntaak_onderdeel_id_fk": {
+          "name": "persoon_kwalificatie_direct_behaalde_pvb_onderdeel_id_kerntaak_onderdeel_id_pvb_onderdeel_id_kerntaak_onderdeel_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "tableTo": "pvb_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "direct_behaalde_pvb_onderdeel_id",
+            "kerntaak_onderdeel_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_onderdeel_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persoon_kwalificatie_afgeleide_pvb_onderdeel_id_kerntaak_onderdeel_id_pvb_onderdeel_id_kerntaak_onderdeel_id_fk": {
+          "name": "persoon_kwalificatie_afgeleide_pvb_onderdeel_id_kerntaak_onderdeel_id_pvb_onderdeel_id_kerntaak_onderdeel_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "tableTo": "pvb_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "afgeleide_pvb_onderdeel_id",
+            "kerntaak_onderdeel_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_onderdeel_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persoon_kwalificatie_kerntaak_onderdeel_id_kerntaak_onderdeel_id_fk": {
+          "name": "persoon_kwalificatie_kerntaak_onderdeel_id_kerntaak_onderdeel_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "tableTo": "kerntaak_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_onderdeel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persoon_kwalificatie_course_id_course_id_fk": {
+          "name": "persoon_kwalificatie_course_id_course_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "tableTo": "course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persoon_kwalificatie_toegevoegd_door_actor_id_fk": {
+          "name": "persoon_kwalificatie_toegevoegd_door_actor_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "toegevoegd_door"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "persoon_kwalificatie_person_id_person_id_fk": {
+          "name": "persoon_kwalificatie_person_id_person_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verkregen_reden_pvb_behaald_constraint": {
+          "name": "verkregen_reden_pvb_behaald_constraint",
+          "value": "(\"kss\".\"persoon_kwalificatie\".\"verkregen_reden\" != 'pvb_behaald') OR (\"kss\".\"persoon_kwalificatie\".\"direct_behaalde_pvb_onderdeel_id\" IS NOT NULL AND \"kss\".\"persoon_kwalificatie\".\"afgeleide_pvb_onderdeel_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "kss.pvb_aanvraag": {
+      "name": "pvb_aanvraag",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kandidaat_id": {
+          "name": "kandidaat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locatie_id": {
+          "name": "locatie_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "pvb_aanvraag_type",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_aanvraag_kandidaat_id_person_id_fk": {
+          "name": "pvb_aanvraag_kandidaat_id_person_id_fk",
+          "tableFrom": "pvb_aanvraag",
+          "tableTo": "person",
+          "columnsFrom": [
+            "kandidaat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_aanvraag_locatie_id_location_id_fk": {
+          "name": "pvb_aanvraag_locatie_id_location_id_fk",
+          "tableFrom": "pvb_aanvraag",
+          "tableTo": "location",
+          "columnsFrom": [
+            "locatie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pvb_aanvraag_handle_unique": {
+          "name": "pvb_aanvraag_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_aanvraag_course": {
+      "name": "pvb_aanvraag_course",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructie_groep_id": {
+          "name": "instructie_groep_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_main_course": {
+          "name": "is_main_course",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pvb_aanvraag_course_pvb_aanvraag_id_instructie_groep_id_index": {
+          "name": "pvb_aanvraag_course_pvb_aanvraag_id_instructie_groep_id_index",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instructie_groep_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"kss\".\"pvb_aanvraag_course\".\"is_main_course\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pvb_aanvraag_course_pvb_aanvraag_id_instructie_groep_id_course_id_index": {
+          "name": "pvb_aanvraag_course_pvb_aanvraag_id_instructie_groep_id_course_id_index",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instructie_groep_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pvb_aanvraag_course_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_aanvraag_course_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_aanvraag_course",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_aanvraag_course_course_id_course_id_fk": {
+          "name": "pvb_aanvraag_course_course_id_course_id_fk",
+          "tableFrom": "pvb_aanvraag_course",
+          "tableTo": "course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_aanvraag_course_instructie_groep_id_instructie_groep_id_fk": {
+          "name": "pvb_aanvraag_course_instructie_groep_id_instructie_groep_id_fk",
+          "tableFrom": "pvb_aanvraag_course",
+          "tableTo": "instructie_groep",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "instructie_groep_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_aanvraag_status": {
+      "name": "pvb_aanvraag_status",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "aanvraag_status",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aangemaakt_op": {
+          "name": "aangemaakt_op",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "aangemaakt_door": {
+          "name": "aangemaakt_door",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reden": {
+          "name": "reden",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_aanvraag_status_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_aanvraag_status_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_aanvraag_status",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_aanvraag_status_aangemaakt_door_actor_id_fk": {
+          "name": "pvb_aanvraag_status_aangemaakt_door_actor_id_fk",
+          "tableFrom": "pvb_aanvraag_status",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "aangemaakt_door"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_beoordelaar_beschikbaarheid": {
+      "name": "pvb_beoordelaar_beschikbaarheid",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beoordelaar_id": {
+          "name": "beoordelaar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pvb_voorstel_datum_id": {
+          "name": "pvb_voorstel_datum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_beoordelaar_beschikbaarheid_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_beoordelaar_beschikbaarheid_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_beoordelaar_beschikbaarheid",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_beoordelaar_beschikbaarheid_beoordelaar_id_person_id_fk": {
+          "name": "pvb_beoordelaar_beschikbaarheid_beoordelaar_id_person_id_fk",
+          "tableFrom": "pvb_beoordelaar_beschikbaarheid",
+          "tableTo": "person",
+          "columnsFrom": [
+            "beoordelaar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_beoordelaar_beschikbaarheid_pvb_voorstel_datum_id_pvb_aanvraag_id_pvb_voorstel_datum_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_beoordelaar_beschikbaarheid_pvb_voorstel_datum_id_pvb_aanvraag_id_pvb_voorstel_datum_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_beoordelaar_beschikbaarheid",
+          "tableTo": "pvb_voorstel_datum",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_voorstel_datum_id",
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id",
+            "pvb_aanvraag_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_beoordelaar_beschikbaarheid_status": {
+      "name": "pvb_beoordelaar_beschikbaarheid_status",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_beoordelaar_beschikbaarheid_id": {
+          "name": "pvb_beoordelaar_beschikbaarheid_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "beoordelaar_beschikbaarheidsstatus",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aangemaakt_op": {
+          "name": "aangemaakt_op",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "aangemaakt_door": {
+          "name": "aangemaakt_door",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reden": {
+          "name": "reden",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_beoordelaar_beschikbaarheid_status_pvb_beoordelaar_beschikbaarheid_id_pvb_beoordelaar_beschikbaarheid_id_fk": {
+          "name": "pvb_beoordelaar_beschikbaarheid_status_pvb_beoordelaar_beschikbaarheid_id_pvb_beoordelaar_beschikbaarheid_id_fk",
+          "tableFrom": "pvb_beoordelaar_beschikbaarheid_status",
+          "tableTo": "pvb_beoordelaar_beschikbaarheid",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_beoordelaar_beschikbaarheid_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_beoordelaar_beschikbaarheid_status_aangemaakt_door_actor_id_fk": {
+          "name": "pvb_beoordelaar_beschikbaarheid_status_aangemaakt_door_actor_id_fk",
+          "tableFrom": "pvb_beoordelaar_beschikbaarheid_status",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "aangemaakt_door"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_beoordelaar_onderdeel_beschikbaarheid": {
+      "name": "pvb_beoordelaar_onderdeel_beschikbaarheid",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_beoordelaar_beschikbaarheid_id": {
+          "name": "pvb_beoordelaar_beschikbaarheid_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pvb_onderdeel_id": {
+          "name": "pvb_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_beoordelaar_onderdeel_beschikbaarheid_pvb_beoordelaar_beschikbaarheid_id_pvb_beoordelaar_beschikbaarheid_id_fk": {
+          "name": "pvb_beoordelaar_onderdeel_beschikbaarheid_pvb_beoordelaar_beschikbaarheid_id_pvb_beoordelaar_beschikbaarheid_id_fk",
+          "tableFrom": "pvb_beoordelaar_onderdeel_beschikbaarheid",
+          "tableTo": "pvb_beoordelaar_beschikbaarheid",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_beoordelaar_beschikbaarheid_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_beoordelaar_onderdeel_beschikbaarheid_pvb_onderdeel_id_pvb_onderdeel_id_fk": {
+          "name": "pvb_beoordelaar_onderdeel_beschikbaarheid_pvb_onderdeel_id_pvb_onderdeel_id_fk",
+          "tableFrom": "pvb_beoordelaar_onderdeel_beschikbaarheid",
+          "tableTo": "pvb_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_onderdeel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_gebeurtenis": {
+      "name": "pvb_gebeurtenis",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pvb_onderdeel_id": {
+          "name": "pvb_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gebeurtenis_type": {
+          "name": "gebeurtenis_type",
+          "type": "pvb_gebeurtenis_type",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aangemaakt_op": {
+          "name": "aangemaakt_op",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "aangemaakt_door": {
+          "name": "aangemaakt_door",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reden": {
+          "name": "reden",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_gebeurtenis_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_gebeurtenis_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_gebeurtenis",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_gebeurtenis_pvb_onderdeel_id_pvb_onderdeel_id_fk": {
+          "name": "pvb_gebeurtenis_pvb_onderdeel_id_pvb_onderdeel_id_fk",
+          "tableFrom": "pvb_gebeurtenis",
+          "tableTo": "pvb_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_onderdeel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_gebeurtenis_aangemaakt_door_actor_id_fk": {
+          "name": "pvb_gebeurtenis_aangemaakt_door_actor_id_fk",
+          "tableFrom": "pvb_gebeurtenis",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "aangemaakt_door"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_leercoach_toestemming": {
+      "name": "pvb_leercoach_toestemming",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leercoach_id": {
+          "name": "leercoach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "leercoach_toestemming_status",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aangemaakt_op": {
+          "name": "aangemaakt_op",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "aangemaakt_door": {
+          "name": "aangemaakt_door",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reden": {
+          "name": "reden",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pvb_leercoach_toestemming_recent_idx": {
+          "name": "pvb_leercoach_toestemming_recent_idx",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "leercoach_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "aangemaakt_op",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pvb_leercoach_toestemming_status_idx": {
+          "name": "pvb_leercoach_toestemming_status_idx",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "leercoach_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pvb_leercoach_toestemming_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_leercoach_toestemming_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_leercoach_toestemming",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_leercoach_toestemming_leercoach_id_person_id_fk": {
+          "name": "pvb_leercoach_toestemming_leercoach_id_person_id_fk",
+          "tableFrom": "pvb_leercoach_toestemming",
+          "tableTo": "person",
+          "columnsFrom": [
+            "leercoach_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_leercoach_toestemming_aangemaakt_door_actor_id_fk": {
+          "name": "pvb_leercoach_toestemming_aangemaakt_door_actor_id_fk",
+          "tableFrom": "pvb_leercoach_toestemming",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "aangemaakt_door"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_onderdeel": {
+      "name": "pvb_onderdeel",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_onderdeel_id": {
+          "name": "kerntaak_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beoordelaar_id": {
+          "name": "beoordelaar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_datum_tijd": {
+          "name": "start_datum_tijd",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uitslag": {
+          "name": "uitslag",
+          "type": "pvb_onderdeel_uitslag",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'nog_niet_bekend'"
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pvb_onderdeel_aanvraag_id_kerntaak_onderdeel_id_beoordelaar_id_unique": {
+          "name": "pvb_onderdeel_aanvraag_id_kerntaak_onderdeel_id_beoordelaar_id_unique",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kerntaak_onderdeel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "beoordelaar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pvb_onderdeel_aanvraag_id_kerntaak_onderdeel_id_unique": {
+          "name": "pvb_onderdeel_aanvraag_id_kerntaak_onderdeel_id_unique",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kerntaak_onderdeel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pvb_onderdeel_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_onderdeel_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_onderdeel",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_onderdeel_kerntaak_onderdeel_id_kerntaak_id_kerntaak_onderdeel_id_kerntaak_id_fk": {
+          "name": "pvb_onderdeel_kerntaak_onderdeel_id_kerntaak_id_kerntaak_onderdeel_id_kerntaak_id_fk",
+          "tableFrom": "pvb_onderdeel",
+          "tableTo": "kerntaak_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_onderdeel_id",
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_onderdeel_kerntaak_id_kerntaak_id_fk": {
+          "name": "pvb_onderdeel_kerntaak_id_kerntaak_id_fk",
+          "tableFrom": "pvb_onderdeel",
+          "tableTo": "kerntaak",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_onderdeel_beoordelaar_id_person_id_fk": {
+          "name": "pvb_onderdeel_beoordelaar_id_person_id_fk",
+          "tableFrom": "pvb_onderdeel",
+          "tableTo": "person",
+          "columnsFrom": [
+            "beoordelaar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pvb_onderdeel_id_kerntaak_onderdeel_id_unique": {
+          "name": "pvb_onderdeel_id_kerntaak_onderdeel_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "kerntaak_onderdeel_id"
+          ]
+        },
+        "pvb_onderdeel_id_kerntaak_onderdeel_id_beoordelaar_id_unique": {
+          "name": "pvb_onderdeel_id_kerntaak_onderdeel_id_beoordelaar_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "kerntaak_onderdeel_id",
+            "beoordelaar_id"
+          ]
+        },
+        "pvb_onderdeel_id_kerntaak_id_unique": {
+          "name": "pvb_onderdeel_id_kerntaak_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "kerntaak_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_onderdeel_beoordelingscriterium": {
+      "name": "pvb_onderdeel_beoordelingscriterium",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_onderdeel_id": {
+          "name": "pvb_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beoordelingscriterium_id": {
+          "name": "beoordelingscriterium_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "behaald": {
+          "name": "behaald",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_onderdeel_beoordelingscriterium_pvb_onderdeel_id_kerntaak_id_pvb_onderdeel_id_kerntaak_id_fk": {
+          "name": "pvb_onderdeel_beoordelingscriterium_pvb_onderdeel_id_kerntaak_id_pvb_onderdeel_id_kerntaak_id_fk",
+          "tableFrom": "pvb_onderdeel_beoordelingscriterium",
+          "tableTo": "pvb_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_onderdeel_id",
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_onderdeel_beoordelingscriterium_beoordelingscriterium_id_kerntaak_id_beoordelingscriterium_id_kerntaak_id_fk": {
+          "name": "pvb_onderdeel_beoordelingscriterium_beoordelingscriterium_id_kerntaak_id_beoordelingscriterium_id_kerntaak_id_fk",
+          "tableFrom": "pvb_onderdeel_beoordelingscriterium",
+          "tableTo": "beoordelingscriterium",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "beoordelingscriterium_id",
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pvb_onderdeel_beoordelingscriterium_kerntaak_id_kerntaak_id_fk": {
+          "name": "pvb_onderdeel_beoordelingscriterium_kerntaak_id_kerntaak_id_fk",
+          "tableFrom": "pvb_onderdeel_beoordelingscriterium",
+          "tableTo": "kerntaak",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pvb_onderdeel_beoordelingscriterium_pvb_onderdeel_id_beoordelingscriterium_id_unique": {
+          "name": "pvb_onderdeel_beoordelingscriterium_pvb_onderdeel_id_beoordelingscriterium_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pvb_onderdeel_id",
+            "beoordelingscriterium_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_voorstel_datum": {
+      "name": "pvb_voorstel_datum",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_na": {
+          "name": "start_na",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eind_voor": {
+          "name": "eind_voor",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voorkeur": {
+          "name": "voorkeur",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_voorstel_datum_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_voorstel_datum_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_voorstel_datum",
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pvb_voorstel_datum_id_pvb_aanvraag_id_unique": {
+          "name": "pvb_voorstel_datum_id_pvb_aanvraag_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "pvb_aanvraag_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.beoordelingscriterium": {
+      "name": "beoordelingscriterium",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "werkproces_id": {
+          "name": "werkproces_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rang": {
+          "name": "rang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "omschrijving": {
+          "name": "omschrijving",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "beoordelingscriterium_werkproces_id_kerntaak_id_werkproces_id_kerntaak_id_fk": {
+          "name": "beoordelingscriterium_werkproces_id_kerntaak_id_werkproces_id_kerntaak_id_fk",
+          "tableFrom": "beoordelingscriterium",
+          "tableTo": "werkproces",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "werkproces_id",
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "beoordelingscriterium_kerntaak_id_kerntaak_id_fk": {
+          "name": "beoordelingscriterium_kerntaak_id_kerntaak_id_fk",
+          "tableFrom": "beoordelingscriterium",
+          "tableTo": "kerntaak",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "beoordelingscriterium_id_kerntaak_id_unique": {
+          "name": "beoordelingscriterium_id_kerntaak_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "kerntaak_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.kerntaak": {
+      "name": "kerntaak",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "titel": {
+          "name": "titel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kwalificatieprofiel_id": {
+          "name": "kwalificatieprofiel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "kerntaakType",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rang": {
+          "name": "rang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kerntaak_kwalificatieprofiel_id_kwalificatieprofiel_id_fk": {
+          "name": "kerntaak_kwalificatieprofiel_id_kwalificatieprofiel_id_fk",
+          "tableFrom": "kerntaak",
+          "tableTo": "kwalificatieprofiel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kwalificatieprofiel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.kerntaak_onderdeel": {
+      "name": "kerntaak_onderdeel",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beoordelingsType": {
+          "name": "beoordelingsType",
+          "type": "kerntaakOnderdeelType",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kerntaak_onderdeel_kerntaak_id_kerntaak_id_fk": {
+          "name": "kerntaak_onderdeel_kerntaak_id_kerntaak_id_fk",
+          "tableFrom": "kerntaak_onderdeel",
+          "tableTo": "kerntaak",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kerntaak_onderdeel_id_kerntaak_id_unique": {
+          "name": "kerntaak_onderdeel_id_kerntaak_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "kerntaak_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.kwalificatieprofiel": {
+      "name": "kwalificatieprofiel",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "titel": {
+          "name": "titel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "richting": {
+          "name": "richting",
+          "type": "richting",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "niveau_id": {
+          "name": "niveau_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kwalificatieprofiel_niveau_id_niveau_id_fk": {
+          "name": "kwalificatieprofiel_niveau_id_niveau_id_fk",
+          "tableFrom": "kwalificatieprofiel",
+          "tableTo": "niveau",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "niveau_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.niveau": {
+      "name": "niveau",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "rang": {
+          "name": "rang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.werkproces": {
+      "name": "werkproces",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "titel": {
+          "name": "titel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resultaat": {
+          "name": "resultaat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rang": {
+          "name": "rang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "werkproces_kerntaak_id_kerntaak_id_fk": {
+          "name": "werkproces_kerntaak_id_kerntaak_id_fk",
+          "tableFrom": "werkproces",
+          "tableTo": "kerntaak",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "werkproces_id_kerntaak_id_unique": {
+          "name": "werkproces_id_kerntaak_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "kerntaak_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.werkproces_kerntaak_onderdeel": {
+      "name": "werkproces_kerntaak_onderdeel",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "werkproces_id": {
+          "name": "werkproces_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_onderdeel_id": {
+          "name": "kerntaak_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "werkproces_kerntaak_onderdeel_werkproces_id_kerntaak_id_werkproces_id_kerntaak_id_fk": {
+          "name": "werkproces_kerntaak_onderdeel_werkproces_id_kerntaak_id_werkproces_id_kerntaak_id_fk",
+          "tableFrom": "werkproces_kerntaak_onderdeel",
+          "tableTo": "werkproces",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "werkproces_id",
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "werkproces_kerntaak_onderdeel_kerntaak_onderdeel_id_kerntaak_id_kerntaak_onderdeel_id_kerntaak_id_fk": {
+          "name": "werkproces_kerntaak_onderdeel_kerntaak_onderdeel_id_kerntaak_id_kerntaak_onderdeel_id_kerntaak_id_fk",
+          "tableFrom": "werkproces_kerntaak_onderdeel",
+          "tableTo": "kerntaak_onderdeel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "kerntaak_onderdeel_id",
+            "kerntaak_id"
+          ],
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "werkproces_kerntaak_onderdeel_werkproces_id_kerntaak_onderdeel_id_unique": {
+          "name": "werkproces_kerntaak_onderdeel_werkproces_id_kerntaak_onderdeel_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "werkproces_id",
+            "kerntaak_onderdeel_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leercoach.chat": {
+      "name": "chat",
+      "schema": "leercoach",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profiel_id": {
+          "name": "profiel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructie_groep_id": {
+          "name": "instructie_groep_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "chat_phase",
+          "typeSchema": "leercoach",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verkennen'"
+        },
+        "active_stream_id": {
+          "name": "active_stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portfolio_id": {
+          "name": "portfolio_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "chat_user_created_idx": {
+          "name": "chat_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_profiel_idx": {
+          "name": "chat_profiel_idx",
+          "columns": [
+            {
+              "expression": "profiel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_profiel_id_kwalificatieprofiel_id_fk": {
+          "name": "chat_profiel_id_kwalificatieprofiel_id_fk",
+          "tableFrom": "chat",
+          "tableTo": "kwalificatieprofiel",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "profiel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "chat_instructie_groep_id_instructie_groep_id_fk": {
+          "name": "chat_instructie_groep_id_instructie_groep_id_fk",
+          "tableFrom": "chat",
+          "tableTo": "instructie_groep",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "instructie_groep_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leercoach.message": {
+      "name": "message",
+      "schema": "leercoach",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "compacted_into_id": {
+          "name": "compacted_into_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compaction_metadata": {
+          "name": "compaction_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "message_chat_created_idx": {
+          "name": "message_chat_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_active_chat_created_idx": {
+          "name": "message_active_chat_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"leercoach\".\"message\".\"compacted_into_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_chat_id_chat_id_fk": {
+          "name": "message_chat_id_chat_id_fk",
+          "tableFrom": "message",
+          "tableTo": "chat",
+          "schemaTo": "leercoach",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leercoach.portfolio": {
+      "name": "portfolio",
+      "schema": "leercoach",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profiel_id": {
+          "name": "profiel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructie_groep_id": {
+          "name": "instructie_groep_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "portfolio_user_created_idx": {
+          "name": "portfolio_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "portfolio_user_profiel_groep_idx": {
+          "name": "portfolio_user_profiel_groep_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profiel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instructie_groep_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "portfolio_instructie_groep_id_instructie_groep_id_fk": {
+          "name": "portfolio_instructie_groep_id_instructie_groep_id_fk",
+          "tableFrom": "portfolio",
+          "tableTo": "instructie_groep",
+          "schemaTo": "kss",
+          "columnsFrom": [
+            "instructie_groep_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leercoach.portfolio_version": {
+      "name": "portfolio_version",
+      "schema": "leercoach",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "portfolio_id": {
+          "name": "portfolio_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "portfolio_version_created_by",
+          "typeSchema": "leercoach",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_message_id": {
+          "name": "created_by_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_note": {
+          "name": "change_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "portfolio_version_portfolio_created_idx": {
+          "name": "portfolio_version_portfolio_created_idx",
+          "columns": [
+            {
+              "expression": "portfolio_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "portfolio_version_portfolio_hash_unique": {
+          "name": "portfolio_version_portfolio_hash_unique",
+          "columns": [
+            {
+              "expression": "portfolio_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "portfolio_version_portfolio_id_portfolio_id_fk": {
+          "name": "portfolio_version_portfolio_id_portfolio_id_fk",
+          "tableFrom": "portfolio_version",
+          "tableTo": "portfolio",
+          "schemaTo": "leercoach",
+          "columnsFrom": [
+            "portfolio_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "portfolio_version_parent_version_id_portfolio_version_id_fk": {
+          "name": "portfolio_version_parent_version_id_portfolio_version_id_fk",
+          "tableFrom": "portfolio_version",
+          "tableTo": "portfolio_version",
+          "schemaTo": "leercoach",
+          "columnsFrom": [
+            "parent_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leercoach.upload_job": {
+      "name": "upload_job",
+      "schema": "leercoach",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "upload_job_kind",
+          "typeSchema": "leercoach",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "upload_job_status",
+          "typeSchema": "leercoach",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "blob_path": {
+          "name": "blob_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "upload_job_user_created_idx": {
+          "name": "upload_job_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "upload_job_status_idx": {
+          "name": "upload_job_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location": {
+      "name": "location",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "status": {
+          "name": "status",
+          "type": "location_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_media_id": {
+          "name": "logo_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "square_logo_media_id": {
+          "name": "square_logo_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_media_id": {
+          "name": "certificate_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "unique_handle_for_location": {
+          "name": "unique_handle_for_location",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_logo_media_id_media_id_fk": {
+          "name": "location_logo_media_id_media_id_fk",
+          "tableFrom": "location",
+          "tableTo": "media",
+          "columnsFrom": [
+            "logo_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_square_logo_media_id_media_id_fk": {
+          "name": "location_square_logo_media_id_media_id_fk",
+          "tableFrom": "location",
+          "tableTo": "media",
+          "columnsFrom": [
+            "square_logo_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_certificate_media_id_media_id_fk": {
+          "name": "location_certificate_media_id_media_id_fk",
+          "tableFrom": "location",
+          "tableTo": "media",
+          "columnsFrom": [
+            "certificate_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_resource_link": {
+      "name": "location_resource_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_type_id": {
+          "name": "gear_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discipline_id": {
+          "name": "discipline_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "location_gear_type_unique": {
+          "name": "location_gear_type_unique",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gear_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_discipline_unique": {
+          "name": "location_discipline_unique",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discipline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_resource_link_location_id_fk": {
+          "name": "location_resource_link_location_id_fk",
+          "tableFrom": "location_resource_link",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_resource_link_gear_type_id_fk": {
+          "name": "location_resource_link_gear_type_id_fk",
+          "tableFrom": "location_resource_link",
+          "tableTo": "gear_type",
+          "columnsFrom": [
+            "gear_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_resource_link_discipline_id_fk": {
+          "name": "location_resource_link_discipline_id_fk",
+          "tableFrom": "location_resource_link",
+          "tableTo": "discipline",
+          "columnsFrom": [
+            "discipline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "location_resource_link_required_one_resource": {
+          "name": "location_resource_link_required_one_resource",
+          "value": "(\n        (gear_type_id is not null)::int + \n        (discipline_id is not null)::int = 1\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.logbook": {
+      "name": "logbook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departure_port": {
+          "name": "departure_port",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arrival_port": {
+          "name": "arrival_port",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wind_power": {
+          "name": "wind_power",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wind_direction": {
+          "name": "wind_direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boat_type": {
+          "name": "boat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boat_length": {
+          "name": "boat_length",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sailed_nautical_miles": {
+          "name": "sailed_nautical_miles",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sailed_hours_in_dark": {
+          "name": "sailed_hours_in_dark",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_role": {
+          "name": "primary_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crew_names": {
+          "name": "crew_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_comments": {
+          "name": "additional_comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "logbook_person_id_fk": {
+          "name": "logbook_person_id_fk",
+          "tableFrom": "logbook",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "marketing.cashback": {
+      "name": "cashback",
+      "schema": "marketing",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "applicant_full_name": {
+          "name": "applicant_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_email": {
+          "name": "applicant_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_iban": {
+          "name": "applicant_iban",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_full_name": {
+          "name": "student_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_media_id": {
+          "name": "verification_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_location": {
+          "name": "verification_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booking_location_id": {
+          "name": "booking_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booking_number": {
+          "name": "booking_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cashback_verification_media_id_media_id_fk": {
+          "name": "cashback_verification_media_id_media_id_fk",
+          "tableFrom": "cashback",
+          "tableTo": "media",
+          "columnsFrom": [
+            "verification_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cashback_booking_location_id_location_id_fk": {
+          "name": "cashback_booking_location_id_location_id_fk",
+          "tableFrom": "cashback",
+          "tableTo": "location",
+          "columnsFrom": [
+            "booking_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "media_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_idx_name_search": {
+          "name": "media_idx_name_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', COALESCE(\"name\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_object_id_fk": {
+          "name": "media_object_id_fk",
+          "tableFrom": "media",
+          "tableTo": "objects",
+          "schemaTo": "storage",
+          "columnsFrom": [
+            "object_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "media_actor_id_fk": {
+          "name": "media_actor_id_fk",
+          "tableFrom": "media",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "media_location_id_fk": {
+          "name": "media_location_id_fk",
+          "tableFrom": "media",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.country": {
+      "name": "country",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ar": {
+          "name": "ar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bg": {
+          "name": "bg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "cs": {
+          "name": "cs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "da": {
+          "name": "da",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "de": {
+          "name": "de",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "el": {
+          "name": "el",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "en": {
+          "name": "en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "es": {
+          "name": "es",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "et": {
+          "name": "et",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "eu": {
+          "name": "eu",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "fi": {
+          "name": "fi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "fr": {
+          "name": "fr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "hu": {
+          "name": "hu",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "it": {
+          "name": "it",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ja": {
+          "name": "ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ko": {
+          "name": "ko",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "lt": {
+          "name": "lt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "nl": {
+          "name": "nl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "no": {
+          "name": "no",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "pl": {
+          "name": "pl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "pt": {
+          "name": "pt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ro": {
+          "name": "ro",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ru": {
+          "name": "ru",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sk": {
+          "name": "sk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sv": {
+          "name": "sv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "th": {
+          "name": "th",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "uk": {
+          "name": "uk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "zh": {
+          "name": "zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "zh-tw": {
+          "name": "zh-tw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "alpha_2": {
+          "name": "alpha_2",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "alpha_3": {
+          "name": "alpha_3",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "country_alpha_2_is_unique": {
+          "name": "country_alpha_2_is_unique",
+          "columns": [
+            {
+              "expression": "alpha_2",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "country_alpha_3_is_unique": {
+          "name": "country_alpha_3_is_unique",
+          "columns": [
+            {
+              "expression": "alpha_3",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "type": {
+          "name": "type",
+          "type": "feedback_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query": {
+          "name": "query",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "base": {
+          "name": "base",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "inserted_by": {
+          "name": "inserted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_inserted_by_fk": {
+          "name": "feedback_inserted_by_fk",
+          "tableFrom": "feedback",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inserted_by"
+          ],
+          "columnsTo": [
+            "auth_user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_cohort_progress": {
+      "name": "student_cohort_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "cohort_allocation_id": {
+          "name": "cohort_allocation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "curriculum_module_competency_id": {
+          "name": "curriculum_module_competency_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cohort_allocation_id_idx": {
+          "name": "cohort_allocation_id_idx",
+          "columns": [
+            {
+              "expression": "cohort_allocation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "curriculum_module_competency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_cohort_progress_cohort_allocation_id_fk": {
+          "name": "student_cohort_progress_cohort_allocation_id_fk",
+          "tableFrom": "student_cohort_progress",
+          "tableTo": "cohort_allocation",
+          "columnsFrom": [
+            "cohort_allocation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "curriculum_competency_competency_id_fk": {
+          "name": "curriculum_competency_competency_id_fk",
+          "tableFrom": "student_cohort_progress",
+          "tableTo": "curriculum_competency",
+          "columnsFrom": [
+            "curriculum_module_competency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_cohort_progress_created_by_fk": {
+          "name": "student_cohort_progress_created_by_fk",
+          "tableFrom": "student_cohort_progress",
+          "tableTo": "person",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.actor": {
+      "name": "actor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "type": {
+          "name": "type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "actor_person_id_fk": {
+          "name": "actor_person_id_fk",
+          "tableFrom": "actor",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "actor_location_link_location_id_fk": {
+          "name": "actor_location_link_location_id_fk",
+          "tableFrom": "actor",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unq_actor_type_person_location": {
+          "name": "unq_actor_type_person_location",
+          "nullsNotDistinct": true,
+          "columns": [
+            "type",
+            "person_id",
+            "location_id"
+          ]
+        },
+        "unq_actor_location_id_unique": {
+          "name": "unq_actor_location_id_unique",
+          "nullsNotDistinct": true,
+          "columns": [
+            "id",
+            "location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person": {
+      "name": "person",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_name_prefix": {
+          "name": "last_name_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_city": {
+          "name": "birth_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_country": {
+          "name": "birth_country",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "person_unq_handle": {
+          "name": "person_unq_handle",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_idx_handle_search": {
+          "name": "person_idx_handle_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', COALESCE(\"handle\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "person_idx_name_search": {
+          "name": "person_idx_name_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', \n        COALESCE(\"first_name\", '') || ' ' || \n        COALESCE(\"last_name_prefix\", '') || ' ' || \n        COALESCE(\"last_name\", '')\n      )",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "person_idx_user_id": {
+          "name": "person_idx_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "person_idx_is_primary": {
+          "name": "person_idx_is_primary",
+          "columns": [
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unq_primary_person": {
+          "name": "unq_primary_person",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"person\".\"is_primary\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_birth_country_country_alpha_2_fk": {
+          "name": "person_birth_country_country_alpha_2_fk",
+          "tableFrom": "person",
+          "tableTo": "country",
+          "columnsFrom": [
+            "birth_country"
+          ],
+          "columnsTo": [
+            "alpha_2"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "person_user_id_fk": {
+          "name": "person_user_id_fk",
+          "tableFrom": "person",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "auth_user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_location_link": {
+      "name": "person_location_link",
+      "schema": "",
+      "columns": {
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "person_location_link_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_level": {
+          "name": "permission_level",
+          "type": "permissionRequestStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "person_location_link_person_id_fk": {
+          "name": "person_location_link_person_id_fk",
+          "tableFrom": "person_location_link",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "person_location_link_location_id_fk": {
+          "name": "person_location_link_location_id_fk",
+          "tableFrom": "person_location_link",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "person_location_link_pk": {
+          "name": "person_location_link_pk",
+          "columns": [
+            "person_id",
+            "location_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_idx_email_full_search": {
+          "name": "user_idx_email_full_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', COALESCE(\"email\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "user_idx_email_username_search": {
+          "name": "user_idx_email_username_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', COALESCE(split_part(\"email\"::text, '@', 1), ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "user_idx_email_domain_search": {
+          "name": "user_idx_email_domain_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', COALESCE(split_part(\"email\"::text, '@', 2), ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_auth_user_id_fk": {
+          "name": "user_auth_user_id_fk",
+          "tableFrom": "user",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "auth_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_acting_profile_preference": {
+      "name": "user_acting_profile_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_acting_profile_preference_user_id_fk": {
+          "name": "user_acting_profile_preference_user_id_fk",
+          "tableFrom": "user_acting_profile_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "auth_user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_acting_profile_preference_location_id_fk": {
+          "name": "user_acting_profile_preference_location_id_fk",
+          "tableFrom": "user_acting_profile_preference",
+          "tableTo": "location",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_acting_profile_preference_person_id_fk": {
+          "name": "user_acting_profile_preference_person_id_fk",
+          "tableFrom": "user_acting_profile_preference",
+          "tableTo": "person",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unq_acting_profile_user_location": {
+          "name": "unq_acting_profile_user_location",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "ai_corpus.consent_level": {
+      "name": "consent_level",
+      "schema": "ai_corpus",
+      "values": [
+        "seed",
+        "opt_in_shared",
+        "user_only"
+      ]
+    },
+    "ai_corpus.domain": {
+      "name": "domain",
+      "schema": "ai_corpus",
+      "values": [
+        "pvb_portfolio",
+        "diplomalijn",
+        "knowledge_center",
+        "artefact"
+      ]
+    },
+    "public.bulk_import_preview_status": {
+      "name": "bulk_import_preview_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "committed",
+        "invalidated_max"
+      ]
+    },
+    "public.person_merge_audit_decision_kind": {
+      "name": "person_merge_audit_decision_kind",
+      "schema": "public",
+      "values": [
+        "create_new",
+        "use_existing",
+        "merge",
+        "skip"
+      ]
+    },
+    "public.person_merge_audit_source": {
+      "name": "person_merge_audit_source",
+      "schema": "public",
+      "values": [
+        "bulk_import_preview",
+        "personen_page",
+        "cohort_view",
+        "single_create_dialog",
+        "sysadmin"
+      ]
+    },
+    "public.role_type": {
+      "name": "role_type",
+      "schema": "public",
+      "values": [
+        "organization",
+        "location",
+        "cohort"
+      ]
+    },
+    "public.competency_type": {
+      "name": "competency_type",
+      "schema": "public",
+      "values": [
+        "knowledge",
+        "skill"
+      ]
+    },
+    "public.kwalificatie_verkregen_reden": {
+      "name": "kwalificatie_verkregen_reden",
+      "schema": "public",
+      "values": [
+        "pvb_behaald",
+        "pvb_instructiegroep_basis",
+        "onbekend"
+      ]
+    },
+    "kss.aanvraag_status": {
+      "name": "aanvraag_status",
+      "schema": "kss",
+      "values": [
+        "concept",
+        "wacht_op_voorwaarden",
+        "gereed_voor_beoordeling",
+        "in_beoordeling",
+        "afgerond",
+        "ingetrokken",
+        "afgebroken"
+      ]
+    },
+    "kss.beoordelaar_beschikbaarheidsstatus": {
+      "name": "beoordelaar_beschikbaarheidsstatus",
+      "schema": "kss",
+      "values": [
+        "geinteresseerd",
+        "toegewezen",
+        "afgewezen_door_beoordelaar",
+        "afgewezen_door_secretariaat",
+        "afgewezen_door_vaarlocatie",
+        "ingetrokken"
+      ]
+    },
+    "kss.leercoach_toestemming_status": {
+      "name": "leercoach_toestemming_status",
+      "schema": "kss",
+      "values": [
+        "gevraagd",
+        "gegeven",
+        "geweigerd",
+        "herroepen"
+      ]
+    },
+    "kss.pvb_aanvraag_type": {
+      "name": "pvb_aanvraag_type",
+      "schema": "kss",
+      "values": [
+        "intern",
+        "extern"
+      ]
+    },
+    "kss.pvb_gebeurtenis_type": {
+      "name": "pvb_gebeurtenis_type",
+      "schema": "kss",
+      "values": [
+        "aanvraag_ingediend",
+        "leercoach_toestemming_gevraagd",
+        "leercoach_toestemming_gegeven",
+        "leercoach_toestemming_geweigerd",
+        "voorwaarden_voltooid",
+        "beoordeling_gestart",
+        "beoordeling_afgerond",
+        "aanvraag_ingetrokken",
+        "onderdeel_toegevoegd",
+        "onderdeel_beoordelaar_gewijzigd",
+        "onderdeel_uitslag_gewijzigd",
+        "onderdeel_startdatum_gewijzigd"
+      ]
+    },
+    "kss.pvb_onderdeel_uitslag": {
+      "name": "pvb_onderdeel_uitslag",
+      "schema": "kss",
+      "values": [
+        "behaald",
+        "niet_behaald",
+        "nog_niet_bekend"
+      ]
+    },
+    "kss.kerntaakOnderdeelType": {
+      "name": "kerntaakOnderdeelType",
+      "schema": "kss",
+      "values": [
+        "portfolio",
+        "praktijk"
+      ]
+    },
+    "kss.kerntaakType": {
+      "name": "kerntaakType",
+      "schema": "kss",
+      "values": [
+        "verplicht",
+        "facultatief"
+      ]
+    },
+    "kss.richting": {
+      "name": "richting",
+      "schema": "kss",
+      "values": [
+        "instructeur",
+        "leercoach",
+        "pvb_beoordelaar"
+      ]
+    },
+    "leercoach.chat_phase": {
+      "name": "chat_phase",
+      "schema": "leercoach",
+      "values": [
+        "verkennen",
+        "ordenen",
+        "concept",
+        "verfijnen"
+      ]
+    },
+    "leercoach.portfolio_version_created_by": {
+      "name": "portfolio_version_created_by",
+      "schema": "leercoach",
+      "values": [
+        "coach",
+        "user",
+        "imported"
+      ]
+    },
+    "leercoach.upload_job_kind": {
+      "name": "upload_job_kind",
+      "schema": "leercoach",
+      "values": [
+        "portfolio"
+      ]
+    },
+    "leercoach.upload_job_status": {
+      "name": "upload_job_status",
+      "schema": "leercoach",
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.location_status": {
+      "name": "location_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "hidden",
+        "archived"
+      ]
+    },
+    "public.media_status": {
+      "name": "media_status",
+      "schema": "public",
+      "values": [
+        "failed",
+        "processing",
+        "ready",
+        "uploaded",
+        "corrupt"
+      ]
+    },
+    "public.media_type": {
+      "name": "media_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "file"
+      ]
+    },
+    "public.feedback_type": {
+      "name": "feedback_type",
+      "schema": "public",
+      "values": [
+        "bug",
+        "product-feedback",
+        "program-feedback",
+        "question",
+        "other"
+      ]
+    },
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": [
+        "student",
+        "instructor",
+        "location_admin",
+        "system",
+        "pvb_beoordelaar",
+        "secretariaat"
+      ]
+    },
+    "public.permissionRequestStatus": {
+      "name": "permissionRequestStatus",
+      "schema": "public",
+      "values": [
+        "none",
+        "requested",
+        "permission_granted"
+      ]
+    },
+    "public.person_location_link_status": {
+      "name": "person_location_link_status",
+      "schema": "public",
+      "values": [
+        "linked",
+        "revoked",
+        "removed"
+      ]
+    }
+  },
+  "schemas": {
+    "ai_corpus": "ai_corpus",
+    "kss": "kss",
+    "leercoach": "leercoach",
+    "marketing": "marketing"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/0041_snapshot.json
+++ b/packages/db/migrations/meta/0041_snapshot.json
@@ -1,0 +1,8413 @@
+{
+  "id": "d55f7610-1601-4db5-9ce0-6f84678b137e",
+  "prevId": "2c7ac624-9e4e-481e-b064-a82a43cd7d01",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "ai_corpus.chunk": {
+      "name": "chunk",
+      "schema": "ai_corpus",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "criterium_id": {
+          "name": "criterium_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "werkproces_id": {
+          "name": "werkproces_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chunk_criterium_quality_idx": {
+          "name": "chunk_criterium_quality_idx",
+          "columns": [
+            {
+              "expression": "criterium_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quality_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "chunk_source_idx": {
+          "name": "chunk_source_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "chunk_source_id_source_id_fk": {
+          "name": "chunk_source_id_source_id_fk",
+          "tableFrom": "chunk",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "tableTo": "source",
+          "schemaTo": "ai_corpus",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "chunk_criterium_id_beoordelingscriterium_id_fk": {
+          "name": "chunk_criterium_id_beoordelingscriterium_id_fk",
+          "tableFrom": "chunk",
+          "columnsFrom": [
+            "criterium_id"
+          ],
+          "tableTo": "beoordelingscriterium",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "chunk_werkproces_id_werkproces_id_fk": {
+          "name": "chunk_werkproces_id_werkproces_id_fk",
+          "tableFrom": "chunk",
+          "columnsFrom": [
+            "werkproces_id"
+          ],
+          "tableTo": "werkproces",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ai_corpus.outline_template": {
+      "name": "outline_template",
+      "schema": "ai_corpus",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "profiel_id": {
+          "name": "profiel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sections": {
+          "name": "sections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "outline_template_profiel_version_unique": {
+          "name": "outline_template_profiel_version_unique",
+          "columns": [
+            {
+              "expression": "profiel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "outline_template_profiel_id_kwalificatieprofiel_id_fk": {
+          "name": "outline_template_profiel_id_kwalificatieprofiel_id_fk",
+          "tableFrom": "outline_template",
+          "columnsFrom": [
+            "profiel_id"
+          ],
+          "tableTo": "kwalificatieprofiel",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "ai_corpus.source": {
+      "name": "source",
+      "schema": "ai_corpus",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "domain": {
+          "name": "domain",
+          "type": "domain",
+          "typeSchema": "ai_corpus",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_identifier": {
+          "name": "source_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_level": {
+          "name": "consent_level",
+          "type": "consent_level",
+          "typeSchema": "ai_corpus",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contributed_by_user_id": {
+          "name": "contributed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profiel_id": {
+          "name": "profiel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "richting": {
+          "name": "richting",
+          "type": "richting",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "niveau_rang": {
+          "name": "niveau_rang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "char_count": {
+          "name": "char_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_storage_path": {
+          "name": "original_storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "source_domain_hash_unique": {
+          "name": "source_domain_hash_unique",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "source_chat_created_idx": {
+          "name": "source_chat_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "source_profiel_id_kwalificatieprofiel_id_fk": {
+          "name": "source_profiel_id_kwalificatieprofiel_id_fk",
+          "tableFrom": "source",
+          "columnsFrom": [
+            "profiel_id"
+          ],
+          "tableTo": "kwalificatieprofiel",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "source_chat_id_chat_id_fk": {
+          "name": "source_chat_id_chat_id_fk",
+          "tableFrom": "source",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "tableTo": "chat",
+          "schemaTo": "leercoach",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bulk_import_preview": {
+      "name": "bulk_import_preview",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_person_id": {
+          "name": "created_by_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_cohort_id": {
+          "name": "target_cohort_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detection_snapshot": {
+          "name": "detection_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rows_parsed": {
+          "name": "rows_parsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "bulk_import_preview_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bulk_import_preview_expires_at_idx": {
+          "name": "bulk_import_preview_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "status = 'active'",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "bulk_import_preview_location_id_fk": {
+          "name": "bulk_import_preview_location_id_fk",
+          "tableFrom": "bulk_import_preview",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "tableTo": "location",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "bulk_import_preview_created_by_person_id_fk": {
+          "name": "bulk_import_preview_created_by_person_id_fk",
+          "tableFrom": "bulk_import_preview",
+          "columnsFrom": [
+            "created_by_person_id"
+          ],
+          "tableTo": "person",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "bulk_import_preview_target_cohort_id_fk": {
+          "name": "bulk_import_preview_target_cohort_id_fk",
+          "tableFrom": "bulk_import_preview",
+          "columnsFrom": [
+            "target_cohort_id"
+          ],
+          "tableTo": "cohort",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_merge_audit": {
+      "name": "person_merge_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "performed_by_person_id": {
+          "name": "performed_by_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_person_id": {
+          "name": "source_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_person_id": {
+          "name": "target_person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_kind": {
+          "name": "decision_kind",
+          "type": "person_merge_audit_decision_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "presented_candidate_person_ids": {
+          "name": "presented_candidate_person_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "person_merge_audit_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bulk_import_preview_token": {
+          "name": "bulk_import_preview_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_merge_audit_target_person_id_idx": {
+          "name": "person_merge_audit_target_person_id_idx",
+          "columns": [
+            {
+              "expression": "target_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "person_merge_audit_location_id_idx": {
+          "name": "person_merge_audit_location_id_idx",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "person_merge_audit_performed_at_idx": {
+          "name": "person_merge_audit_performed_at_idx",
+          "columns": [
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "person_merge_audit_location_id_fk": {
+          "name": "person_merge_audit_location_id_fk",
+          "tableFrom": "person_merge_audit",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "tableTo": "location",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "person_merge_audit_bulk_import_preview_token_fk": {
+          "name": "person_merge_audit_bulk_import_preview_token_fk",
+          "tableFrom": "person_merge_audit",
+          "columnsFrom": [
+            "bulk_import_preview_token"
+          ],
+          "tableTo": "bulk_import_preview",
+          "columnsTo": [
+            "token"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.token": {
+      "name": "token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partial_key": {
+          "name": "partial_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "token_hashed_key_index": {
+          "name": "token_hashed_key_index",
+          "columns": [
+            {
+              "expression": "hashed_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "token_user_id_fk": {
+          "name": "token_user_id_fk",
+          "tableFrom": "token",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "auth_user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.token_usage": {
+      "name": "token_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "token_usage_token_id_used_at_index": {
+          "name": "token_usage_token_id_used_at_index",
+          "columns": [
+            {
+              "expression": "token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "used_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "token_usage_token_id_fk": {
+          "name": "token_usage_token_id_fk",
+          "tableFrom": "token_usage",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "tableTo": "token",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cohort_allocation_role": {
+      "name": "cohort_allocation_role",
+      "schema": "",
+      "columns": {
+        "cohort_allocation_id": {
+          "name": "cohort_allocation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cohort_allocation_role_allocation_id_fk": {
+          "name": "cohort_allocation_role_allocation_id_fk",
+          "tableFrom": "cohort_allocation_role",
+          "columnsFrom": [
+            "cohort_allocation_id"
+          ],
+          "tableTo": "cohort_allocation",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "user_role_role_id_fk": {
+          "name": "user_role_role_id_fk",
+          "tableFrom": "cohort_allocation_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "tableTo": "role",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "cohort_allocation_role_cohort_allocation_id_role_id_pk": {
+          "name": "cohort_allocation_role_cohort_allocation_id_role_id_pk",
+          "columns": [
+            "cohort_allocation_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_role": {
+      "name": "person_role",
+      "schema": "",
+      "columns": {
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "person_role_person_id_fk": {
+          "name": "person_role_person_id_fk",
+          "tableFrom": "person_role",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "tableTo": "person",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "user_role_role_id_fk": {
+          "name": "user_role_role_id_fk",
+          "tableFrom": "person_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "tableTo": "role",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "person_role_person_id_role_id_pk": {
+          "name": "person_role_person_id_role_id_pk",
+          "columns": [
+            "person_id",
+            "role_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.privilege": {
+      "name": "privilege",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "privilege_handle_index": {
+          "name": "privilege_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "role_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "role_handle_index": {
+          "name": "role_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "role_location_id_fk": {
+          "name": "role_location_id_fk",
+          "tableFrom": "role",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "tableTo": "location",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_privilege": {
+      "name": "role_privilege",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privilege_id": {
+          "name": "privilege_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_privilege_role_id_fk": {
+          "name": "role_privilege_role_id_fk",
+          "tableFrom": "role_privilege",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "tableTo": "role",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "role_privilege_privilege_id_fk": {
+          "name": "role_privilege_privilege_id_fk",
+          "tableFrom": "role_privilege",
+          "columnsFrom": [
+            "privilege_id"
+          ],
+          "tableTo": "privilege",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_privilege_pk": {
+          "name": "role_privilege_pk",
+          "columns": [
+            "role_id",
+            "privilege_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.token_privilege": {
+      "name": "token_privilege",
+      "schema": "",
+      "columns": {
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privilege_id": {
+          "name": "privilege_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "token_privilege_token_id_fk": {
+          "name": "token_privilege_token_id_fk",
+          "tableFrom": "token_privilege",
+          "columnsFrom": [
+            "token_id"
+          ],
+          "tableTo": "token",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "token_privilege_privilege_id_fk": {
+          "name": "token_privilege_privilege_id_fk",
+          "tableFrom": "token_privilege",
+          "columnsFrom": [
+            "privilege_id"
+          ],
+          "tableTo": "privilege",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "token_privilege_pk": {
+          "name": "token_privilege_pk",
+          "columns": [
+            "token_id",
+            "privilege_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certificate": {
+      "name": "certificate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_curriculum_id": {
+          "name": "student_curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort_allocation_id": {
+          "name": "cohort_allocation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visible_from": {
+          "name": "visible_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "certificate_unq_handle": {
+          "name": "certificate_unq_handle",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "certificate_idx_location": {
+          "name": "certificate_idx_location",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "certificate_idx_issued_at": {
+          "name": "certificate_idx_issued_at",
+          "columns": [
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "certificate_idx_visible_from": {
+          "name": "certificate_idx_visible_from",
+          "columns": [
+            {
+              "expression": "visible_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "certificate_idx_deleted_at": {
+          "name": "certificate_idx_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "certificate_idx_location_issued_at": {
+          "name": "certificate_idx_location_issued_at",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "certificate_idx_handle_search": {
+          "name": "certificate_idx_handle_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', \"handle\")",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "certificate_student_curriculum_link_id_fk": {
+          "name": "certificate_student_curriculum_link_id_fk",
+          "tableFrom": "certificate",
+          "columnsFrom": [
+            "student_curriculum_id"
+          ],
+          "tableTo": "student_curriculum",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "certificate_location_id_fk": {
+          "name": "certificate_location_id_fk",
+          "tableFrom": "certificate",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "tableTo": "location",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "certificate_cohort_allocation_id_fk": {
+          "name": "certificate_cohort_allocation_id_fk",
+          "tableFrom": "certificate",
+          "columnsFrom": [
+            "cohort_allocation_id"
+          ],
+          "tableTo": "cohort_allocation",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_certificate": {
+      "name": "external_certificate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuing_authority": {
+          "name": "issuing_authority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuing_location": {
+          "name": "issuing_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awarded_at": {
+          "name": "awarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_comments": {
+          "name": "additional_comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "external_certificate_media_id_media_id_fk": {
+          "name": "external_certificate_media_id_media_id_fk",
+          "tableFrom": "external_certificate",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "tableTo": "media",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "external_certificate_person_id_fk": {
+          "name": "external_certificate_person_id_fk",
+          "tableFrom": "external_certificate",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "tableTo": "person",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "external_certificate_location_id_fk": {
+          "name": "external_certificate_location_id_fk",
+          "tableFrom": "external_certificate",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "tableTo": "location",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_completed_competency": {
+      "name": "student_completed_competency",
+      "schema": "",
+      "columns": {
+        "student_curriculum_id": {
+          "name": "student_curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "curriculum_module_competency_id": {
+          "name": "curriculum_module_competency_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "certificate_id": {
+          "name": "certificate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_merge_conflict_duplicate": {
+          "name": "is_merge_conflict_duplicate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "student_completed_competency_unq_active_non_merge": {
+          "name": "student_completed_competency_unq_active_non_merge",
+          "columns": [
+            {
+              "expression": "student_curriculum_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "curriculum_module_competency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"student_completed_competency\".\"is_merge_conflict_duplicate\" = false AND \"student_completed_competency\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "student_completed_competency_student_curriculum_link_id_fk": {
+          "name": "student_completed_competency_student_curriculum_link_id_fk",
+          "tableFrom": "student_completed_competency",
+          "columnsFrom": [
+            "student_curriculum_id"
+          ],
+          "tableTo": "student_curriculum",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "curriculum_competency_competency_id_fk": {
+          "name": "curriculum_competency_competency_id_fk",
+          "tableFrom": "student_completed_competency",
+          "columnsFrom": [
+            "curriculum_module_competency_id"
+          ],
+          "tableTo": "curriculum_competency",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "student_completed_competency_certificate_id_fk": {
+          "name": "student_completed_competency_certificate_id_fk",
+          "tableFrom": "student_completed_competency",
+          "columnsFrom": [
+            "certificate_id"
+          ],
+          "tableTo": "certificate",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "student_completed_competency_pk": {
+          "name": "student_completed_competency_pk",
+          "columns": [
+            "student_curriculum_id",
+            "curriculum_module_competency_id",
+            "certificate_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_curriculum": {
+      "name": "student_curriculum",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "curriculum_id": {
+          "name": "curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_type_id": {
+          "name": "gear_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "student_curriculum_unq_identity_gear_curriculum": {
+          "name": "student_curriculum_unq_identity_gear_curriculum",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "curriculum_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gear_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"student_curriculum\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "student_curriculum_idx_person": {
+          "name": "student_curriculum_idx_person",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "student_curriculum_link_curriculum_id_gear_type_id_fk": {
+          "name": "student_curriculum_link_curriculum_id_gear_type_id_fk",
+          "tableFrom": "student_curriculum",
+          "columnsFrom": [
+            "curriculum_id",
+            "gear_type_id"
+          ],
+          "tableTo": "curriculum_gear_link",
+          "columnsTo": [
+            "curriculum_id",
+            "gear_type_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "student_curriculum_link_curriculum_id_fk": {
+          "name": "student_curriculum_link_curriculum_id_fk",
+          "tableFrom": "student_curriculum",
+          "columnsFrom": [
+            "curriculum_id"
+          ],
+          "tableTo": "curriculum",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "student_curriculum_link_gear_type_id_fk": {
+          "name": "student_curriculum_link_gear_type_id_fk",
+          "tableFrom": "student_curriculum",
+          "columnsFrom": [
+            "gear_type_id"
+          ],
+          "tableTo": "gear_type",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "student_curriculum_link_person_id_fk": {
+          "name": "student_curriculum_link_person_id_fk",
+          "tableFrom": "student_curriculum",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "tableTo": "person",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cohort": {
+      "name": "cohort",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_start_time": {
+          "name": "access_start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_end_time": {
+          "name": "access_end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "certificates_visible_from": {
+          "name": "certificates_visible_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cohort_handle_location_id_index": {
+          "name": "cohort_handle_location_id_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "deleted_at IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "cohort_location_id_fk": {
+          "name": "cohort_location_id_fk",
+          "tableFrom": "cohort",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "tableTo": "location",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cohort_allocation": {
+      "name": "cohort_allocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "cohort_id": {
+          "name": "cohort_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_curriculum_id": {
+          "name": "student_curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructor_id": {
+          "name": "instructor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "progress_visible_up_until": {
+          "name": "progress_visible_up_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cohort_allocation_cohort_id_actor_id_student_curriculum_id_index": {
+          "name": "cohort_allocation_cohort_id_actor_id_student_curriculum_id_index",
+          "columns": [
+            {
+              "expression": "cohort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "student_curriculum_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"cohort_allocation\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "cohort_allocation_cohort_id_tags_index": {
+          "name": "cohort_allocation_cohort_id_tags_index",
+          "columns": [
+            {
+              "expression": "cohort_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "cohort_allocation_cohort_id_fk": {
+          "name": "cohort_allocation_cohort_id_fk",
+          "tableFrom": "cohort_allocation",
+          "columnsFrom": [
+            "cohort_id"
+          ],
+          "tableTo": "cohort",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "cohort_allocation_actor_id_fk": {
+          "name": "cohort_allocation_actor_id_fk",
+          "tableFrom": "cohort_allocation",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "tableTo": "actor",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "cohort_allocation_student_curriculum_id_fk": {
+          "name": "cohort_allocation_student_curriculum_id_fk",
+          "tableFrom": "cohort_allocation",
+          "columnsFrom": [
+            "student_curriculum_id"
+          ],
+          "tableTo": "student_curriculum",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "cohort_allocation_instructor_id_fk": {
+          "name": "cohort_allocation_instructor_id_fk",
+          "tableFrom": "cohort_allocation",
+          "columnsFrom": [
+            "instructor_id"
+          ],
+          "tableTo": "actor",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category": {
+      "name": "category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "parent_category_id": {
+          "name": "parent_category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "category_handle_index": {
+          "name": "category_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "category_parent_category_id_fk": {
+          "name": "category_parent_category_id_fk",
+          "tableFrom": "category",
+          "columnsFrom": [
+            "parent_category_id"
+          ],
+          "tableTo": "category",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competency": {
+      "name": "competency",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "competency_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "competency_handle_index": {
+          "name": "competency_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course": {
+      "name": "course",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discipline_id": {
+          "name": "discipline_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "course_handle_index": {
+          "name": "course_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "course_discipline_id_fk": {
+          "name": "course_discipline_id_fk",
+          "tableFrom": "course",
+          "columnsFrom": [
+            "discipline_id"
+          ],
+          "tableTo": "discipline",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_category": {
+      "name": "course_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "course_category_category_id_course_id_index": {
+          "name": "course_category_category_id_course_id_index",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "course_category_course_id_fk": {
+          "name": "course_category_course_id_fk",
+          "tableFrom": "course_category",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "tableTo": "course",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "course_category_category_id_fk": {
+          "name": "course_category_category_id_fk",
+          "tableFrom": "course_category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "tableTo": "category",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.degree": {
+      "name": "degree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rang": {
+          "name": "rang",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "degree_handle_index": {
+          "name": "degree_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "degree_rang_index": {
+          "name": "degree_rang_index",
+          "columns": [
+            {
+              "expression": "rang",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discipline": {
+      "name": "discipline",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "discipline_handle_index": {
+          "name": "discipline_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gear_type": {
+      "name": "gear_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gear_type_handle_index": {
+          "name": "gear_type_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.module": {
+      "name": "module",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "module_handle_index": {
+          "name": "module_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.program": {
+      "name": "program",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degree_id": {
+          "name": "degree_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "program_handle_index": {
+          "name": "program_handle_index",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "program_course_id_fk": {
+          "name": "program_course_id_fk",
+          "tableFrom": "program",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "tableTo": "course",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "program_degree_id_fk": {
+          "name": "program_degree_id_fk",
+          "tableFrom": "program",
+          "columnsFrom": [
+            "degree_id"
+          ],
+          "tableTo": "degree",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curriculum": {
+      "name": "curriculum",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "curriculum_program_id_revision_index": {
+          "name": "curriculum_program_id_revision_index",
+          "columns": [
+            {
+              "expression": "program_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "curriculum_program_id_fk": {
+          "name": "curriculum_program_id_fk",
+          "tableFrom": "curriculum",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "tableTo": "program",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curriculum_competency": {
+      "name": "curriculum_competency",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "curriculum_id": {
+          "name": "curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competency_id": {
+          "name": "competency_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement": {
+          "name": "requirement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "curriculum_competency_unq_set": {
+          "name": "curriculum_competency_unq_set",
+          "columns": [
+            {
+              "expression": "curriculum_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "module_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "curriculum_competency_curriculum_module_id_fk": {
+          "name": "curriculum_competency_curriculum_module_id_fk",
+          "tableFrom": "curriculum_competency",
+          "columnsFrom": [
+            "curriculum_id",
+            "module_id"
+          ],
+          "tableTo": "curriculum_module",
+          "columnsTo": [
+            "curriculum_id",
+            "module_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "curriculum_competency_competency_id_fk": {
+          "name": "curriculum_competency_competency_id_fk",
+          "tableFrom": "curriculum_competency",
+          "columnsFrom": [
+            "competency_id"
+          ],
+          "tableTo": "competency",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curriculum_gear_link": {
+      "name": "curriculum_gear_link",
+      "schema": "",
+      "columns": {
+        "curriculum_id": {
+          "name": "curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_type_id": {
+          "name": "gear_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "curriculum_gear_link_curriculum_id_fk": {
+          "name": "curriculum_gear_link_curriculum_id_fk",
+          "tableFrom": "curriculum_gear_link",
+          "columnsFrom": [
+            "curriculum_id"
+          ],
+          "tableTo": "curriculum",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "curriculum_gear_link_gear_type_id_fk": {
+          "name": "curriculum_gear_link_gear_type_id_fk",
+          "tableFrom": "curriculum_gear_link",
+          "columnsFrom": [
+            "gear_type_id"
+          ],
+          "tableTo": "gear_type",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curriculum_gear_link_curriculum_id_gear_type_id_pk": {
+          "name": "curriculum_gear_link_curriculum_id_gear_type_id_pk",
+          "columns": [
+            "curriculum_id",
+            "gear_type_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curriculum_module": {
+      "name": "curriculum_module",
+      "schema": "",
+      "columns": {
+        "curriculum_id": {
+          "name": "curriculum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "curriculum_module_curriculum_id_module_id_index": {
+          "name": "curriculum_module_curriculum_id_module_id_index",
+          "columns": [
+            {
+              "expression": "curriculum_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "module_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "curriculum_module_curriculum_id_fk": {
+          "name": "curriculum_module_curriculum_id_fk",
+          "tableFrom": "curriculum_module",
+          "columnsFrom": [
+            "curriculum_id"
+          ],
+          "tableTo": "curriculum",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "curriculum_module_module_id_fk": {
+          "name": "curriculum_module_module_id_fk",
+          "tableFrom": "curriculum_module",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "tableTo": "module",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "curriculum_module_curriculum_id_module_id_pk": {
+          "name": "curriculum_module_curriculum_id_module_id_pk",
+          "columns": [
+            "curriculum_id",
+            "module_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.instructie_groep": {
+      "name": "instructie_groep",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "richting": {
+          "name": "richting",
+          "type": "richting",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.instructie_groep_cursus": {
+      "name": "instructie_groep_cursus",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "instructie_groep_id": {
+          "name": "instructie_groep_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "instructie_groep_cursus_instructie_groep_id_course_id_index": {
+          "name": "instructie_groep_cursus_instructie_groep_id_course_id_index",
+          "columns": [
+            {
+              "expression": "instructie_groep_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "instructie_groep_cursus_instructie_groep_id_instructie_groep_id_fk": {
+          "name": "instructie_groep_cursus_instructie_groep_id_instructie_groep_id_fk",
+          "tableFrom": "instructie_groep_cursus",
+          "columnsFrom": [
+            "instructie_groep_id"
+          ],
+          "tableTo": "instructie_groep",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "instructie_groep_cursus_course_id_course_id_fk": {
+          "name": "instructie_groep_cursus_course_id_course_id_fk",
+          "tableFrom": "instructie_groep_cursus",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "tableTo": "course",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.persoon_kwalificatie": {
+      "name": "persoon_kwalificatie",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "direct_behaalde_pvb_onderdeel_id": {
+          "name": "direct_behaalde_pvb_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "afgeleide_pvb_onderdeel_id": {
+          "name": "afgeleide_pvb_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_onderdeel_id": {
+          "name": "kerntaak_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verkregen_reden": {
+          "name": "verkregen_reden",
+          "type": "kwalificatie_verkregen_reden",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'onbekend'"
+        },
+        "toegevoegd_op": {
+          "name": "toegevoegd_op",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toegevoegd_door": {
+          "name": "toegevoegd_door",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "unique_person_course_kerntaak_onderdeel": {
+          "name": "unique_person_course_kerntaak_onderdeel",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kerntaak_onderdeel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "persoon_kwalificatie_direct_behaalde_pvb_onderdeel_id_kerntaak_onderdeel_id_pvb_onderdeel_id_kerntaak_onderdeel_id_fk": {
+          "name": "persoon_kwalificatie_direct_behaalde_pvb_onderdeel_id_kerntaak_onderdeel_id_pvb_onderdeel_id_kerntaak_onderdeel_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "columnsFrom": [
+            "direct_behaalde_pvb_onderdeel_id",
+            "kerntaak_onderdeel_id"
+          ],
+          "tableTo": "pvb_onderdeel",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id",
+            "kerntaak_onderdeel_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "persoon_kwalificatie_afgeleide_pvb_onderdeel_id_kerntaak_onderdeel_id_pvb_onderdeel_id_kerntaak_onderdeel_id_fk": {
+          "name": "persoon_kwalificatie_afgeleide_pvb_onderdeel_id_kerntaak_onderdeel_id_pvb_onderdeel_id_kerntaak_onderdeel_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "columnsFrom": [
+            "afgeleide_pvb_onderdeel_id",
+            "kerntaak_onderdeel_id"
+          ],
+          "tableTo": "pvb_onderdeel",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id",
+            "kerntaak_onderdeel_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "persoon_kwalificatie_kerntaak_onderdeel_id_kerntaak_onderdeel_id_fk": {
+          "name": "persoon_kwalificatie_kerntaak_onderdeel_id_kerntaak_onderdeel_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "columnsFrom": [
+            "kerntaak_onderdeel_id"
+          ],
+          "tableTo": "kerntaak_onderdeel",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "persoon_kwalificatie_course_id_course_id_fk": {
+          "name": "persoon_kwalificatie_course_id_course_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "tableTo": "course",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "persoon_kwalificatie_toegevoegd_door_actor_id_fk": {
+          "name": "persoon_kwalificatie_toegevoegd_door_actor_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "columnsFrom": [
+            "toegevoegd_door"
+          ],
+          "tableTo": "actor",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "persoon_kwalificatie_person_id_person_id_fk": {
+          "name": "persoon_kwalificatie_person_id_person_id_fk",
+          "tableFrom": "persoon_kwalificatie",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "tableTo": "person",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verkregen_reden_pvb_behaald_constraint": {
+          "name": "verkregen_reden_pvb_behaald_constraint",
+          "value": "(\"kss\".\"persoon_kwalificatie\".\"verkregen_reden\" != 'pvb_behaald') OR (\"kss\".\"persoon_kwalificatie\".\"direct_behaalde_pvb_onderdeel_id\" IS NOT NULL AND \"kss\".\"persoon_kwalificatie\".\"afgeleide_pvb_onderdeel_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "kss.pvb_aanvraag": {
+      "name": "pvb_aanvraag",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kandidaat_id": {
+          "name": "kandidaat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locatie_id": {
+          "name": "locatie_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "pvb_aanvraag_type",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_aanvraag_kandidaat_id_person_id_fk": {
+          "name": "pvb_aanvraag_kandidaat_id_person_id_fk",
+          "tableFrom": "pvb_aanvraag",
+          "columnsFrom": [
+            "kandidaat_id"
+          ],
+          "tableTo": "person",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "pvb_aanvraag_locatie_id_location_id_fk": {
+          "name": "pvb_aanvraag_locatie_id_location_id_fk",
+          "tableFrom": "pvb_aanvraag",
+          "columnsFrom": [
+            "locatie_id"
+          ],
+          "tableTo": "location",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pvb_aanvraag_handle_unique": {
+          "name": "pvb_aanvraag_handle_unique",
+          "columns": [
+            "handle"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_aanvraag_course": {
+      "name": "pvb_aanvraag_course",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructie_groep_id": {
+          "name": "instructie_groep_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_main_course": {
+          "name": "is_main_course",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pvb_aanvraag_course_pvb_aanvraag_id_instructie_groep_id_index": {
+          "name": "pvb_aanvraag_course_pvb_aanvraag_id_instructie_groep_id_index",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instructie_groep_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"kss\".\"pvb_aanvraag_course\".\"is_main_course\" = true",
+          "concurrently": false
+        },
+        "pvb_aanvraag_course_pvb_aanvraag_id_instructie_groep_id_course_id_index": {
+          "name": "pvb_aanvraag_course_pvb_aanvraag_id_instructie_groep_id_course_id_index",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instructie_groep_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "pvb_aanvraag_course_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_aanvraag_course_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_aanvraag_course",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "pvb_aanvraag_course_course_id_course_id_fk": {
+          "name": "pvb_aanvraag_course_course_id_course_id_fk",
+          "tableFrom": "pvb_aanvraag_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "tableTo": "course",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "pvb_aanvraag_course_instructie_groep_id_instructie_groep_id_fk": {
+          "name": "pvb_aanvraag_course_instructie_groep_id_instructie_groep_id_fk",
+          "tableFrom": "pvb_aanvraag_course",
+          "columnsFrom": [
+            "instructie_groep_id"
+          ],
+          "tableTo": "instructie_groep",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_aanvraag_status": {
+      "name": "pvb_aanvraag_status",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "aanvraag_status",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aangemaakt_op": {
+          "name": "aangemaakt_op",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "aangemaakt_door": {
+          "name": "aangemaakt_door",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reden": {
+          "name": "reden",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_aanvraag_status_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_aanvraag_status_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_aanvraag_status",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "pvb_aanvraag_status_aangemaakt_door_actor_id_fk": {
+          "name": "pvb_aanvraag_status_aangemaakt_door_actor_id_fk",
+          "tableFrom": "pvb_aanvraag_status",
+          "columnsFrom": [
+            "aangemaakt_door"
+          ],
+          "tableTo": "actor",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_beoordelaar_beschikbaarheid": {
+      "name": "pvb_beoordelaar_beschikbaarheid",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beoordelaar_id": {
+          "name": "beoordelaar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pvb_voorstel_datum_id": {
+          "name": "pvb_voorstel_datum_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_beoordelaar_beschikbaarheid_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_beoordelaar_beschikbaarheid_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_beoordelaar_beschikbaarheid",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "pvb_beoordelaar_beschikbaarheid_beoordelaar_id_person_id_fk": {
+          "name": "pvb_beoordelaar_beschikbaarheid_beoordelaar_id_person_id_fk",
+          "tableFrom": "pvb_beoordelaar_beschikbaarheid",
+          "columnsFrom": [
+            "beoordelaar_id"
+          ],
+          "tableTo": "person",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "pvb_beoordelaar_beschikbaarheid_pvb_voorstel_datum_id_pvb_aanvraag_id_pvb_voorstel_datum_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_beoordelaar_beschikbaarheid_pvb_voorstel_datum_id_pvb_aanvraag_id_pvb_voorstel_datum_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_beoordelaar_beschikbaarheid",
+          "columnsFrom": [
+            "pvb_voorstel_datum_id",
+            "pvb_aanvraag_id"
+          ],
+          "tableTo": "pvb_voorstel_datum",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id",
+            "pvb_aanvraag_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_beoordelaar_beschikbaarheid_status": {
+      "name": "pvb_beoordelaar_beschikbaarheid_status",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_beoordelaar_beschikbaarheid_id": {
+          "name": "pvb_beoordelaar_beschikbaarheid_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "beoordelaar_beschikbaarheidsstatus",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aangemaakt_op": {
+          "name": "aangemaakt_op",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "aangemaakt_door": {
+          "name": "aangemaakt_door",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reden": {
+          "name": "reden",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_beoordelaar_beschikbaarheid_status_pvb_beoordelaar_beschikbaarheid_id_pvb_beoordelaar_beschikbaarheid_id_fk": {
+          "name": "pvb_beoordelaar_beschikbaarheid_status_pvb_beoordelaar_beschikbaarheid_id_pvb_beoordelaar_beschikbaarheid_id_fk",
+          "tableFrom": "pvb_beoordelaar_beschikbaarheid_status",
+          "columnsFrom": [
+            "pvb_beoordelaar_beschikbaarheid_id"
+          ],
+          "tableTo": "pvb_beoordelaar_beschikbaarheid",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "pvb_beoordelaar_beschikbaarheid_status_aangemaakt_door_actor_id_fk": {
+          "name": "pvb_beoordelaar_beschikbaarheid_status_aangemaakt_door_actor_id_fk",
+          "tableFrom": "pvb_beoordelaar_beschikbaarheid_status",
+          "columnsFrom": [
+            "aangemaakt_door"
+          ],
+          "tableTo": "actor",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_beoordelaar_onderdeel_beschikbaarheid": {
+      "name": "pvb_beoordelaar_onderdeel_beschikbaarheid",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_beoordelaar_beschikbaarheid_id": {
+          "name": "pvb_beoordelaar_beschikbaarheid_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pvb_onderdeel_id": {
+          "name": "pvb_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_beoordelaar_onderdeel_beschikbaarheid_pvb_beoordelaar_beschikbaarheid_id_pvb_beoordelaar_beschikbaarheid_id_fk": {
+          "name": "pvb_beoordelaar_onderdeel_beschikbaarheid_pvb_beoordelaar_beschikbaarheid_id_pvb_beoordelaar_beschikbaarheid_id_fk",
+          "tableFrom": "pvb_beoordelaar_onderdeel_beschikbaarheid",
+          "columnsFrom": [
+            "pvb_beoordelaar_beschikbaarheid_id"
+          ],
+          "tableTo": "pvb_beoordelaar_beschikbaarheid",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "pvb_beoordelaar_onderdeel_beschikbaarheid_pvb_onderdeel_id_pvb_onderdeel_id_fk": {
+          "name": "pvb_beoordelaar_onderdeel_beschikbaarheid_pvb_onderdeel_id_pvb_onderdeel_id_fk",
+          "tableFrom": "pvb_beoordelaar_onderdeel_beschikbaarheid",
+          "columnsFrom": [
+            "pvb_onderdeel_id"
+          ],
+          "tableTo": "pvb_onderdeel",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_gebeurtenis": {
+      "name": "pvb_gebeurtenis",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pvb_onderdeel_id": {
+          "name": "pvb_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gebeurtenis_type": {
+          "name": "gebeurtenis_type",
+          "type": "pvb_gebeurtenis_type",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aangemaakt_op": {
+          "name": "aangemaakt_op",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "aangemaakt_door": {
+          "name": "aangemaakt_door",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reden": {
+          "name": "reden",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_gebeurtenis_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_gebeurtenis_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_gebeurtenis",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "pvb_gebeurtenis_pvb_onderdeel_id_pvb_onderdeel_id_fk": {
+          "name": "pvb_gebeurtenis_pvb_onderdeel_id_pvb_onderdeel_id_fk",
+          "tableFrom": "pvb_gebeurtenis",
+          "columnsFrom": [
+            "pvb_onderdeel_id"
+          ],
+          "tableTo": "pvb_onderdeel",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "pvb_gebeurtenis_aangemaakt_door_actor_id_fk": {
+          "name": "pvb_gebeurtenis_aangemaakt_door_actor_id_fk",
+          "tableFrom": "pvb_gebeurtenis",
+          "columnsFrom": [
+            "aangemaakt_door"
+          ],
+          "tableTo": "actor",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_leercoach_toestemming": {
+      "name": "pvb_leercoach_toestemming",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leercoach_id": {
+          "name": "leercoach_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "leercoach_toestemming_status",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aangemaakt_op": {
+          "name": "aangemaakt_op",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "aangemaakt_door": {
+          "name": "aangemaakt_door",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reden": {
+          "name": "reden",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pvb_leercoach_toestemming_recent_idx": {
+          "name": "pvb_leercoach_toestemming_recent_idx",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "leercoach_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "aangemaakt_op",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "pvb_leercoach_toestemming_status_idx": {
+          "name": "pvb_leercoach_toestemming_status_idx",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "leercoach_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "pvb_leercoach_toestemming_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_leercoach_toestemming_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_leercoach_toestemming",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "pvb_leercoach_toestemming_leercoach_id_person_id_fk": {
+          "name": "pvb_leercoach_toestemming_leercoach_id_person_id_fk",
+          "tableFrom": "pvb_leercoach_toestemming",
+          "columnsFrom": [
+            "leercoach_id"
+          ],
+          "tableTo": "person",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "pvb_leercoach_toestemming_aangemaakt_door_actor_id_fk": {
+          "name": "pvb_leercoach_toestemming_aangemaakt_door_actor_id_fk",
+          "tableFrom": "pvb_leercoach_toestemming",
+          "columnsFrom": [
+            "aangemaakt_door"
+          ],
+          "tableTo": "actor",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_onderdeel": {
+      "name": "pvb_onderdeel",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_onderdeel_id": {
+          "name": "kerntaak_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beoordelaar_id": {
+          "name": "beoordelaar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_datum_tijd": {
+          "name": "start_datum_tijd",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uitslag": {
+          "name": "uitslag",
+          "type": "pvb_onderdeel_uitslag",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'nog_niet_bekend'"
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pvb_onderdeel_aanvraag_id_kerntaak_onderdeel_id_beoordelaar_id_unique": {
+          "name": "pvb_onderdeel_aanvraag_id_kerntaak_onderdeel_id_beoordelaar_id_unique",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kerntaak_onderdeel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "beoordelaar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "pvb_onderdeel_aanvraag_id_kerntaak_onderdeel_id_unique": {
+          "name": "pvb_onderdeel_aanvraag_id_kerntaak_onderdeel_id_unique",
+          "columns": [
+            {
+              "expression": "pvb_aanvraag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kerntaak_onderdeel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "pvb_onderdeel_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_onderdeel_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_onderdeel",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "pvb_onderdeel_kerntaak_onderdeel_id_kerntaak_id_kerntaak_onderdeel_id_kerntaak_id_fk": {
+          "name": "pvb_onderdeel_kerntaak_onderdeel_id_kerntaak_id_kerntaak_onderdeel_id_kerntaak_id_fk",
+          "tableFrom": "pvb_onderdeel",
+          "columnsFrom": [
+            "kerntaak_onderdeel_id",
+            "kerntaak_id"
+          ],
+          "tableTo": "kerntaak_onderdeel",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "pvb_onderdeel_kerntaak_id_kerntaak_id_fk": {
+          "name": "pvb_onderdeel_kerntaak_id_kerntaak_id_fk",
+          "tableFrom": "pvb_onderdeel",
+          "columnsFrom": [
+            "kerntaak_id"
+          ],
+          "tableTo": "kerntaak",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "pvb_onderdeel_beoordelaar_id_person_id_fk": {
+          "name": "pvb_onderdeel_beoordelaar_id_person_id_fk",
+          "tableFrom": "pvb_onderdeel",
+          "columnsFrom": [
+            "beoordelaar_id"
+          ],
+          "tableTo": "person",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pvb_onderdeel_id_kerntaak_onderdeel_id_unique": {
+          "name": "pvb_onderdeel_id_kerntaak_onderdeel_id_unique",
+          "columns": [
+            "id",
+            "kerntaak_onderdeel_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "pvb_onderdeel_id_kerntaak_onderdeel_id_beoordelaar_id_unique": {
+          "name": "pvb_onderdeel_id_kerntaak_onderdeel_id_beoordelaar_id_unique",
+          "columns": [
+            "id",
+            "kerntaak_onderdeel_id",
+            "beoordelaar_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "pvb_onderdeel_id_kerntaak_id_unique": {
+          "name": "pvb_onderdeel_id_kerntaak_id_unique",
+          "columns": [
+            "id",
+            "kerntaak_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_onderdeel_beoordelingscriterium": {
+      "name": "pvb_onderdeel_beoordelingscriterium",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_onderdeel_id": {
+          "name": "pvb_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beoordelingscriterium_id": {
+          "name": "beoordelingscriterium_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "behaald": {
+          "name": "behaald",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_onderdeel_beoordelingscriterium_pvb_onderdeel_id_kerntaak_id_pvb_onderdeel_id_kerntaak_id_fk": {
+          "name": "pvb_onderdeel_beoordelingscriterium_pvb_onderdeel_id_kerntaak_id_pvb_onderdeel_id_kerntaak_id_fk",
+          "tableFrom": "pvb_onderdeel_beoordelingscriterium",
+          "columnsFrom": [
+            "pvb_onderdeel_id",
+            "kerntaak_id"
+          ],
+          "tableTo": "pvb_onderdeel",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "pvb_onderdeel_beoordelingscriterium_beoordelingscriterium_id_kerntaak_id_beoordelingscriterium_id_kerntaak_id_fk": {
+          "name": "pvb_onderdeel_beoordelingscriterium_beoordelingscriterium_id_kerntaak_id_beoordelingscriterium_id_kerntaak_id_fk",
+          "tableFrom": "pvb_onderdeel_beoordelingscriterium",
+          "columnsFrom": [
+            "beoordelingscriterium_id",
+            "kerntaak_id"
+          ],
+          "tableTo": "beoordelingscriterium",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "pvb_onderdeel_beoordelingscriterium_kerntaak_id_kerntaak_id_fk": {
+          "name": "pvb_onderdeel_beoordelingscriterium_kerntaak_id_kerntaak_id_fk",
+          "tableFrom": "pvb_onderdeel_beoordelingscriterium",
+          "columnsFrom": [
+            "kerntaak_id"
+          ],
+          "tableTo": "kerntaak",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pvb_onderdeel_beoordelingscriterium_pvb_onderdeel_id_beoordelingscriterium_id_unique": {
+          "name": "pvb_onderdeel_beoordelingscriterium_pvb_onderdeel_id_beoordelingscriterium_id_unique",
+          "columns": [
+            "pvb_onderdeel_id",
+            "beoordelingscriterium_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.pvb_voorstel_datum": {
+      "name": "pvb_voorstel_datum",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "pvb_aanvraag_id": {
+          "name": "pvb_aanvraag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_na": {
+          "name": "start_na",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eind_voor": {
+          "name": "eind_voor",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voorkeur": {
+          "name": "voorkeur",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opmerkingen": {
+          "name": "opmerkingen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pvb_voorstel_datum_pvb_aanvraag_id_pvb_aanvraag_id_fk": {
+          "name": "pvb_voorstel_datum_pvb_aanvraag_id_pvb_aanvraag_id_fk",
+          "tableFrom": "pvb_voorstel_datum",
+          "columnsFrom": [
+            "pvb_aanvraag_id"
+          ],
+          "tableTo": "pvb_aanvraag",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pvb_voorstel_datum_id_pvb_aanvraag_id_unique": {
+          "name": "pvb_voorstel_datum_id_pvb_aanvraag_id_unique",
+          "columns": [
+            "id",
+            "pvb_aanvraag_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.beoordelingscriterium": {
+      "name": "beoordelingscriterium",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "werkproces_id": {
+          "name": "werkproces_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rang": {
+          "name": "rang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "omschrijving": {
+          "name": "omschrijving",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "beoordelingscriterium_werkproces_id_kerntaak_id_werkproces_id_kerntaak_id_fk": {
+          "name": "beoordelingscriterium_werkproces_id_kerntaak_id_werkproces_id_kerntaak_id_fk",
+          "tableFrom": "beoordelingscriterium",
+          "columnsFrom": [
+            "werkproces_id",
+            "kerntaak_id"
+          ],
+          "tableTo": "werkproces",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "beoordelingscriterium_kerntaak_id_kerntaak_id_fk": {
+          "name": "beoordelingscriterium_kerntaak_id_kerntaak_id_fk",
+          "tableFrom": "beoordelingscriterium",
+          "columnsFrom": [
+            "kerntaak_id"
+          ],
+          "tableTo": "kerntaak",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "beoordelingscriterium_id_kerntaak_id_unique": {
+          "name": "beoordelingscriterium_id_kerntaak_id_unique",
+          "columns": [
+            "id",
+            "kerntaak_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.kerntaak": {
+      "name": "kerntaak",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "titel": {
+          "name": "titel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kwalificatieprofiel_id": {
+          "name": "kwalificatieprofiel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "kerntaakType",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rang": {
+          "name": "rang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kerntaak_kwalificatieprofiel_id_kwalificatieprofiel_id_fk": {
+          "name": "kerntaak_kwalificatieprofiel_id_kwalificatieprofiel_id_fk",
+          "tableFrom": "kerntaak",
+          "columnsFrom": [
+            "kwalificatieprofiel_id"
+          ],
+          "tableTo": "kwalificatieprofiel",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.kerntaak_onderdeel": {
+      "name": "kerntaak_onderdeel",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beoordelingsType": {
+          "name": "beoordelingsType",
+          "type": "kerntaakOnderdeelType",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kerntaak_onderdeel_kerntaak_id_kerntaak_id_fk": {
+          "name": "kerntaak_onderdeel_kerntaak_id_kerntaak_id_fk",
+          "tableFrom": "kerntaak_onderdeel",
+          "columnsFrom": [
+            "kerntaak_id"
+          ],
+          "tableTo": "kerntaak",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kerntaak_onderdeel_id_kerntaak_id_unique": {
+          "name": "kerntaak_onderdeel_id_kerntaak_id_unique",
+          "columns": [
+            "id",
+            "kerntaak_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.kwalificatieprofiel": {
+      "name": "kwalificatieprofiel",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "titel": {
+          "name": "titel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "richting": {
+          "name": "richting",
+          "type": "richting",
+          "typeSchema": "kss",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "niveau_id": {
+          "name": "niveau_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kwalificatieprofiel_niveau_id_niveau_id_fk": {
+          "name": "kwalificatieprofiel_niveau_id_niveau_id_fk",
+          "tableFrom": "kwalificatieprofiel",
+          "columnsFrom": [
+            "niveau_id"
+          ],
+          "tableTo": "niveau",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.niveau": {
+      "name": "niveau",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "rang": {
+          "name": "rang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.werkproces": {
+      "name": "werkproces",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "titel": {
+          "name": "titel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resultaat": {
+          "name": "resultaat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rang": {
+          "name": "rang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "werkproces_kerntaak_id_kerntaak_id_fk": {
+          "name": "werkproces_kerntaak_id_kerntaak_id_fk",
+          "tableFrom": "werkproces",
+          "columnsFrom": [
+            "kerntaak_id"
+          ],
+          "tableTo": "kerntaak",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "werkproces_id_kerntaak_id_unique": {
+          "name": "werkproces_id_kerntaak_id_unique",
+          "columns": [
+            "id",
+            "kerntaak_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "kss.werkproces_kerntaak_onderdeel": {
+      "name": "werkproces_kerntaak_onderdeel",
+      "schema": "kss",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "werkproces_id": {
+          "name": "werkproces_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_onderdeel_id": {
+          "name": "kerntaak_onderdeel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kerntaak_id": {
+          "name": "kerntaak_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "werkproces_kerntaak_onderdeel_werkproces_id_kerntaak_id_werkproces_id_kerntaak_id_fk": {
+          "name": "werkproces_kerntaak_onderdeel_werkproces_id_kerntaak_id_werkproces_id_kerntaak_id_fk",
+          "tableFrom": "werkproces_kerntaak_onderdeel",
+          "columnsFrom": [
+            "werkproces_id",
+            "kerntaak_id"
+          ],
+          "tableTo": "werkproces",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "werkproces_kerntaak_onderdeel_kerntaak_onderdeel_id_kerntaak_id_kerntaak_onderdeel_id_kerntaak_id_fk": {
+          "name": "werkproces_kerntaak_onderdeel_kerntaak_onderdeel_id_kerntaak_id_kerntaak_onderdeel_id_kerntaak_id_fk",
+          "tableFrom": "werkproces_kerntaak_onderdeel",
+          "columnsFrom": [
+            "kerntaak_onderdeel_id",
+            "kerntaak_id"
+          ],
+          "tableTo": "kerntaak_onderdeel",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id",
+            "kerntaak_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "werkproces_kerntaak_onderdeel_werkproces_id_kerntaak_onderdeel_id_unique": {
+          "name": "werkproces_kerntaak_onderdeel_werkproces_id_kerntaak_onderdeel_id_unique",
+          "columns": [
+            "werkproces_id",
+            "kerntaak_onderdeel_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leercoach.chat": {
+      "name": "chat",
+      "schema": "leercoach",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profiel_id": {
+          "name": "profiel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructie_groep_id": {
+          "name": "instructie_groep_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "chat_phase",
+          "typeSchema": "leercoach",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verkennen'"
+        },
+        "active_stream_id": {
+          "name": "active_stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portfolio_id": {
+          "name": "portfolio_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "chat_user_created_idx": {
+          "name": "chat_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "chat_profiel_idx": {
+          "name": "chat_profiel_idx",
+          "columns": [
+            {
+              "expression": "profiel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "chat_profiel_id_kwalificatieprofiel_id_fk": {
+          "name": "chat_profiel_id_kwalificatieprofiel_id_fk",
+          "tableFrom": "chat",
+          "columnsFrom": [
+            "profiel_id"
+          ],
+          "tableTo": "kwalificatieprofiel",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "chat_instructie_groep_id_instructie_groep_id_fk": {
+          "name": "chat_instructie_groep_id_instructie_groep_id_fk",
+          "tableFrom": "chat",
+          "columnsFrom": [
+            "instructie_groep_id"
+          ],
+          "tableTo": "instructie_groep",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leercoach.message": {
+      "name": "message",
+      "schema": "leercoach",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "compacted_into_id": {
+          "name": "compacted_into_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compaction_metadata": {
+          "name": "compaction_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "message_chat_created_idx": {
+          "name": "message_chat_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "message_active_chat_created_idx": {
+          "name": "message_active_chat_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"leercoach\".\"message\".\"compacted_into_id\" is null",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "message_chat_id_chat_id_fk": {
+          "name": "message_chat_id_chat_id_fk",
+          "tableFrom": "message",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "tableTo": "chat",
+          "schemaTo": "leercoach",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leercoach.portfolio": {
+      "name": "portfolio",
+      "schema": "leercoach",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profiel_id": {
+          "name": "profiel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructie_groep_id": {
+          "name": "instructie_groep_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "portfolio_user_created_idx": {
+          "name": "portfolio_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "portfolio_user_profiel_groep_idx": {
+          "name": "portfolio_user_profiel_groep_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profiel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "instructie_groep_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "portfolio_instructie_groep_id_instructie_groep_id_fk": {
+          "name": "portfolio_instructie_groep_id_instructie_groep_id_fk",
+          "tableFrom": "portfolio",
+          "columnsFrom": [
+            "instructie_groep_id"
+          ],
+          "tableTo": "instructie_groep",
+          "schemaTo": "kss",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leercoach.portfolio_version": {
+      "name": "portfolio_version",
+      "schema": "leercoach",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "portfolio_id": {
+          "name": "portfolio_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "portfolio_version_created_by",
+          "typeSchema": "leercoach",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_message_id": {
+          "name": "created_by_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_note": {
+          "name": "change_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "portfolio_version_portfolio_created_idx": {
+          "name": "portfolio_version_portfolio_created_idx",
+          "columns": [
+            {
+              "expression": "portfolio_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "portfolio_version_portfolio_hash_unique": {
+          "name": "portfolio_version_portfolio_hash_unique",
+          "columns": [
+            {
+              "expression": "portfolio_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "portfolio_version_portfolio_id_portfolio_id_fk": {
+          "name": "portfolio_version_portfolio_id_portfolio_id_fk",
+          "tableFrom": "portfolio_version",
+          "columnsFrom": [
+            "portfolio_id"
+          ],
+          "tableTo": "portfolio",
+          "schemaTo": "leercoach",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "portfolio_version_parent_version_id_portfolio_version_id_fk": {
+          "name": "portfolio_version_parent_version_id_portfolio_version_id_fk",
+          "tableFrom": "portfolio_version",
+          "columnsFrom": [
+            "parent_version_id"
+          ],
+          "tableTo": "portfolio_version",
+          "schemaTo": "leercoach",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leercoach.upload_job": {
+      "name": "upload_job",
+      "schema": "leercoach",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "upload_job_kind",
+          "typeSchema": "leercoach",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "upload_job_status",
+          "typeSchema": "leercoach",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "blob_path": {
+          "name": "blob_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "upload_job_user_created_idx": {
+          "name": "upload_job_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "upload_job_status_idx": {
+          "name": "upload_job_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location": {
+      "name": "location",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "status": {
+          "name": "status",
+          "type": "location_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_media_id": {
+          "name": "logo_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "square_logo_media_id": {
+          "name": "square_logo_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_media_id": {
+          "name": "certificate_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "unique_handle_for_location": {
+          "name": "unique_handle_for_location",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "location_logo_media_id_media_id_fk": {
+          "name": "location_logo_media_id_media_id_fk",
+          "tableFrom": "location",
+          "columnsFrom": [
+            "logo_media_id"
+          ],
+          "tableTo": "media",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "location_square_logo_media_id_media_id_fk": {
+          "name": "location_square_logo_media_id_media_id_fk",
+          "tableFrom": "location",
+          "columnsFrom": [
+            "square_logo_media_id"
+          ],
+          "tableTo": "media",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "location_certificate_media_id_media_id_fk": {
+          "name": "location_certificate_media_id_media_id_fk",
+          "tableFrom": "location",
+          "columnsFrom": [
+            "certificate_media_id"
+          ],
+          "tableTo": "media",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_resource_link": {
+      "name": "location_resource_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gear_type_id": {
+          "name": "gear_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discipline_id": {
+          "name": "discipline_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "location_gear_type_unique": {
+          "name": "location_gear_type_unique",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gear_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "location_discipline_unique": {
+          "name": "location_discipline_unique",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discipline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "location_resource_link_location_id_fk": {
+          "name": "location_resource_link_location_id_fk",
+          "tableFrom": "location_resource_link",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "tableTo": "location",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "location_resource_link_gear_type_id_fk": {
+          "name": "location_resource_link_gear_type_id_fk",
+          "tableFrom": "location_resource_link",
+          "columnsFrom": [
+            "gear_type_id"
+          ],
+          "tableTo": "gear_type",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "location_resource_link_discipline_id_fk": {
+          "name": "location_resource_link_discipline_id_fk",
+          "tableFrom": "location_resource_link",
+          "columnsFrom": [
+            "discipline_id"
+          ],
+          "tableTo": "discipline",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "location_resource_link_required_one_resource": {
+          "name": "location_resource_link_required_one_resource",
+          "value": "(\n        (gear_type_id is not null)::int + \n        (discipline_id is not null)::int = 1\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.logbook": {
+      "name": "logbook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departure_port": {
+          "name": "departure_port",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "arrival_port": {
+          "name": "arrival_port",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wind_power": {
+          "name": "wind_power",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wind_direction": {
+          "name": "wind_direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boat_type": {
+          "name": "boat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boat_length": {
+          "name": "boat_length",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sailed_nautical_miles": {
+          "name": "sailed_nautical_miles",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sailed_hours_in_dark": {
+          "name": "sailed_hours_in_dark",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_role": {
+          "name": "primary_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crew_names": {
+          "name": "crew_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_comments": {
+          "name": "additional_comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "logbook_person_id_fk": {
+          "name": "logbook_person_id_fk",
+          "tableFrom": "logbook",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "tableTo": "person",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "marketing.cashback": {
+      "name": "cashback",
+      "schema": "marketing",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "applicant_full_name": {
+          "name": "applicant_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_email": {
+          "name": "applicant_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_iban": {
+          "name": "applicant_iban",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_full_name": {
+          "name": "student_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_media_id": {
+          "name": "verification_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_location": {
+          "name": "verification_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booking_location_id": {
+          "name": "booking_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booking_number": {
+          "name": "booking_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cashback_verification_media_id_media_id_fk": {
+          "name": "cashback_verification_media_id_media_id_fk",
+          "tableFrom": "cashback",
+          "columnsFrom": [
+            "verification_media_id"
+          ],
+          "tableTo": "media",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "cashback_booking_location_id_location_id_fk": {
+          "name": "cashback_booking_location_id_location_id_fk",
+          "tableFrom": "cashback",
+          "columnsFrom": [
+            "booking_location_id"
+          ],
+          "tableTo": "location",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "media_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "media_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_idx_name_search": {
+          "name": "media_idx_name_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', COALESCE(\"name\", ''))",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "media_object_id_fk": {
+          "name": "media_object_id_fk",
+          "tableFrom": "media",
+          "columnsFrom": [
+            "object_id"
+          ],
+          "tableTo": "objects",
+          "schemaTo": "storage",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "media_actor_id_fk": {
+          "name": "media_actor_id_fk",
+          "tableFrom": "media",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "tableTo": "actor",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "media_location_id_fk": {
+          "name": "media_location_id_fk",
+          "tableFrom": "media",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "tableTo": "location",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.country": {
+      "name": "country",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ar": {
+          "name": "ar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "bg": {
+          "name": "bg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "cs": {
+          "name": "cs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "da": {
+          "name": "da",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "de": {
+          "name": "de",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "el": {
+          "name": "el",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "en": {
+          "name": "en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "es": {
+          "name": "es",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "et": {
+          "name": "et",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "eu": {
+          "name": "eu",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "fi": {
+          "name": "fi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "fr": {
+          "name": "fr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "hu": {
+          "name": "hu",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "it": {
+          "name": "it",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ja": {
+          "name": "ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ko": {
+          "name": "ko",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "lt": {
+          "name": "lt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "nl": {
+          "name": "nl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "no": {
+          "name": "no",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "pl": {
+          "name": "pl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "pt": {
+          "name": "pt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ro": {
+          "name": "ro",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ru": {
+          "name": "ru",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sk": {
+          "name": "sk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sv": {
+          "name": "sv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "th": {
+          "name": "th",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "uk": {
+          "name": "uk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "zh": {
+          "name": "zh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "zh-tw": {
+          "name": "zh-tw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "alpha_2": {
+          "name": "alpha_2",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "alpha_3": {
+          "name": "alpha_3",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "country_alpha_2_is_unique": {
+          "name": "country_alpha_2_is_unique",
+          "columns": [
+            {
+              "expression": "alpha_2",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "country_alpha_3_is_unique": {
+          "name": "country_alpha_3_is_unique",
+          "columns": [
+            {
+              "expression": "alpha_3",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "type": {
+          "name": "type",
+          "type": "feedback_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query": {
+          "name": "query",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "base": {
+          "name": "base",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "inserted_by": {
+          "name": "inserted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_inserted_by_fk": {
+          "name": "feedback_inserted_by_fk",
+          "tableFrom": "feedback",
+          "columnsFrom": [
+            "inserted_by"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "auth_user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_cohort_progress": {
+      "name": "student_cohort_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "cohort_allocation_id": {
+          "name": "cohort_allocation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "curriculum_module_competency_id": {
+          "name": "curriculum_module_competency_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cohort_allocation_id_idx": {
+          "name": "cohort_allocation_id_idx",
+          "columns": [
+            {
+              "expression": "cohort_allocation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "curriculum_module_competency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "student_cohort_progress_cohort_allocation_id_fk": {
+          "name": "student_cohort_progress_cohort_allocation_id_fk",
+          "tableFrom": "student_cohort_progress",
+          "columnsFrom": [
+            "cohort_allocation_id"
+          ],
+          "tableTo": "cohort_allocation",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "curriculum_competency_competency_id_fk": {
+          "name": "curriculum_competency_competency_id_fk",
+          "tableFrom": "student_cohort_progress",
+          "columnsFrom": [
+            "curriculum_module_competency_id"
+          ],
+          "tableTo": "curriculum_competency",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "student_cohort_progress_created_by_fk": {
+          "name": "student_cohort_progress_created_by_fk",
+          "tableFrom": "student_cohort_progress",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "person",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.actor": {
+      "name": "actor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "type": {
+          "name": "type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "actor_person_id_fk": {
+          "name": "actor_person_id_fk",
+          "tableFrom": "actor",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "tableTo": "person",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "actor_location_link_location_id_fk": {
+          "name": "actor_location_link_location_id_fk",
+          "tableFrom": "actor",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "tableTo": "location",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unq_actor_type_person_location": {
+          "name": "unq_actor_type_person_location",
+          "columns": [
+            "type",
+            "person_id",
+            "location_id"
+          ],
+          "nullsNotDistinct": true
+        },
+        "unq_actor_location_id_unique": {
+          "name": "unq_actor_location_id_unique",
+          "columns": [
+            "id",
+            "location_id"
+          ],
+          "nullsNotDistinct": true
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person": {
+      "name": "person",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_name_prefix": {
+          "name": "last_name_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_city": {
+          "name": "birth_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_country": {
+          "name": "birth_country",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "person_unq_handle": {
+          "name": "person_unq_handle",
+          "columns": [
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "person_idx_handle_search": {
+          "name": "person_idx_handle_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', COALESCE(\"handle\", ''))",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "person_idx_name_search": {
+          "name": "person_idx_name_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', \n        COALESCE(\"first_name\", '') || ' ' || \n        COALESCE(\"last_name_prefix\", '') || ' ' || \n        COALESCE(\"last_name\", '')\n      )",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "person_idx_user_id": {
+          "name": "person_idx_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "person_idx_is_primary": {
+          "name": "person_idx_is_primary",
+          "columns": [
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "unq_primary_person": {
+          "name": "unq_primary_person",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"person\".\"is_primary\" = true",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "person_birth_country_country_alpha_2_fk": {
+          "name": "person_birth_country_country_alpha_2_fk",
+          "tableFrom": "person",
+          "columnsFrom": [
+            "birth_country"
+          ],
+          "tableTo": "country",
+          "columnsTo": [
+            "alpha_2"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "person_user_id_fk": {
+          "name": "person_user_id_fk",
+          "tableFrom": "person",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "auth_user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_location_link": {
+      "name": "person_location_link",
+      "schema": "",
+      "columns": {
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "person_location_link_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_level": {
+          "name": "permission_level",
+          "type": "permissionRequestStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "person_location_link_person_id_fk": {
+          "name": "person_location_link_person_id_fk",
+          "tableFrom": "person_location_link",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "tableTo": "person",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "person_location_link_location_id_fk": {
+          "name": "person_location_link_location_id_fk",
+          "tableFrom": "person_location_link",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "tableTo": "location",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "person_location_link_pk": {
+          "name": "person_location_link_pk",
+          "columns": [
+            "person_id",
+            "location_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_metadata": {
+          "name": "_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_idx_email_full_search": {
+          "name": "user_idx_email_full_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', COALESCE(\"email\", ''))",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "user_idx_email_username_search": {
+          "name": "user_idx_email_username_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', COALESCE(split_part(\"email\"::text, '@', 1), ''))",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "user_idx_email_domain_search": {
+          "name": "user_idx_email_domain_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', COALESCE(split_part(\"email\"::text, '@', 2), ''))",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_auth_user_id_fk": {
+          "name": "user_auth_user_id_fk",
+          "tableFrom": "user",
+          "columnsFrom": [
+            "auth_user_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_acting_profile_preference": {
+      "name": "user_acting_profile_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "extensions.uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_acting_profile_preference_user_id_fk": {
+          "name": "user_acting_profile_preference_user_id_fk",
+          "tableFrom": "user_acting_profile_preference",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "auth_user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "user_acting_profile_preference_location_id_fk": {
+          "name": "user_acting_profile_preference_location_id_fk",
+          "tableFrom": "user_acting_profile_preference",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "tableTo": "location",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "user_acting_profile_preference_person_id_fk": {
+          "name": "user_acting_profile_preference_person_id_fk",
+          "tableFrom": "user_acting_profile_preference",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "tableTo": "person",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unq_acting_profile_user_location": {
+          "name": "unq_acting_profile_user_location",
+          "columns": [
+            "user_id",
+            "location_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "ai_corpus.consent_level": {
+      "name": "consent_level",
+      "schema": "ai_corpus",
+      "values": [
+        "seed",
+        "opt_in_shared",
+        "user_only"
+      ]
+    },
+    "ai_corpus.domain": {
+      "name": "domain",
+      "schema": "ai_corpus",
+      "values": [
+        "pvb_portfolio",
+        "diplomalijn",
+        "knowledge_center",
+        "artefact"
+      ]
+    },
+    "public.bulk_import_preview_status": {
+      "name": "bulk_import_preview_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "committed",
+        "invalidated_max"
+      ]
+    },
+    "public.person_merge_audit_decision_kind": {
+      "name": "person_merge_audit_decision_kind",
+      "schema": "public",
+      "values": [
+        "create_new",
+        "use_existing",
+        "merge",
+        "skip"
+      ]
+    },
+    "public.person_merge_audit_source": {
+      "name": "person_merge_audit_source",
+      "schema": "public",
+      "values": [
+        "bulk_import_preview",
+        "personen_page",
+        "cohort_view",
+        "single_create_dialog",
+        "sysadmin"
+      ]
+    },
+    "public.role_type": {
+      "name": "role_type",
+      "schema": "public",
+      "values": [
+        "organization",
+        "location",
+        "cohort"
+      ]
+    },
+    "public.competency_type": {
+      "name": "competency_type",
+      "schema": "public",
+      "values": [
+        "knowledge",
+        "skill"
+      ]
+    },
+    "public.kwalificatie_verkregen_reden": {
+      "name": "kwalificatie_verkregen_reden",
+      "schema": "public",
+      "values": [
+        "pvb_behaald",
+        "pvb_instructiegroep_basis",
+        "onbekend"
+      ]
+    },
+    "kss.aanvraag_status": {
+      "name": "aanvraag_status",
+      "schema": "kss",
+      "values": [
+        "concept",
+        "wacht_op_voorwaarden",
+        "gereed_voor_beoordeling",
+        "in_beoordeling",
+        "afgerond",
+        "ingetrokken",
+        "afgebroken"
+      ]
+    },
+    "kss.beoordelaar_beschikbaarheidsstatus": {
+      "name": "beoordelaar_beschikbaarheidsstatus",
+      "schema": "kss",
+      "values": [
+        "geinteresseerd",
+        "toegewezen",
+        "afgewezen_door_beoordelaar",
+        "afgewezen_door_secretariaat",
+        "afgewezen_door_vaarlocatie",
+        "ingetrokken"
+      ]
+    },
+    "kss.leercoach_toestemming_status": {
+      "name": "leercoach_toestemming_status",
+      "schema": "kss",
+      "values": [
+        "gevraagd",
+        "gegeven",
+        "geweigerd",
+        "herroepen"
+      ]
+    },
+    "kss.pvb_aanvraag_type": {
+      "name": "pvb_aanvraag_type",
+      "schema": "kss",
+      "values": [
+        "intern",
+        "extern"
+      ]
+    },
+    "kss.pvb_gebeurtenis_type": {
+      "name": "pvb_gebeurtenis_type",
+      "schema": "kss",
+      "values": [
+        "aanvraag_ingediend",
+        "leercoach_toestemming_gevraagd",
+        "leercoach_toestemming_gegeven",
+        "leercoach_toestemming_geweigerd",
+        "voorwaarden_voltooid",
+        "beoordeling_gestart",
+        "beoordeling_afgerond",
+        "aanvraag_ingetrokken",
+        "onderdeel_toegevoegd",
+        "onderdeel_beoordelaar_gewijzigd",
+        "onderdeel_uitslag_gewijzigd",
+        "onderdeel_startdatum_gewijzigd"
+      ]
+    },
+    "kss.pvb_onderdeel_uitslag": {
+      "name": "pvb_onderdeel_uitslag",
+      "schema": "kss",
+      "values": [
+        "behaald",
+        "niet_behaald",
+        "nog_niet_bekend"
+      ]
+    },
+    "kss.kerntaakOnderdeelType": {
+      "name": "kerntaakOnderdeelType",
+      "schema": "kss",
+      "values": [
+        "portfolio",
+        "praktijk"
+      ]
+    },
+    "kss.kerntaakType": {
+      "name": "kerntaakType",
+      "schema": "kss",
+      "values": [
+        "verplicht",
+        "facultatief"
+      ]
+    },
+    "kss.richting": {
+      "name": "richting",
+      "schema": "kss",
+      "values": [
+        "instructeur",
+        "leercoach",
+        "pvb_beoordelaar"
+      ]
+    },
+    "leercoach.chat_phase": {
+      "name": "chat_phase",
+      "schema": "leercoach",
+      "values": [
+        "verkennen",
+        "ordenen",
+        "concept",
+        "verfijnen"
+      ]
+    },
+    "leercoach.portfolio_version_created_by": {
+      "name": "portfolio_version_created_by",
+      "schema": "leercoach",
+      "values": [
+        "coach",
+        "user",
+        "imported"
+      ]
+    },
+    "leercoach.upload_job_kind": {
+      "name": "upload_job_kind",
+      "schema": "leercoach",
+      "values": [
+        "portfolio"
+      ]
+    },
+    "leercoach.upload_job_status": {
+      "name": "upload_job_status",
+      "schema": "leercoach",
+      "values": [
+        "pending",
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.location_status": {
+      "name": "location_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "hidden",
+        "archived"
+      ]
+    },
+    "public.media_status": {
+      "name": "media_status",
+      "schema": "public",
+      "values": [
+        "failed",
+        "processing",
+        "ready",
+        "uploaded",
+        "corrupt"
+      ]
+    },
+    "public.media_type": {
+      "name": "media_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "file"
+      ]
+    },
+    "public.feedback_type": {
+      "name": "feedback_type",
+      "schema": "public",
+      "values": [
+        "bug",
+        "product-feedback",
+        "program-feedback",
+        "question",
+        "other"
+      ]
+    },
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": [
+        "student",
+        "instructor",
+        "location_admin",
+        "system",
+        "pvb_beoordelaar",
+        "secretariaat"
+      ]
+    },
+    "public.permissionRequestStatus": {
+      "name": "permissionRequestStatus",
+      "schema": "public",
+      "values": [
+        "none",
+        "requested",
+        "permission_granted"
+      ]
+    },
+    "public.person_location_link_status": {
+      "name": "person_location_link_status",
+      "schema": "public",
+      "values": [
+        "linked",
+        "revoked",
+        "removed"
+      ]
+    }
+  },
+  "schemas": {
+    "ai_corpus": "ai_corpus",
+    "kss": "kss",
+    "leercoach": "leercoach",
+    "marketing": "marketing"
+  },
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -281,6 +281,20 @@
       "when": 1780083278742,
       "tag": "0039_cuddly_alex_power",
       "breakpoints": false
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1783194583613,
+      "tag": "0040_gifted_changeling",
+      "breakpoints": false
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1783194584256,
+      "tag": "0041_productive_joshua_kane",
+      "breakpoints": false
     }
   ]
 }

--- a/packages/db/src/schema/user.ts
+++ b/packages/db/src/schema/user.ts
@@ -139,6 +139,41 @@ export const actor = pgTable(
   ],
 );
 
+export const userActingProfilePreference = pgTable(
+  "user_acting_profile_preference",
+  {
+    id: uuid("id")
+      .default(sql`extensions.uuid_generate_v4()`)
+      .primaryKey()
+      .notNull(),
+    userId: uuid("user_id").notNull(),
+    locationId: uuid("location_id").notNull(),
+    personId: uuid("person_id").notNull(),
+    ...timestamps,
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [user.authUserId],
+      name: "user_acting_profile_preference_user_id_fk",
+    }),
+    foreignKey({
+      columns: [table.locationId],
+      foreignColumns: [location.id],
+      name: "user_acting_profile_preference_location_id_fk",
+    }),
+    foreignKey({
+      columns: [table.personId],
+      foreignColumns: [person.id],
+      name: "user_acting_profile_preference_person_id_fk",
+    }),
+    unique("unq_acting_profile_user_location").on(
+      table.userId,
+      table.locationId,
+    ),
+  ],
+);
+
 export const personLocationLinkStatus = pgEnum("person_location_link_status", [
   "linked", // Indicates an active link.
   "revoked", // The person has revoked the link with the location.


### PR DESCRIPTION
## Summary

First half of the migration described in `docs/designs/explicit-acting-profile.md` (included in this PR): stop using "main profile" (`person.isPrimary`) as authorization, UI-gate, and audit identity, and introduce an explicit per-location acting profile.

**Phase 1 — the support-case fix:**
- `getPrimaryPerson` no longer silently *writes* `isPrimary` during reads (read-only default from here on)
- The four `/profiel/[handle]` gates (instructor tab, dashboard toggle, `require-instructor-person`, own-PVB page) now derive identity from the route handle + active roles — a non-primary instructor profile finally sees its staff tabs and its own PVB pages
- `retrievePvbAanvraagByHandle` authorizes against any owned person (direct kandidaat/leercoach/beoordelaar match first, location-admin fallback second)

**Phase 2 — explicit acting context for `/locatie`:**
- New `userActingProfilePreference` table (migrations `0040`/`0041` — **must be executed on deploy**) with core accessors
- `resolveActingContextForLocation`: request-scoped (React `cache()`) resolver — 0 eligible profiles → unauthorized, 1 → auto-selected, multiple → remembered preference or a blocking chooser
- `/locatie/[location]/kies-profiel` chooser route (validated `?next=`, no open redirects)
- Sidebar "Handelt als" indicator + switcher
- `listLocationsForPerson` unions across all owned persons; 10 location-scoped reads now authorize as the acting person; 11 non-cohort location pages gate through the chooser

Design decisions (and why `cache()`/no-URL-authority/choose-before-view) are documented in the design doc, verified against the vendored Next 16.1.6 source.

Phase 3 (cohort resolver, explicit-acting mutations, auth-hole fixes) follows as a stacked PR.

## Test plan
- [ ] Non-primary instructor profile shows staff tabs + own PVB pages under its own handle
- [ ] Location dashboard with one eligible profile: opens directly, sidebar shows "Handelt als"
- [ ] Two eligible profiles, no preference: blocking chooser before any location data; choice persists and is switchable from the sidebar
- [ ] Remembered profile that lost its role: chooser prompts again
- [ ] `?next=` on the chooser rejects external/absolute URLs
- [ ] Migrations 0040/0041 applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/buchungapp/codesmith/nationaal-watersportdiploma/pr/482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785826333&installation_id=137554715&pr_number=482&repository=buchungapp%2Fnationaal-watersportdiploma&return_to=https%3A%2F%2Fgithub.com%2Fbuchungapp%2Fnationaal-watersportdiploma%2Fpull%2F482&signature=fb0b413468b0aabcb2d6108bffa6ea66af9a08d05d76565a17631cef1ac65594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization and identity across profiel and location dashboards; incorrect acting resolution could block staff or expose data, though page gates and fail-closed data helpers mitigate this.
> 
> **Overview**
> Stops using **`person.isPrimary`** as the gate for instructor UI and location staff access. On **`/profiel/[handle]`**, instructor tabs, dashboard toggle, **`requireInstructorPerson`**, and own-PvB pages now key off the **route handle** plus active roles (`instructor`, `pvb_beoordelaar`, `location_admin`). **`getPrimaryPerson`** is **read-only** (no more silent `setPrimary` on read). **`retrievePvbAanvraagByHandle`** checks **any owned profile** for kandidaat/leercoach/beoordelaar before falling back to location-admin across persons.
> 
> For **`/locatie/[location]`**, adds **explicit acting context**: migration **`0040`** + **`User.ActingProfile`** preference storage, request-scoped **`resolveActingContextForLocation`** (React `cache()`), **`requireActingPersonForLocationPage`** (chooser redirect when ambiguous), **`/kies-profiel`** with validated **`?next=`**, sidebar **“Handelt als”** switcher, and **`setActingProfileForLocationAction`** with server-side eligibility checks. Location-scoped reads in **`nwd.ts`** authorize via **`requireActingPersonForLocation`** instead of the primary person; **`listLocationsForPerson`** unions locations across all owned profiles.
> 
> Includes design doc **`docs/designs/explicit-acting-profile.md`**. Deploy needs migration **0040**; **0041** enables RLS on all public tables (verify intent separately from acting-profile).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41e2c6a1ef2811182b96dcb70315e1441419f798. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added location-level “acting profile” switching, letting eligible users choose which profile they’re using in a location dashboard.
  * Added a profile choice page when multiple profiles are available.
  * Expanded access across location pages to work with the selected acting profile.

* **Bug Fixes**
  * Removed several checks that incorrectly blocked dashboard access when a profile wasn’t marked as primary.
  * Improved profile-based access so the right content and actions appear for eligible users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->