### PR TITLE
Explicit acting profile: secretariaat hardening, API auth, certificate downloads (phase 4)

### DIFF
--- a/apps/web/src/app/(dashboard)/(account)/profiel/route.ts
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/route.ts
@@ -1,11 +1,11 @@
 import { redirect } from "next/navigation";
 import type { NextRequest } from "next/server";
-import { getUserOrThrow } from "~/lib/nwd";
+import { getDefaultPerson, getUserOrThrow } from "~/lib/nwd";
 
 export async function GET(_request: NextRequest) {
   const user = await getUserOrThrow();
 
-  const primaryPerson = user.persons.find((person) => person.isPrimary);
+  const primaryPerson = getDefaultPerson(user);
 
   if (!primaryPerson) {
     redirect("/account");

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/students-table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/students-table.tsx
@@ -308,12 +308,14 @@ const columns = [
 
 export default function StudentsTable({
   cohortId,
+  locationId,
   students,
   totalItems,
   noOptionsLabel = "Geen items gevonden",
   defaultCertificateVisibleFromDate,
 }: {
   cohortId: string;
+  locationId: string;
   students: Awaited<ReturnType<typeof listCertificateOverviewByCohortId>>;
   totalItems: number;
   noOptionsLabel?: React.ReactNode;
@@ -457,6 +459,7 @@ export default function StudentsTable({
         <ActionButtons
           rows={actionRows}
           cohortId={cohortId}
+          locationId={locationId}
           defaultVisibleFrom={defaultCertificateVisibleFromDate}
           resetSelection={() => setRowSelection({})}
         />

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/table-actions.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/_components/table-actions.tsx
@@ -64,6 +64,7 @@ interface Props {
     studentCurriculum: Student["studentCurriculum"];
   }[];
   cohortId: string;
+  locationId: string;
   defaultVisibleFrom?: string;
   resetSelection: () => void;
 }
@@ -525,6 +526,7 @@ function CoreModulesSubmitButton() {
 
 function DownloadCertificatesDialog({
   rows,
+  locationId,
   isOpen,
   close,
   resetSelection,
@@ -540,6 +542,7 @@ function DownloadCertificatesDialog({
   const { execute, input, reset, result } = useAction(
     downloadCertificatesAction.bind(
       null,
+      locationId,
       // biome-ignore lint/suspicious/noNonNullAssertedOptionalChain: all rows have a certificate, when action is executed
       // biome-ignore lint/style/noNonNullAssertion: all rows have a certificate, when action is executed
       rows.map((row) => row.certificate?.handle!),

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/cohorten/[cohort]/(overview)/diplomas/page.tsx
@@ -170,6 +170,7 @@ export default async function Page(props: {
       students={searchedStudents}
       totalItems={searchedStudents.length}
       cohortId={cohort.id}
+      locationId={cohort.locationId}
       // TODO: this can be optimized
       defaultCertificateVisibleFromDate={
         (await retrieveDefaultCertificateVisibleFromDate(cohort.id)) ??

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_components/table-actions.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_components/table-actions.tsx
@@ -51,11 +51,13 @@ import type { listCertificates } from "~/lib/nwd";
 type Certificate = Awaited<ReturnType<typeof listCertificates>>[number];
 
 interface Props {
+  locationId: string;
   rows: Certificate[];
   resetSelection: () => void;
 }
 
 function DownloadCertificatesDialog({
+  locationId,
   rows,
   isOpen,
   close,
@@ -72,6 +74,7 @@ function DownloadCertificatesDialog({
   const { execute, input, reset, result } = useAction(
     downloadCertificatesAction.bind(
       null,
+      locationId,
       rows.map((row) => row.handle),
     ),
     {

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_components/table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_components/table.tsx
@@ -116,10 +116,12 @@ const columns = [
 ];
 
 export default function CertificateTable({
+  locationId,
   certificates,
   totalItems,
   placeholderRows,
 }: {
+  locationId: string;
   certificates: Certificate[];
   totalItems: number;
   placeholderRows?: number;
@@ -187,6 +189,7 @@ export default function CertificateTable({
         clearRowSelection={() => setRowSelection({})}
       >
         <ActionButtons
+          locationId={locationId}
           rows={actionRows}
           resetSelection={() => setRowSelection({})}
         />

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/page.tsx
@@ -34,7 +34,11 @@ async function CertificatesTable(props: {
   });
 
   return (
-    <Table certificates={certificates.items} totalItems={certificates.count} />
+    <Table
+      locationId={location.id}
+      certificates={certificates.items}
+      totalItems={certificates.count}
+    />
   );
 }
 
@@ -66,7 +70,12 @@ export default async function Page(props: {
 
       <Suspense
         fallback={
-          <Table placeholderRows={10} certificates={[]} totalItems={0} />
+          <Table
+            locationId={location.id}
+            placeholderRows={10}
+            certificates={[]}
+            totalItems={0}
+          />
         }
       >
         <CertificatesTable

--- a/apps/web/src/app/(public)/_components/header/trustbar.tsx
+++ b/apps/web/src/app/(public)/_components/header/trustbar.tsx
@@ -3,7 +3,7 @@ import { ArrowRightIcon } from "@heroicons/react/16/solid";
 import { constants } from "@nawadi/lib";
 import Link from "next/link";
 import { Suspense } from "react";
-import { getUserOrThrow } from "~/lib/nwd";
+import { getDefaultPerson, getUserOrThrow } from "~/lib/nwd";
 import {
   Facebook,
   Instagram,
@@ -15,7 +15,7 @@ import {
 async function AccountButton() {
   const user = await getUserOrThrow().catch(() => null);
 
-  const primaryPerson = user?.persons.find((person) => person.isPrimary);
+  const primaryPerson = user ? getDefaultPerson(user) : null;
 
   return (
     <DataInteractive>

--- a/apps/web/src/app/_actions/certificate/download-certificates-action.ts
+++ b/apps/web/src/app/_actions/certificate/download-certificates-action.ts
@@ -4,7 +4,10 @@ import { z } from "zod";
 import { zfd } from "zod-form-data";
 import { actionClientWithMeta } from "~/app/_actions/safe-action";
 import dayjs from "~/lib/dayjs";
-import { storeCertificateHandles } from "~/lib/nwd";
+import {
+  assertCertificateHandlesBelongToLocation,
+  storeCertificateHandles,
+} from "~/lib/nwd";
 
 const downloadCertificatesSchema = zfd.formData({
   filename: z.string().default(`${dayjs().toISOString()}-export-diplomas`),
@@ -13,8 +16,9 @@ const downloadCertificatesSchema = zfd.formData({
 });
 
 const downloadCertificatesArgsSchema: [
+  locationId: z.ZodString,
   certificateHandles: z.ZodArray<z.ZodString>,
-] = [z.array(z.string())];
+] = [z.string().uuid(), z.array(z.string())];
 
 export const downloadCertificatesAction = actionClientWithMeta
   .metadata({
@@ -25,8 +29,16 @@ export const downloadCertificatesAction = actionClientWithMeta
   .action(
     async ({
       parsedInput: { filename, sort, previousModules },
-      bindArgsParsedInputs: [certificateHandles],
+      bindArgsParsedInputs: [locationId, certificateHandles],
     }) => {
+      // Authorize before minting the download uuid: the bulk PDF route consumes
+      // the uuid unauthenticated, so the acting profile must be a location_admin
+      // and every handle must belong to this location.
+      await assertCertificateHandlesBelongToLocation({
+        locationId,
+        handles: certificateHandles,
+      });
+
       const uuid = await storeCertificateHandles({
         handles: certificateHandles,
         fileName: filename,

--- a/apps/web/src/app/_actions/kss/instructiegroep.ts
+++ b/apps/web/src/app/_actions/kss/instructiegroep.ts
@@ -2,13 +2,25 @@
 
 import { KSS } from "@nawadi/core";
 import { revalidatePath } from "next/cache";
+import { isSystemAdmin } from "~/lib/authorization";
+import { getUserOrThrow } from "~/lib/nwd";
 import { actionClientWithMeta } from "../safe-action";
+
+// Defense in depth: the /secretariaat edge middleware gates the pages, but a
+// server action is an independently callable endpoint, so we check here too.
+async function assertSecretariaat() {
+  const user = await getUserOrThrow();
+  if (!isSystemAdmin(user.email)) {
+    throw new Error("Geen toegang tot deze functie");
+  }
+}
 
 // Create instructiegroep
 export const createInstructiegroep = actionClientWithMeta
   .metadata({ name: "kss.instructiegroep.create" })
   .inputSchema(KSS.createInstructiegroepSchema)
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result = await KSS.InstructieGroep.create(parsedInput);
     revalidatePath("/secretariaat/kss/instructiegroepen");
     return result;
@@ -19,6 +31,7 @@ export const updateInstructiegroep = actionClientWithMeta
   .metadata({ name: "kss.instructiegroep.update" })
   .inputSchema(KSS.updateInstructiegroepSchema)
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result = await KSS.InstructieGroep.update(parsedInput);
     revalidatePath("/secretariaat/kss/instructiegroepen");
     return result;
@@ -29,6 +42,7 @@ export const deleteInstructiegroep = actionClientWithMeta
   .metadata({ name: "kss.instructiegroep.delete" })
   .inputSchema(KSS.deleteInstructiegroepSchema)
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result = await KSS.InstructieGroep.remove(parsedInput);
     revalidatePath("/secretariaat/kss/instructiegroepen");
     return result;
@@ -39,6 +53,7 @@ export const addCourseToInstructiegroep = actionClientWithMeta
   .metadata({ name: "kss.instructiegroep.addCourse" })
   .inputSchema(KSS.addCourseToInstructiegroepSchema)
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result = await KSS.InstructieGroep.addCourse(parsedInput);
     revalidatePath("/secretariaat/kss/instructiegroepen");
     return result;
@@ -49,6 +64,7 @@ export const removeCourseFromInstructiegroep = actionClientWithMeta
   .metadata({ name: "kss.instructiegroep.removeCourse" })
   .inputSchema(KSS.removeCourseFromInstructiegroepSchema)
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result = await KSS.InstructieGroep.removeCourse(parsedInput);
     revalidatePath("/secretariaat/kss/instructiegroepen");
     return result;

--- a/apps/web/src/app/_actions/kss/kwalificatieprofiel.ts
+++ b/apps/web/src/app/_actions/kss/kwalificatieprofiel.ts
@@ -3,13 +3,25 @@
 import { KSS } from "@nawadi/core";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import { isSystemAdmin } from "~/lib/authorization";
+import { getUserOrThrow } from "~/lib/nwd";
 import { actionClientWithMeta } from "../safe-action";
+
+// Defense in depth: the /secretariaat edge middleware gates the pages, but a
+// server action is an independently callable endpoint, so we check here too.
+async function assertSecretariaat() {
+  const user = await getUserOrThrow();
+  if (!isSystemAdmin(user.email)) {
+    throw new Error("Geen toegang tot deze functie");
+  }
+}
 
 // Create kwalificatieprofiel
 export const createKwalificatieprofiel = actionClientWithMeta
   .metadata({ name: "kss.kwalificatieprofiel.create" })
   .inputSchema(KSS.createKwalificatieprofielSchema)
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result = await KSS.Kwalificatieprofiel.create(parsedInput);
     revalidatePath("/secretariaat/kss/kwalificatieprofielen");
     return result;
@@ -20,6 +32,7 @@ export const updateKwalificatieprofiel = actionClientWithMeta
   .metadata({ name: "kss.kwalificatieprofiel.update" })
   .inputSchema(KSS.updateKwalificatieprofielSchema)
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result = await KSS.Kwalificatieprofiel.update(parsedInput);
     revalidatePath("/secretariaat/kss/kwalificatieprofielen");
     return result;
@@ -30,6 +43,7 @@ export const deleteKwalificatieprofiel = actionClientWithMeta
   .metadata({ name: "kss.kwalificatieprofiel.delete" })
   .inputSchema(KSS.deleteKwalificatieprofielSchema)
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result = await KSS.Kwalificatieprofiel.remove(parsedInput);
     revalidatePath("/secretariaat/kss/kwalificatieprofielen");
     return result;
@@ -40,6 +54,7 @@ export const createKerntaak = actionClientWithMeta
   .metadata({ name: "kss.kerntaak.create" })
   .inputSchema(KSS.createKerntaakSchema)
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result = await KSS.Kwalificatieprofiel.createKerntaak(parsedInput);
     revalidatePath("/secretariaat/kss/kerntaken");
     return result;
@@ -50,6 +65,7 @@ export const updateKerntaak = actionClientWithMeta
   .metadata({ name: "kss.kerntaak.update" })
   .inputSchema(KSS.updateKerntaakSchema)
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result = await KSS.Kwalificatieprofiel.updateKerntaak(parsedInput);
     revalidatePath("/secretariaat/kss/kerntaken");
     return result;
@@ -60,6 +76,7 @@ export const deleteKerntaak = actionClientWithMeta
   .metadata({ name: "kss.kerntaak.delete" })
   .inputSchema(KSS.deleteKerntaakSchema)
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result = await KSS.Kwalificatieprofiel.deleteKerntaak(parsedInput);
     revalidatePath("/secretariaat/kss/kerntaken");
     return result;
@@ -70,6 +87,7 @@ export const createKerntaakOnderdeel = actionClientWithMeta
   .metadata({ name: "kss.kerntaakOnderdeel.create" })
   .inputSchema(KSS.createKerntaakOnderdeelSchema)
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result =
       await KSS.Kwalificatieprofiel.createKerntaakOnderdeel(parsedInput);
     revalidatePath("/secretariaat/kss/kerntaken");
@@ -81,6 +99,7 @@ export const deleteKerntaakOnderdeel = actionClientWithMeta
   .metadata({ name: "kss.kerntaakOnderdeel.delete" })
   .inputSchema(KSS.deleteKerntaakOnderdeelSchema)
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result =
       await KSS.Kwalificatieprofiel.deleteKerntaakOnderdeel(parsedInput);
     revalidatePath("/secretariaat/kss/kerntaken");
@@ -92,6 +111,7 @@ export const createWerkproces = actionClientWithMeta
   .metadata({ name: "kss.werkproces.create" })
   .inputSchema(KSS.createWerkprocesSchema)
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result = await KSS.Kwalificatieprofiel.createWerkproces(parsedInput);
     revalidatePath("/secretariaat/kss/werkprocessen");
     return result;
@@ -102,6 +122,7 @@ export const updateWerkproces = actionClientWithMeta
   .metadata({ name: "kss.werkproces.update" })
   .inputSchema(KSS.updateWerkprocesSchema)
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result = await KSS.Kwalificatieprofiel.updateWerkproces(parsedInput);
     revalidatePath("/secretariaat/kss/werkprocessen");
     return result;
@@ -112,6 +133,7 @@ export const deleteWerkproces = actionClientWithMeta
   .metadata({ name: "kss.werkproces.delete" })
   .inputSchema(KSS.deleteWerkprocesSchema)
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result = await KSS.Kwalificatieprofiel.deleteWerkproces(parsedInput);
     revalidatePath("/secretariaat/kss/werkprocessen");
     return result;
@@ -122,6 +144,7 @@ export const createBeoordelingscriterium = actionClientWithMeta
   .metadata({ name: "kss.beoordelingscriterium.create" })
   .inputSchema(KSS.createBeoordelingscriteriumSchema)
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result =
       await KSS.Kwalificatieprofiel.createBeoordelingscriterium(parsedInput);
     revalidatePath("/secretariaat/kss/beoordelingscriteria");
@@ -133,6 +156,7 @@ export const updateBeoordelingscriterium = actionClientWithMeta
   .metadata({ name: "kss.beoordelingscriterium.update" })
   .inputSchema(KSS.updateBeoordelingscriteriumSchema)
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result =
       await KSS.Kwalificatieprofiel.updateBeoordelingscriterium(parsedInput);
     revalidatePath("/secretariaat/kss/beoordelingscriteria");
@@ -144,6 +168,7 @@ export const deleteBeoordelingscriterium = actionClientWithMeta
   .metadata({ name: "kss.beoordelingscriterium.delete" })
   .inputSchema(KSS.deleteBeoordelingscriteriumSchema)
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result =
       await KSS.Kwalificatieprofiel.deleteBeoordelingscriterium(parsedInput);
     revalidatePath("/secretariaat/kss/beoordelingscriteria");
@@ -168,6 +193,7 @@ export const bulkCreateBeoordelingscriteria = actionClientWithMeta
     }),
   )
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const results = [];
 
     // Create each criterium using the existing single create function
@@ -193,6 +219,7 @@ export const assignWerkprocessenToOnderdeel = actionClientWithMeta
     }),
   )
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result =
       await KSS.Kwalificatieprofiel.assignWerkprocesToOnderdeel(parsedInput);
     revalidatePath("/secretariaat/kss/kerntaken");
@@ -208,6 +235,7 @@ export const listWerkprocessenByOnderdeel = actionClientWithMeta
     }),
   )
   .action(async ({ parsedInput }) => {
+    await assertSecretariaat();
     const result =
       await KSS.Kwalificatieprofiel.listWerkprocessenByOnderdeel(parsedInput);
     return result;

--- a/apps/web/src/app/_actions/kss/manage-kwalificaties.ts
+++ b/apps/web/src/app/_actions/kss/manage-kwalificaties.ts
@@ -49,8 +49,12 @@ export const addKwalificatieAction = actionClientWithMeta
         throw new Error("Deze kwalificatie bestaat al voor deze persoon");
       }
 
-      // Get the actor who is adding this (system admin)
-      const actor = user.persons[0]?.actors.find((a) => a.type === "system");
+      // Get the actor who is adding this (system admin). Search across ALL
+      // owned persons for a "system" actor rather than trusting an arbitrary
+      // first person.
+      const actor = user.persons
+        .flatMap((p) => p.actors)
+        .find((a) => a.type === "system");
 
       // Create the kwalificatie
       await tx.insert(s.persoonKwalificatie).values({
@@ -133,8 +137,12 @@ export const addBulkKwalificatiesAction = actionClientWithMeta
     }
 
     const results = await withTransaction(async (tx) => {
-      // Get the actor who is adding this (system admin)
-      const actor = user.persons[0]?.actors.find((a) => a.type === "system");
+      // Get the actor who is adding this (system admin). Search across ALL
+      // owned persons for a "system" actor rather than trusting an arbitrary
+      // first person.
+      const actor = user.persons
+        .flatMap((p) => p.actors)
+        .find((a) => a.type === "system");
 
       // Check for existing kwalificaties
       const existing = await tx

--- a/apps/web/src/app/_actions/secretariat/copy-curriculum-action.ts
+++ b/apps/web/src/app/_actions/secretariat/copy-curriculum-action.ts
@@ -3,7 +3,8 @@
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { zfd } from "zod-form-data";
-import { copyCurriculum } from "~/lib/nwd";
+import { isSystemAdmin } from "~/lib/authorization";
+import { copyCurriculum, getUserOrThrow } from "~/lib/nwd";
 import { actionClientWithMeta } from "../safe-action";
 
 const copyCurriculumSchema = zfd.formData({
@@ -25,6 +26,14 @@ export const copyCurriculumAction = actionClientWithMeta
       parsedInput: { revision },
       bindArgsParsedInputs: [curriculumId],
     }) => {
+      // Defense in depth: the /secretariaat edge middleware gates the pages, but
+      // a server action is an independently callable endpoint, so we check here
+      // too (copyCurriculum itself performs no authorization).
+      const user = await getUserOrThrow();
+      if (!isSystemAdmin(user.email)) {
+        throw new Error("Geen toegang tot deze functie");
+      }
+
       const result = await copyCurriculum({
         curriculumId,
         revision,

--- a/apps/web/src/lib/nwd.ts
+++ b/apps/web/src/lib/nwd.ts
@@ -141,6 +141,17 @@ export async function getPrimaryPerson<T extends boolean = true>(
   return primaryPerson;
 }
 
+/**
+ * The default profile for the /profiel landing ONLY: the primary owned person,
+ * or null when none is marked primary. Strictly read-only (no write-during-read,
+ * no arbitrary-first fallback). Never use for authorization — staff surfaces
+ * resolve the acting person per location/cohort instead.
+ */
+export const getDefaultPerson = (
+  user: Awaited<ReturnType<typeof getUserOrThrow>>,
+): Awaited<ReturnType<typeof getUserOrThrow>>["persons"][number] | null =>
+  user.persons.find((person) => person.isPrimary) ?? null;
+
 async function isActiveActorTypeInLocation({
   actorType,
   locationId,
@@ -3713,6 +3724,50 @@ export const updatePersonDetails = async ({
   });
 };
 
+/**
+ * Authorize a bulk certificate download: the acting profile must be a
+ * location_admin at `locationId`, and every requested handle must belong to
+ * that location. This is the mint-side gate for the (otherwise unauthenticated,
+ * uuid-capability-based) /api/export/certificate/pdf/bulk/[id] route: once the
+ * uuid is stored the download itself is not re-authenticated, so the handle set
+ * must be validated here before it is stored.
+ */
+export const assertCertificateHandlesBelongToLocation = async ({
+  locationId,
+  handles,
+}: {
+  locationId: string;
+  handles: string[];
+}) => {
+  return makeRequest(async () => {
+    const acting = await requireActingPersonForLocation(locationId);
+
+    await isActiveActorTypeInLocation({
+      actorType: ["location_admin"],
+      locationId,
+      personId: acting.person.id,
+    });
+
+    const uniqueHandles = [...new Set(handles)];
+
+    if (uniqueHandles.length === 0) {
+      throw new Error("Geen diploma's geselecteerd");
+    }
+
+    const found = await Certificate.list({
+      filter: { locationId, number: uniqueHandles },
+    });
+
+    const foundHandles = new Set(found.items.map((item) => item.handle));
+
+    const allBelong = uniqueHandles.every((handle) => foundHandles.has(handle));
+
+    if (!allBelong) {
+      throw new Error("Unauthorized");
+    }
+  });
+};
+
 export const storeCertificateHandles = async (props: {
   handles: string[];
   fileName?: string;
@@ -4038,6 +4093,10 @@ export const listKssNiveaus = cache(async () => {
 export const listKssKwalificatieprofielenWithOnderdelen = cache(
   async (niveauId: string) => {
     return makeRequest(async () => {
+      // KSS kwalificatieprofielen are reference data; getUserOrThrow enforces
+      // authentication.
+      await getUserOrThrow();
+
       return await KSS.Kwalificatieprofiel.listWithOnderdelen({
         niveauId,
       });
@@ -4120,6 +4179,10 @@ export const getInstructiegroepByCourseId = cache(
     richting: "instructeur" | "leercoach" | "pvb_beoordelaar",
   ) => {
     return makeRequest(async () => {
+      // KSS instructiegroepen are reference data; getUserOrThrow enforces
+      // authentication.
+      await getUserOrThrow();
+
       const result = await KSS.InstructieGroep.findByCourseId({
         courseId,
         richting,

--- a/docs/designs/explicit-acting-profile.md
+++ b/docs/designs/explicit-acting-profile.md
@@ -161,13 +161,31 @@ The migration list is larger than `/profiel` + `/locatie`:
 - **API routes** used by dashboards (`api/persons/list/[location]`,
   `api/beoordelaars/list/[location]`, certificate PDF exports): authorize per
   request via the same resolve-for-location logic (they have a `location` param;
-  `cache()` works per request in route handlers the same way).
-- **`secretariaat/`** (org-wide, no `locationId` — the preference key cannot
-  represent it): resolve by the `secretariaat` actor type across owned profiles; if
-  multiple qualify this is a data error to surface, not a chooser case. Explicitly
-  phase 4; until then it stays on the read-only `getDefaultPerson` (bug class does
-  not apply: secretariaat users are Buchung-managed).
-- **`penningmeester/`**: same treatment as secretariaat.
+  `cache()` works per request in route handlers the same way). The reference
+  routes `api/instructiegroep/by-course/[course]` and
+  `api/kwalificatieprofielen/by-niveau/[niveau]` serve KSS reference data — they
+  only need a login gate (`getUserOrThrow`), added in phase 4 to their nwd.ts
+  resolvers.
+- **`secretariaat/`** is **email-allowlist gated** (`isSystemAdmin(email)`, via
+  the `/secretariaat` edge middleware) — there is no per-person actor-type
+  resolution and no acting-profile ambiguity (secretariaat users are
+  Buchung-managed). Phase 4 did not introduce actor resolution here; instead it
+  hardened the independently-callable secretariaat **server actions** (KSS
+  `kwalificatieprofiel.ts`, `instructiegroep.ts`, `copy-curriculum-action.ts`),
+  which the edge middleware does not protect, by asserting `isSystemAdmin` inside
+  each action.
+- **`penningmeester/`** is likewise **email-allowlist gated**
+  (`canViewFinancialReport(email)` = penningmeester allowlist ∪ sysadmin), in both
+  the middleware branch and inside each report server action. No actor-type
+  resolution is needed.
+- **Certificate PDF export routes.** The single-certificate route
+  `api/export/certificate/pdf/[id]` is **intentionally public**: it is the diploma
+  verification surface, gated by the `handle` + `issuedAt` pair acting as a shared
+  secret (a recipient can verify a diploma without an account). The **bulk** route
+  `api/export/certificate/pdf/bulk/[id]` is uuid-capability-based (an unguessable
+  Redis uuid); phase 4 authorized the **minting** side — `downloadCertificatesAction`
+  now requires the acting profile to be a location_admin and verifies every
+  requested handle belongs to that location before storing the uuid.
 
 ## Mutation Rules
 
@@ -223,19 +241,30 @@ The migration list is larger than `/profiel` + `/locatie`:
 
 ## Phasing
 
-1. **Quick win (kills most support cases):** make the default-person lookup truly
-   read-only (delete the write-during-read — which today can fire repeatedly per
-   action invocation, since `cache()` does not dedupe there), and switch the four
-   `/profiel/[handle]` gates to handle-derived identity. Also widen
+Phases 1–4 are **delivered** (phases 1–3 in stacked PRs #482/#483; phase 4 on
+`feat/acting-profile-phase-4`).
+
+1. **[delivered] Quick win (kills most support cases):** make the default-person
+   lookup truly read-only (delete the write-during-read — which today can fire
+   repeatedly per action invocation, since `cache()` does not dedupe there), and
+   switch the four `/profiel/[handle]` gates to handle-derived identity. Also widen
    `retrievePvbAanvraagByHandle` from primary-person to any-owned-person
    authorization so the PVB page fix is effective (the explicit acting-person
    parameter lands in phase 3). Small diff, immediately shippable.
-2. **Location tree:** `resolveActingContextForLocation`, chooser route, preference
-   table, sidebar switcher, migrate `/locatie/[location]` pages.
-3. **Cohorts + mutations + auth fixes:** `resolveActingContextForCohort`, migrate
-   cohort pages/actions and PVB actions, fix the enumerated authorization holes,
-   route audit fields through the acting profile.
-4. **Remaining surfaces:** API routes, secretariaat, penningmeester.
+2. **[delivered] Location tree:** `resolveActingContextForLocation`, chooser route,
+   preference table, sidebar switcher, migrate `/locatie/[location]` pages.
+3. **[delivered] Cohorts + mutations + auth fixes:** `resolveActingContextForCohort`,
+   migrate cohort pages/actions and PVB actions, fix the enumerated authorization
+   holes, route audit fields through the acting profile.
+4. **[delivered] Remaining surfaces:** login-gate the KSS reference API resolvers
+   (`getInstructiegroepByCourseId`, `listKssKwalificatieprofielenWithOnderdelen`);
+   harden the independently-callable secretariaat server actions (KSS
+   `kwalificatieprofiel.ts`, `instructiegroep.ts`, `copy-curriculum-action.ts`)
+   with `isSystemAdmin`; authorize the bulk-certificate download mint
+   (`downloadCertificatesAction`) against the acting location_admin and verify
+   handle ownership; add the read-only `getDefaultPerson` and adopt it in the two
+   `/profiel`-landing reimplementations. Secretariaat and penningmeester stay
+   email-allowlist gated (no actor-type resolution) as documented above.
 
 ## Test Plan
 


### PR DESCRIPTION
## Summary

**Stacked on #483** (which stacks on #482) — final phase of `docs/designs/explicit-acting-profile.md`.

Recon for this phase found the original scope partly moot — `api/persons/list` and `api/beoordelaars/list` are already covered transitively by the migrated `nwd.ts` functions, and secretariaat/penningmeester turn out to be email-allowlist gated (`isSystemAdmin`/`canViewFinancialReport`), not actor-type based, so no acting-profile resolution applies there (design doc corrected). What phase 4 actually fixes are the holes recon surfaced:

- **Ungated secretariaat server actions**: every action in `_actions/kss/kwalificatieprofiel.ts` (17), `_actions/kss/instructiegroep.ts` (5), and `copy-curriculum-action.ts` had **zero authorization** — server actions are independently callable endpoints; the `/secretariaat` edge middleware only gates page navigation. All now gate on `isSystemAdmin` (same defense-in-depth pattern penningmeester already documents).
- **`toegevoegdDoor` attribution** in `manage-kwalificaties.ts` grabbed `user.persons[0]` — now searches all owned persons for the system actor.
- **Reference API routes** (`api/instructiegroep/by-course`, `api/kwalificatieprofielen/by-niveau`): their nwd readers had no login gate, unlike their KSS siblings — added.
- **Bulk certificate download chain**: `downloadCertificatesAction` accepted arbitrary client-supplied handles with no auth and minted a Redis uuid consumed by the unauthenticated bulk PDF route. Minting now requires the acting `location_admin` and verifies every handle belongs to the location (core's `filter.number` maps to the handle column — verified). The single-certificate PDF route stays public by design: it is the diploma-verification surface (handle + issuedAt as shared secret).
- **`getDefaultPerson`** lands as the named, strictly read-only `/profiel`-landing helper, replacing two inline reimplementations (profiel redirect, public header). Never authorization.

With this PR the migration is complete: no `getPrimaryPerson` call remains outside `nwd.ts`, and inside it only the intentional default-subject fallback in `listActiveCohortsForPerson` survives.

## Test plan
- [ ] KSS mutations (kwalificatieprofiel/instructiegroep/copy-curriculum) rejected for non-sysadmin accounts, including direct server-action invocation
- [ ] Bulk diploma export works for acting location admins; rejected for instructors without admin role, for handles from another location, and for direct action calls without a valid location
- [ ] Single diploma PDF verification (handle + issuedAt) still works unauthenticated
- [ ] Reference API routes require a session
- [ ] `/profiel` redirect and header account link unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/buchungapp/codesmith/nationaal-watersportdiploma/pr/484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785832288&installation_id=137554715&pr_number=484&repository=buchungapp%2Fnationaal-watersportdiploma&return_to=https%3A%2F%2Fgithub.com%2Fbuchungapp%2Fnationaal-watersportdiploma%2Fpull%2F484&signature=edca57e05627abfc6655f06227bd5916dbb1bba94fffd4788b1ae4835af521ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication and authorization on certificate bulk export minting and many secretariaat mutations; incorrect checks could block legitimate admins or leave actions callable—bulk export in particular is security-sensitive because the PDF route is uuid-capability based.
> 
> **Overview**
> Final **explicit acting profile** phase: closes authorization gaps on independently callable server actions and on bulk diploma PDF minting, without changing public single-diploma verification.
> 
> **Bulk diploma export** now takes `locationId` from location and cohort diploma UIs and, in `downloadCertificatesAction`, calls `assertCertificateHandlesBelongToLocation` before storing the Redis uuid. That check requires the acting profile to be a **location_admin** at that location and verifies every handle belongs there—because the bulk PDF route consumes the uuid **without** re-authentication.
> 
> **Secretariaat KSS** actions (`kwalificatieprofiel`, `instructiegroep`, `copy-curriculum`) each assert **`isSystemAdmin`** (middleware only gates pages). **`manage-kwalificaties`** resolves the system actor across all owned persons for `toegevoegdDoor`, not `persons[0]`.
> 
> **KSS reference readers** in `nwd.ts` (`listKssKwalificatieprofielenWithOnderdelen`, `getInstructiegroepByCourseId`) now require **`getUserOrThrow`**. **`getDefaultPerson`** centralizes read-only `/profiel` landing behavior (profiel redirect, public header account link)—not for authorization.
> 
> Design doc updated to mark phases 1–4 delivered and document allowlist-gated secretariaat/penningmeester vs bulk vs public single-certificate routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6726ae47bac42179563195423305f5e4ebcae953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->