### PR TITLE
feat(secretariaat): vaarlocaties list and onboarding hub (stacked on #427)

### DIFF
--- a/apps/web/src/app/(dashboard)/(management)/@sidebar/secretariaat/_components/sidebar-menu.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/@sidebar/secretariaat/_components/sidebar-menu.tsx
@@ -102,7 +102,7 @@ export function SecretariaatSidebarMenu() {
           {
             name: "Overzicht",
             href: "/secretariaat/locaties",
-            current: lastSegment === "cohorten",
+            current: lastSegment === "locaties",
           },
         ].map((item) => (
           <SidebarItem key={item.name} href={item.href} current={item.current}>

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/personen/_components/create-bulk-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/personen/_components/create-bulk-dialog.tsx
@@ -9,15 +9,15 @@ import {
   previewBulkImportAction,
 } from "~/app/_actions/person/bulk-import-actions";
 import {
-  commitBulkImportInstructorsAsSystemAdminAction,
-  previewBulkImportInstructorsAsSystemAdminAction,
-} from "~/app/_actions/secretariat/bulk-import-instructors-action";
-import {
   COLUMN_MAPPING,
   COLUMN_MAPPING_WITH_TAG,
   type CSVData,
   SELECT_LABEL,
 } from "~/app/_actions/person/person-bulk-csv-mappings";
+import {
+  commitBulkImportInstructorsAsSystemAdminAction,
+  previewBulkImportInstructorsAsSystemAdminAction,
+} from "~/app/_actions/secretariat/bulk-import-instructors-action";
 import { DEFAULT_SERVER_ERROR_MESSAGE } from "~/app/_actions/utils";
 import Spinner from "~/app/_components/spinner";
 import { Button } from "~/app/(dashboard)/_components/button";
@@ -369,67 +369,68 @@ function SubmitForm({
       ? commitBulkImportInstructorsAsSystemAdminAction
       : commitBulkImportAction,
     {
-    onSuccess: ({ data: result }) => {
-      setCommitting(false);
-      if (!result) {
-        setErrorMessage(DEFAULT_SERVER_ERROR_MESSAGE);
-        return;
-      }
-      const r = result as
-        | {
-            kind: "committed";
-            createdPersonIds: string[];
-            linkedPersonIds: string[];
-          }
-        | {
-            kind: "preview_invalidated";
-            attempt: 2 | 3;
-            updatedMatches: PreviewMatches;
-          }
-        | { kind: "preview_invalidated_max"; message: string };
+      onSuccess: ({ data: result }) => {
+        setCommitting(false);
+        if (!result) {
+          setErrorMessage(DEFAULT_SERVER_ERROR_MESSAGE);
+          return;
+        }
+        const r = result as
+          | {
+              kind: "committed";
+              createdPersonIds: string[];
+              linkedPersonIds: string[];
+            }
+          | {
+              kind: "preview_invalidated";
+              attempt: 2 | 3;
+              updatedMatches: PreviewMatches;
+            }
+          | { kind: "preview_invalidated_max"; message: string };
 
-      if (r.kind === "committed") {
-        const total = r.createdPersonIds.length + r.linkedPersonIds.length;
-        toast.success(successToast(total));
-        if (authVariant === "secretariat") {
-          router.refresh();
+        if (r.kind === "committed") {
+          const total = r.createdPersonIds.length + r.linkedPersonIds.length;
+          toast.success(successToast(total));
+          if (authVariant === "secretariat") {
+            router.refresh();
+          }
+          close();
+          return;
         }
-        close();
-        return;
-      }
-      if (r.kind === "preview_invalidated") {
-        if (previewModel) {
-          setPreviewModel({
-            ...previewModel,
-            attempt: r.attempt,
-            matches: r.updatedMatches,
-          });
+        if (r.kind === "preview_invalidated") {
+          if (previewModel) {
+            setPreviewModel({
+              ...previewModel,
+              attempt: r.attempt,
+              matches: r.updatedMatches,
+            });
+          }
+          setRaceBanner(
+            "Roster veranderde tijdens je review — bekijk de gemarkeerde rijen.",
+          );
+          return;
         }
-        setRaceBanner(
-          "Roster veranderde tijdens je review — bekijk de gemarkeerde rijen.",
+        if (r.kind === "preview_invalidated_max") {
+          setStep("invalidated_max");
+          return;
+        }
+      },
+      onError: ({ error }) => {
+        setCommitting(false);
+        // Surface the real server-side message during development (and any
+        // validation issues from next-safe-action) instead of swallowing
+        // them under the generic fallback. Production users still see the
+        // friendly fallback if no message is available.
+        const serverMsg = error.serverError;
+        const validationMsg = error.validationErrors
+          ? JSON.stringify(error.validationErrors)
+          : undefined;
+        setErrorMessage(
+          serverMsg ?? validationMsg ?? DEFAULT_SERVER_ERROR_MESSAGE,
         );
-        return;
-      }
-      if (r.kind === "preview_invalidated_max") {
-        setStep("invalidated_max");
-        return;
-      }
+      },
     },
-    onError: ({ error }) => {
-      setCommitting(false);
-      // Surface the real server-side message during development (and any
-      // validation issues from next-safe-action) instead of swallowing
-      // them under the generic fallback. Production users still see the
-      // friendly fallback if no message is available.
-      const serverMsg = error.serverError;
-      const validationMsg = error.validationErrors
-        ? JSON.stringify(error.validationErrors)
-        : undefined;
-      setErrorMessage(
-        serverMsg ?? validationMsg ?? DEFAULT_SERVER_ERROR_MESSAGE,
-      );
-    },
-  });
+  );
 
   const onMappingSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/personen/_components/create-bulk-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/personen/_components/create-bulk-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useAction } from "next-safe-action/hooks";
 import { use, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -7,6 +8,10 @@ import {
   commitBulkImportAction,
   previewBulkImportAction,
 } from "~/app/_actions/person/bulk-import-actions";
+import {
+  commitBulkImportInstructorsAsSystemAdminAction,
+  previewBulkImportInstructorsAsSystemAdminAction,
+} from "~/app/_actions/secretariat/bulk-import-instructors-action";
 import {
   COLUMN_MAPPING,
   COLUMN_MAPPING_WITH_TAG,
@@ -101,6 +106,8 @@ interface Props {
   // Localized title + success toast wording for the variant.
   dialogTitle?: string;
   successToast?: (count: number) => string;
+  // Secretariaat variant uses sysadmin auth instead of location_admin.
+  authVariant?: "operator" | "secretariat";
 }
 
 export default function Wrapper(props: Props) {
@@ -135,6 +142,7 @@ function CreateDialog({
   enableTags = false,
   dialogTitle = "Personen toevoegen (bulk)",
   successToast = (n) => `${n} ${n === 1 ? "persoon" : "personen"} toegevoegd.`,
+  authVariant = "operator",
 }: Props) {
   const [isUpload, setIsUpload] = useState(true);
   const [data, setData] = useState<CSVData>({ labels: null, rows: null });
@@ -263,6 +271,7 @@ function CreateDialog({
           targetCohortId={targetCohortId}
           enableTags={enableTags}
           successToast={successToast}
+          authVariant={authVariant}
           close={() => setIsOpen(false)}
         />
       )}
@@ -280,6 +289,7 @@ function SubmitForm({
   targetCohortId,
   enableTags,
   successToast,
+  authVariant,
   close,
 }: {
   data: CSVData;
@@ -289,8 +299,10 @@ function SubmitForm({
   targetCohortId?: string;
   enableTags?: boolean;
   successToast: (count: number) => string;
+  authVariant: "operator" | "secretariat";
   close: () => void;
 }) {
+  const router = useRouter();
   const [step, setStep] = useState<Step>("mapping");
   const [previewModel, setPreviewModel] = useState<PreviewModel | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -307,14 +319,22 @@ function SubmitForm({
       guessColumn(item?.label ?? "", { enableTags }) ?? SELECT_LABEL;
   });
 
-  const previewBound = previewBulkImportAction.bind(
-    null,
-    locationId,
-    roles,
-    data,
-    countries,
-    targetCohortId,
-  );
+  const previewBound =
+    authVariant === "secretariat"
+      ? previewBulkImportInstructorsAsSystemAdminAction.bind(
+          null,
+          locationId,
+          data,
+          countries,
+        )
+      : previewBulkImportAction.bind(
+          null,
+          locationId,
+          roles,
+          data,
+          countries,
+          targetCohortId,
+        );
 
   const previewExec = useAction(previewBound, {
     onSuccess: ({ data: result }) => {
@@ -344,7 +364,11 @@ function SubmitForm({
     onError: () => setErrorMessage(DEFAULT_SERVER_ERROR_MESSAGE),
   });
 
-  const commitExec = useAction(commitBulkImportAction, {
+  const commitExec = useAction(
+    authVariant === "secretariat"
+      ? commitBulkImportInstructorsAsSystemAdminAction
+      : commitBulkImportAction,
+    {
     onSuccess: ({ data: result }) => {
       setCommitting(false);
       if (!result) {
@@ -367,6 +391,9 @@ function SubmitForm({
       if (r.kind === "committed") {
         const total = r.createdPersonIds.length + r.linkedPersonIds.length;
         toast.success(successToast(total));
+        if (authVariant === "secretariat") {
+          router.refresh();
+        }
         close();
         return;
       }

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/gebruikers/_components/merge-persons-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/gebruikers/_components/merge-persons-dialog.tsx
@@ -1,12 +1,9 @@
 "use client";
 
-import * as Headless from "@headlessui/react";
 import {
   ArrowsRightLeftIcon,
   ExclamationTriangleIcon,
 } from "@heroicons/react/20/solid";
-import type { User } from "@nawadi/core";
-import clsx from "clsx";
 import { useAction } from "next-safe-action/hooks";
 import { parseAsBoolean, parseAsString, useQueryState } from "nuqs";
 import { useCallback, useEffect, useState } from "react";
@@ -27,12 +24,9 @@ import {
   DialogTitle,
 } from "~/app/(dashboard)/_components/dialog";
 import { Field, Fieldset, Label } from "~/app/(dashboard)/_components/fieldset";
+import { PersonSearchCombobox } from "~/app/(dashboard)/_components/person-search-combobox";
 import { Code } from "~/app/(dashboard)/_components/text";
 import { usePersonSearch } from "~/app/(dashboard)/_hooks/swr/use-person-search";
-
-type SearchPerson = Awaited<
-  ReturnType<typeof User.Person.searchForAutocomplete>
->[number];
 
 type PreflightData = NonNullable<
   Awaited<ReturnType<typeof getMergePreflightAction>>["data"]
@@ -41,171 +35,6 @@ type PreflightData = NonNullable<
 type PersonData = NonNullable<
   Awaited<ReturnType<typeof getPersonByIdAction>>["data"]
 >;
-
-// --- Combobox CSS (reused from the wrapper component) ---
-
-const controlClasses = clsx(
-  "relative block w-full",
-  "before:absolute before:inset-px before:rounded-[calc(var(--radius-lg)-1px)] before:bg-white before:shadow-sm",
-  "dark:before:hidden",
-  "after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:ring-transparent after:ring-inset sm:focus-within:after:ring-2 sm:focus-within:after:ring-blue-500",
-  "has-data-disabled:opacity-50 has-data-disabled:before:bg-zinc-950/5 has-data-disabled:before:shadow-none",
-  "has-data-invalid:before:shadow-red-500/10",
-);
-
-const inputClasses = clsx(
-  "relative block w-full appearance-none rounded-lg py-[calc(--spacing(2.5)-1px)] sm:py-[calc(--spacing(1.5)-1px)]",
-  "pr-[calc(--spacing(10)-1px)] pl-[calc(--spacing(3.5)-1px)] sm:pr-[calc(--spacing(9)-1px)] sm:pl-[calc(--spacing(3)-1px)]",
-  "text-base/6 text-zinc-950 placeholder:text-zinc-500 sm:text-sm/6 dark:text-white",
-  "border border-zinc-950/10 data-hover:border-zinc-950/20 dark:border-white/10 dark:data-hover:border-white/20",
-  "bg-transparent dark:bg-white/5",
-  "focus:outline-hidden",
-  "data-invalid:border-red-500 data-invalid:data-hover:border-red-500 dark:data-invalid:border-red-500 dark:data-invalid:data-hover:border-red-500",
-  "data-disabled:border-zinc-950/20 dark:data-disabled:border-white/15 dark:data-disabled:bg-white/[2.5%] dark:data-hover:data-disabled:border-white/15",
-  "dark:scheme-dark",
-);
-
-const optionsClasses = clsx(
-  "[--anchor-gap:--spacing(2)] [--anchor-padding:--spacing(4)] sm:data-[anchor~=start]:[--anchor-offset:-4px]",
-  "isolate min-w-[calc(var(--input-width)+8px)] scroll-py-1 rounded-xl p-1 select-none empty:invisible",
-  "outline outline-transparent focus:outline-hidden",
-  "overflow-y-scroll overscroll-contain",
-  "bg-white/75 backdrop-blur-xl dark:bg-zinc-800/75",
-  "shadow-lg ring-1 ring-zinc-950/10 dark:ring-white/10 dark:ring-inset",
-  "transition-opacity duration-100 ease-in data-closed:data-leave:opacity-0 data-transition:pointer-events-none",
-);
-
-const optionClasses = clsx(
-  "group/option grid w-full cursor-default grid-cols-[1fr_--spacing(5)] items-baseline gap-x-2 rounded-lg py-2.5 pr-2 pl-3.5 sm:grid-cols-[1fr_--spacing(4)] sm:py-1.5 sm:pr-2 sm:pl-3",
-  "text-base/6 text-zinc-950 sm:text-sm/6 dark:text-white forced-colors:text-[CanvasText]",
-  "outline-hidden data-focus:bg-blue-500 data-focus:text-white",
-  "forced-color-adjust-none forced-colors:data-focus:bg-[Highlight] forced-colors:data-focus:text-[HighlightText]",
-  "data-disabled:opacity-50",
-);
-
-// --- PersonSearchCombobox ---
-
-function PersonSearchCombobox({
-  selectedPersonName,
-  onSelect,
-  label,
-  isSearching,
-  results,
-  query,
-  debouncedQuery,
-  onQueryChange,
-}: {
-  selectedPersonName: string | null;
-  onSelect: (person: SearchPerson) => void;
-  label: string;
-  isSearching: boolean;
-  results: SearchPerson[];
-  query: string;
-  debouncedQuery: string | null;
-  onQueryChange: (query: string) => void;
-}) {
-  const isTyping = query.length > 0;
-
-  return (
-    <Headless.Combobox
-      immediate
-      onChange={(person: SearchPerson | null) => {
-        if (person) {
-          onSelect(person);
-        }
-        onQueryChange("");
-      }}
-      onClose={() => onQueryChange("")}
-    >
-      <span data-slot="control" className={controlClasses}>
-        <Headless.ComboboxInput
-          aria-label={label}
-          data-slot="control"
-          value={isTyping ? query : (selectedPersonName ?? "")}
-          onChange={(event) => {
-            onQueryChange(event.target.value);
-          }}
-          placeholder="Typ om te zoeken…"
-          autoComplete="off"
-          spellCheck={false}
-          className={inputClasses}
-        />
-        <Headless.ComboboxButton
-          className="group right-0 absolute inset-y-0 flex items-center px-2"
-          aria-label="Opties tonen"
-        >
-          <svg
-            className="stroke-zinc-500 dark:group-data-hover:stroke-zinc-300 dark:stroke-zinc-400 forced-colors:stroke-[CanvasText] group-data-disabled:stroke-zinc-600 group-data-hover:stroke-zinc-700 size-5 sm:size-4"
-            viewBox="0 0 16 16"
-            aria-hidden="true"
-            fill="none"
-          >
-            <path
-              d="M5.75 10.75L8 13L10.25 10.75"
-              strokeWidth={1.5}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-            <path
-              d="M10.25 5.25L8 3L5.75 5.25"
-              strokeWidth={1.5}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </Headless.ComboboxButton>
-      </span>
-      <Headless.ComboboxOptions
-        transition
-        anchor="bottom"
-        className={optionsClasses}
-      >
-        {isSearching && (
-          <div
-            className="flex items-center gap-2 px-3.5 py-2 text-sm text-zinc-500"
-            aria-live="polite"
-          >
-            <Spinner className="h-3 w-3" aria-hidden="true" /> Zoeken…
-          </div>
-        )}
-        {!isSearching && debouncedQuery && results.length === 0 && (
-          <div className="px-3.5 py-2 text-sm text-zinc-500" aria-live="polite">
-            Geen personen gevonden
-          </div>
-        )}
-        {results.map((person) => {
-          const name = [
-            person.firstName,
-            person.lastNamePrefix,
-            person.lastName,
-          ]
-            .filter(Boolean)
-            .join(" ");
-          return (
-            <Headless.ComboboxOption
-              key={person.id}
-              value={person}
-              className={optionClasses}
-            >
-              <span className="flex min-w-0 flex-col">
-                <span className="ml-2.5 truncate first:ml-0 sm:ml-2 sm:first:ml-0">
-                  {name}
-                </span>
-                <span className="flex flex-1 overflow-hidden text-zinc-500 group-data-focus/option:text-white before:w-2 before:min-w-0 before:shrink dark:text-zinc-400">
-                  <span className="flex-1 truncate">
-                    {person.email ?? "Geen e-mail"} · {person.handle}
-                    {person.dateOfBirth &&
-                      ` · Geb. ${new Intl.DateTimeFormat("nl-NL", { day: "numeric", month: "long", year: "numeric" }).format(new Date(person.dateOfBirth))}`}
-                  </span>
-                </span>
-              </span>
-            </Headless.ComboboxOption>
-          );
-        })}
-      </Headless.ComboboxOptions>
-    </Headless.Combobox>
-  );
-}
 
 // --- PersonPreviewCard ---
 

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/gebruikers/_components/merge-persons-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/gebruikers/_components/merge-persons-dialog.tsx
@@ -408,6 +408,7 @@ export default function MergePersonsDialog() {
                 <PersonSearchCombobox
                   selectedPersonName={primaryPersonName}
                   onSelect={(person) => setPrimaryId(person.id)}
+                  onClearSelection={() => setPrimaryId(null)}
                   label="Zoek primaire persoon"
                   isSearching={isPrimarySearching}
                   results={primaryResults}
@@ -434,6 +435,7 @@ export default function MergePersonsDialog() {
                 <PersonSearchCombobox
                   selectedPersonName={duplicatePersonName}
                   onSelect={(person) => setDuplicateId(person.id)}
+                  onClearSelection={() => setDuplicateId(null)}
                   label="Zoek duplicaat persoon"
                   isSearching={isDuplicateSearching}
                   results={duplicateResults}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/_components/add-location-admin-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/_components/add-location-admin-dialog.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useAction } from "next-safe-action/hooks";
+import { useState } from "react";
+import { toast } from "sonner";
+import { addLocationAdminAsSystemAdminAction } from "~/app/_actions/location/add-location-admin-action";
+import { DEFAULT_SERVER_ERROR_MESSAGE } from "~/app/_actions/utils";
+import {
+  Alert,
+  AlertActions,
+  AlertBody,
+  AlertDescription,
+  AlertTitle,
+} from "~/app/(dashboard)/_components/alert";
+import { Button } from "~/app/(dashboard)/_components/button";
+import { Field, Fieldset, Label } from "~/app/(dashboard)/_components/fieldset";
+import {
+  PersonSearchCombobox,
+  type SearchPerson,
+} from "~/app/(dashboard)/_components/person-search-combobox";
+import { usePersonSearch } from "~/app/(dashboard)/_hooks/swr/use-person-search";
+
+export function AddLocationAdminDialog({
+  locationId,
+  locationName,
+  isOpen,
+  onClose,
+}: {
+  locationId: string;
+  locationName: string | null;
+  isOpen: boolean;
+  onClose: () => void;
+}) {
+  const router = useRouter();
+  const [selectedPersonId, setSelectedPersonId] = useState<string | null>(null);
+  const [selectedPersonName, setSelectedPersonName] = useState<string | null>(
+    null,
+  );
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const {
+    data: searchResults,
+    debouncedQuery,
+    isLoading: isSearching,
+  } = usePersonSearch(searchQuery);
+
+  const { execute, reset, isExecuting } = useAction(
+    addLocationAdminAsSystemAdminAction,
+    {
+      onSuccess: () => {
+        toast.success("Locatiebeheerder toegevoegd.");
+        router.refresh();
+        closeDialog();
+      },
+      onError: ({ error }) => {
+        toast.error(error.serverError ?? DEFAULT_SERVER_ERROR_MESSAGE);
+      },
+    },
+  );
+
+  const closeDialog = () => {
+    setSelectedPersonId(null);
+    setSelectedPersonName(null);
+    setSearchQuery("");
+    reset();
+    onClose();
+  };
+
+  const handleSelectPerson = (person: SearchPerson) => {
+    setSelectedPersonId(person.id);
+    const name = [person.firstName, person.lastNamePrefix, person.lastName]
+      .filter(Boolean)
+      .join(" ");
+    setSelectedPersonName(name);
+  };
+
+  return (
+    <Alert open={isOpen} onClose={closeDialog} size="md">
+      <AlertTitle>Locatiebeheerder toevoegen</AlertTitle>
+      <AlertDescription>
+        Zoek en selecteer de persoon die je als locatiebeheerder wilt toevoegen
+        voor {locationName ?? "deze locatie"}.
+      </AlertDescription>
+      <AlertBody>
+        <Fieldset>
+          <Field>
+            <Label>Persoon</Label>
+            <PersonSearchCombobox
+              selectedPersonName={selectedPersonName}
+              onSelect={handleSelectPerson}
+              label="Zoek persoon"
+              isSearching={isSearching}
+              results={searchResults}
+              query={searchQuery}
+              debouncedQuery={debouncedQuery}
+              onQueryChange={setSearchQuery}
+            />
+          </Field>
+        </Fieldset>
+      </AlertBody>
+      <AlertActions>
+        <Button plain onClick={closeDialog}>
+          Annuleren
+        </Button>
+        <Button
+          color="branding-dark"
+          disabled={!selectedPersonId || isExecuting}
+          onClick={() => {
+            if (selectedPersonId) {
+              execute({ locationId, personId: selectedPersonId });
+            }
+          }}
+        >
+          {isExecuting ? "Toevoegen..." : "Toevoegen"}
+        </Button>
+      </AlertActions>
+    </Alert>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/_components/add-location-admin-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/_components/add-location-admin-dialog.tsx
@@ -89,6 +89,10 @@ export function AddLocationAdminDialog({
             <PersonSearchCombobox
               selectedPersonName={selectedPersonName}
               onSelect={handleSelectPerson}
+              onClearSelection={() => {
+                setSelectedPersonId(null);
+                setSelectedPersonName(null);
+              }}
               label="Zoek persoon"
               isSearching={isSearching}
               results={searchResults}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/_components/import-instructors-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/_components/import-instructors-dialog.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import PersonenBulkDialog from "~/app/(dashboard)/(management)/locatie/[location]/personen/_components/create-bulk-dialog";
+
+interface Props {
+  locationId: string;
+  countries: { code: string; name: string }[];
+  isOpen: boolean;
+  setIsOpen: (value: boolean) => void;
+}
+
+export function ImportInstructorsDialog({
+  locationId,
+  countries,
+  isOpen,
+  setIsOpen,
+}: Props) {
+  return (
+    <PersonenBulkDialog
+      locationId={locationId}
+      countries={countries}
+      isOpen={isOpen}
+      setIsOpen={setIsOpen}
+      fixedRoles={["instructor"]}
+      authVariant="secretariat"
+      dialogTitle="Instructeurs importeren (bulk)"
+      successToast={(n) =>
+        `${n} ${n === 1 ? "instructeur toegevoegd" : "instructeurs toegevoegd"}.`
+      }
+    />
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/_components/import-kwalificaties-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/_components/import-kwalificaties-dialog.tsx
@@ -1,0 +1,390 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useAction } from "next-safe-action/hooks";
+import { useRef, useState } from "react";
+import { toast } from "sonner";
+import {
+  commitBulkImportKwalificatiesAction,
+  previewBulkImportKwalificatiesAction,
+} from "~/app/_actions/kss/bulk-import-kwalificaties-action";
+import { KWALIFICATIE_COLUMN_MAPPING } from "~/app/_actions/kss/kwalificatie-bulk-import-parser";
+import {
+  SELECT_LABEL,
+  type CSVData,
+} from "~/app/_actions/person/person-bulk-csv-mappings";
+import { DEFAULT_SERVER_ERROR_MESSAGE } from "~/app/_actions/utils";
+import Spinner from "~/app/_components/spinner";
+import { Button } from "~/app/(dashboard)/_components/button";
+import {
+  Dialog,
+  DialogActions,
+  DialogBody,
+  DialogDescription,
+  DialogTitle,
+} from "~/app/(dashboard)/_components/dialog";
+import {
+  ErrorMessage,
+  Fieldset,
+  Legend,
+} from "~/app/(dashboard)/_components/fieldset";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "~/app/(dashboard)/_components/table";
+import { Code, Text } from "~/app/(dashboard)/_components/text";
+import { Textarea } from "~/app/(dashboard)/_components/textarea";
+import { Select } from "~/app/(dashboard)/_components/select";
+import { invariant } from "~/utils/invariant";
+
+type PreviewResult = {
+  previewToken: string;
+  results: Array<
+    | {
+        rowIndex: number;
+        status: "ready";
+        personName: string;
+        courseTitle: string;
+        kwalificatieLabel: string;
+        kerntaakOnderdeelCount: number;
+        toSkip: number;
+      }
+    | { rowIndex: number; status: "error"; error: string }
+  >;
+  summary: {
+    ready: number;
+    errors: number;
+    totalKwalificatiesToAdd: number;
+    totalKwalificatiesToSkip: number;
+  };
+  parseErrors: Array<{ rowIndex: number; error: string }>;
+};
+
+export function ImportKwalificatiesDialog({
+  locationId,
+  isOpen,
+  setIsOpen,
+}: {
+  locationId: string;
+  isOpen: boolean;
+  setIsOpen: (value: boolean) => void;
+}) {
+  const forceRerenderId = useRef(0);
+
+  return (
+    <ImportKwalificatiesDialogInner
+      key={String(forceRerenderId.current)}
+      locationId={locationId}
+      isOpen={isOpen}
+      setIsOpen={(next) => {
+        setIsOpen(next);
+        if (!next) forceRerenderId.current += 1;
+      }}
+    />
+  );
+}
+
+function ImportKwalificatiesDialogInner({
+  locationId,
+  isOpen,
+  setIsOpen,
+}: {
+  locationId: string;
+  isOpen: boolean;
+  setIsOpen: (value: boolean) => void;
+}) {
+  const router = useRouter();
+  const [step, setStep] = useState<"paste" | "mapping" | "preview">("paste");
+  const [data, setData] = useState<CSVData>({ labels: null, rows: null });
+  const [preview, setPreview] = useState<PreviewResult | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const previewBound = previewBulkImportKwalificatiesAction.bind(
+    null,
+    locationId,
+    data,
+  );
+
+  const previewExec = useAction(previewBound, {
+    onSuccess: ({ data: result }) => {
+      if (!result) {
+        setErrorMessage(DEFAULT_SERVER_ERROR_MESSAGE);
+        return;
+      }
+      if (result.kind === "needs-mapping") {
+        setStep("mapping");
+        return;
+      }
+      if (result.kind === "parse_errors") {
+        setErrorMessage(
+          result.parseErrors.map((e) => `Rij ${e.rowIndex}: ${e.error}`).join("\n"),
+        );
+        return;
+      }
+      if (result.kind === "previewed") {
+        setPreview({
+          previewToken: result.previewToken,
+          results: result.results as PreviewResult["results"],
+          summary: result.summary,
+          parseErrors: result.parseErrors,
+        });
+        setStep("preview");
+        setErrorMessage(null);
+      }
+    },
+    onError: ({ error }) => {
+      setErrorMessage(error.serverError ?? DEFAULT_SERVER_ERROR_MESSAGE);
+    },
+  });
+
+  const commitExec = useAction(commitBulkImportKwalificatiesAction, {
+    onSuccess: ({ data: result }) => {
+      if (!result) {
+        setErrorMessage(DEFAULT_SERVER_ERROR_MESSAGE);
+        return;
+      }
+      toast.success(
+        `${result.added} kwalificatie${result.added === 1 ? "" : "s"} toegevoegd` +
+          (result.skipped > 0 ? `, ${result.skipped} overgeslagen` : ""),
+      );
+      router.refresh();
+      setIsOpen(false);
+    },
+    onError: ({ error }) => {
+      setErrorMessage(error.serverError ?? DEFAULT_SERVER_ERROR_MESSAGE);
+    },
+  });
+
+  const handlePasteSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const raw = formData.get("data") as string;
+
+    const splitRows = raw
+      .split("\n")
+      .filter((line) => line.trim() !== "")
+      .map((line) => line.split("\t"));
+
+    const headers = splitRows[0];
+    invariant(headers, "Data moet minimaal één rij bevatten.");
+    splitRows.shift();
+
+    const labels = headers.map((header, item) => ({
+      label: header,
+      value: splitRows.slice(0, 2).map((row) => row[item]),
+    }));
+
+    setData({ labels, rows: splitRows });
+    setStep("mapping");
+  };
+
+  const defaultMapping: Record<string, string> = {};
+  data.labels?.forEach((item, index) => {
+    const header = item.label.toLowerCase();
+    const match = KWALIFICATIE_COLUMN_MAPPING.find((col) =>
+      header.includes(col.toLowerCase().replace("-", "")),
+    );
+    defaultMapping[`include-column-${index}`] = match ?? SELECT_LABEL;
+  });
+
+  const onMappingSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const indexToColumnSelection: Record<string, string> = {};
+    for (const [k, v] of formData.entries()) {
+      if (typeof v === "string") indexToColumnSelection[k] = v;
+    }
+    previewExec.execute(indexToColumnSelection);
+  };
+
+  return (
+    <Dialog open={isOpen} onClose={() => setIsOpen(false)} size="5xl">
+      <DialogTitle>Kwalificaties importeren (bulk)</DialogTitle>
+
+      {step === "paste" ? (
+        <form onSubmit={handlePasteSubmit}>
+          <DialogBody>
+            <Fieldset>
+              <Legend>Data</Legend>
+            </Fieldset>
+            <Text className="mt-2">
+              Plak tab-gescheiden data met kolommen: E-mailadres of NWD-id,
+              Cursus, Richting (instructeur/leercoach/pvb_beoordelaar), Niveau
+              (1-5), optioneel Kerntaak en Opmerkingen.
+            </Text>
+            <Textarea
+              className="mt-4"
+              name="data"
+              rows={10}
+              placeholder={
+                "E-mail\tCursus\tRichting\tNiveau\nvoorbeeld@mail.nl\tKielboot Volwassenen\tinstructeur\t3"
+              }
+            />
+          </DialogBody>
+          <DialogActions>
+            <Button plain type="button" onClick={() => setIsOpen(false)}>
+              Sluiten
+            </Button>
+            <Button color="branding-dark" type="submit">
+              Verder
+            </Button>
+          </DialogActions>
+        </form>
+      ) : null}
+
+      {step === "mapping" ? (
+        <form onSubmit={onMappingSubmit}>
+          <DialogDescription>
+            Koppel de kolommen aan de juiste velden.
+          </DialogDescription>
+          <DialogBody>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableHeader>Kolom</TableHeader>
+                  <TableHeader>Voorbeeld</TableHeader>
+                  <TableHeader>Doel</TableHeader>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {data.labels?.map((item, index) => (
+                  <TableRow key={item.label}>
+                    <TableCell>{item.label}</TableCell>
+                    <TableCell className="space-x-2">
+                      {item.value
+                        .filter((val) => !!val)
+                        .map((value, valueIndex) => (
+                          <Code key={`${item.label}-${valueIndex}`}>
+                            {String(value)}
+                          </Code>
+                        ))}
+                    </TableCell>
+                    <TableCell>
+                      <Select
+                        name={`include-column-${index}`}
+                        defaultValue={
+                          defaultMapping[`include-column-${index}`]
+                        }
+                        className="min-w-48"
+                      >
+                        <option value={SELECT_LABEL}>{SELECT_LABEL}</option>
+                        {KWALIFICATIE_COLUMN_MAPPING.map((column) => (
+                          <option key={column} value={column}>
+                            {column}
+                          </option>
+                        ))}
+                      </Select>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+            {errorMessage ? (
+              <div className="pt-4">
+                <ErrorMessage>{errorMessage}</ErrorMessage>
+              </div>
+            ) : null}
+          </DialogBody>
+          <DialogActions>
+            <Button plain type="button" onClick={() => setStep("paste")}>
+              Terug
+            </Button>
+            <Button
+              color="branding-dark"
+              type="submit"
+              disabled={previewExec.status === "executing"}
+            >
+              {previewExec.status === "executing" ? (
+                <Spinner className="text-white" />
+              ) : null}
+              Preview
+            </Button>
+          </DialogActions>
+        </form>
+      ) : null}
+
+      {step === "preview" && preview ? (
+        <>
+          <DialogBody>
+            <Text>
+              {preview.summary.ready} rij(en) klaar, {preview.summary.errors}{" "}
+              fout(en). {preview.summary.totalKwalificatiesToAdd} kwalificatie(s)
+              worden toegevoegd, {preview.summary.totalKwalificatiesToSkip}{" "}
+              bestaan al.
+            </Text>
+            <Table className="mt-4">
+              <TableHead>
+                <TableRow>
+                  <TableHeader>Rij</TableHeader>
+                  <TableHeader>Persoon</TableHeader>
+                  <TableHeader>Cursus</TableHeader>
+                  <TableHeader>Kwalificatie</TableHeader>
+                  <TableHeader>Status</TableHeader>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {preview.results.map((row) => (
+                  <TableRow key={row.rowIndex}>
+                    <TableCell>{row.rowIndex}</TableCell>
+                    <TableCell>
+                      {row.status === "ready" ? row.personName : "—"}
+                    </TableCell>
+                    <TableCell>
+                      {row.status === "ready" ? row.courseTitle : "—"}
+                    </TableCell>
+                    <TableCell>
+                      {row.status === "ready" ? row.kwalificatieLabel : "—"}
+                    </TableCell>
+                    <TableCell>
+                      {row.status === "ready" ? (
+                        <span className="text-green-700">
+                          +{row.kerntaakOnderdeelCount}
+                          {row.toSkip > 0 ? ` (${row.toSkip} overgeslagen)` : ""}
+                        </span>
+                      ) : (
+                        <span className="text-red-600">{row.error}</span>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+            {errorMessage ? (
+              <div className="pt-4">
+                <ErrorMessage>{errorMessage}</ErrorMessage>
+              </div>
+            ) : null}
+          </DialogBody>
+          <DialogActions>
+            <Button plain onClick={() => setStep("mapping")}>
+              Terug
+            </Button>
+            <Button
+              color="branding-dark"
+              disabled={
+                commitExec.status === "executing" ||
+                preview.summary.totalKwalificatiesToAdd === 0
+              }
+              onClick={() => {
+                commitExec.execute({
+                  previewToken: preview.previewToken,
+                  locationId,
+                  defaultOpmerkingen: "Geïmporteerd via secretariaat",
+                });
+              }}
+            >
+              {commitExec.status === "executing" ? (
+                <Spinner className="text-white" />
+              ) : null}
+              Importeren
+            </Button>
+          </DialogActions>
+        </>
+      ) : null}
+    </Dialog>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/_components/import-kwalificaties-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/_components/import-kwalificaties-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useAction } from "next-safe-action/hooks";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import {
   commitBulkImportKwalificatiesAction,
@@ -10,8 +10,8 @@ import {
 } from "~/app/_actions/kss/bulk-import-kwalificaties-action";
 import { KWALIFICATIE_COLUMN_MAPPING } from "~/app/_actions/kss/kwalificatie-bulk-import-parser";
 import {
-  SELECT_LABEL,
   type CSVData,
+  SELECT_LABEL,
 } from "~/app/_actions/person/person-bulk-csv-mappings";
 import { DEFAULT_SERVER_ERROR_MESSAGE } from "~/app/_actions/utils";
 import Spinner from "~/app/_components/spinner";
@@ -28,6 +28,7 @@ import {
   Fieldset,
   Legend,
 } from "~/app/(dashboard)/_components/fieldset";
+import { Select } from "~/app/(dashboard)/_components/select";
 import {
   Table,
   TableBody,
@@ -38,7 +39,6 @@ import {
 } from "~/app/(dashboard)/_components/table";
 import { Code, Text } from "~/app/(dashboard)/_components/text";
 import { Textarea } from "~/app/(dashboard)/_components/textarea";
-import { Select } from "~/app/(dashboard)/_components/select";
 import { invariant } from "~/utils/invariant";
 
 type PreviewResult = {
@@ -73,16 +73,16 @@ export function ImportKwalificatiesDialog({
   isOpen: boolean;
   setIsOpen: (value: boolean) => void;
 }) {
-  const forceRerenderId = useRef(0);
+  const [forceRerenderId, setForceRerenderId] = useState(0);
 
   return (
     <ImportKwalificatiesDialogInner
-      key={String(forceRerenderId.current)}
+      key={String(forceRerenderId)}
       locationId={locationId}
       isOpen={isOpen}
       setIsOpen={(next) => {
         setIsOpen(next);
-        if (!next) forceRerenderId.current += 1;
+        if (!next) setForceRerenderId((n) => n + 1);
       }}
     />
   );
@@ -121,7 +121,9 @@ function ImportKwalificatiesDialogInner({
       }
       if (result.kind === "parse_errors") {
         setErrorMessage(
-          result.parseErrors.map((e) => `Rij ${e.rowIndex}: ${e.error}`).join("\n"),
+          result.parseErrors
+            .map((e) => `Rij ${e.rowIndex}: ${e.error}`)
+            .join("\n"),
         );
         return;
       }
@@ -266,9 +268,7 @@ function ImportKwalificatiesDialogInner({
                     <TableCell>
                       <Select
                         name={`include-column-${index}`}
-                        defaultValue={
-                          defaultMapping[`include-column-${index}`]
-                        }
+                        defaultValue={defaultMapping[`include-column-${index}`]}
                         className="min-w-48"
                       >
                         <option value={SELECT_LABEL}>{SELECT_LABEL}</option>
@@ -312,9 +312,12 @@ function ImportKwalificatiesDialogInner({
           <DialogBody>
             <Text>
               {preview.summary.ready} rij(en) klaar, {preview.summary.errors}{" "}
-              fout(en). {preview.summary.totalKwalificatiesToAdd} kwalificatie(s)
-              worden toegevoegd, {preview.summary.totalKwalificatiesToSkip}{" "}
-              bestaan al.
+              fout(en)
+              {preview.parseErrors.length > 0
+                ? `, ${preview.parseErrors.length} rij(en) niet gelezen`
+                : ""}
+              . {preview.summary.totalKwalificatiesToAdd} kwalificatie(s) worden
+              toegevoegd, {preview.summary.totalKwalificatiesToSkip} bestaan al.
             </Text>
             <Table className="mt-4">
               <TableHead>
@@ -327,30 +330,41 @@ function ImportKwalificatiesDialogInner({
                 </TableRow>
               </TableHead>
               <TableBody>
-                {preview.results.map((row) => (
-                  <TableRow key={row.rowIndex}>
-                    <TableCell>{row.rowIndex}</TableCell>
-                    <TableCell>
-                      {row.status === "ready" ? row.personName : "—"}
-                    </TableCell>
-                    <TableCell>
-                      {row.status === "ready" ? row.courseTitle : "—"}
-                    </TableCell>
-                    <TableCell>
-                      {row.status === "ready" ? row.kwalificatieLabel : "—"}
-                    </TableCell>
-                    <TableCell>
-                      {row.status === "ready" ? (
-                        <span className="text-green-700">
-                          +{row.kerntaakOnderdeelCount}
-                          {row.toSkip > 0 ? ` (${row.toSkip} overgeslagen)` : ""}
-                        </span>
-                      ) : (
-                        <span className="text-red-600">{row.error}</span>
-                      )}
-                    </TableCell>
-                  </TableRow>
-                ))}
+                {[
+                  ...preview.results,
+                  ...preview.parseErrors.map((e) => ({
+                    rowIndex: e.rowIndex,
+                    status: "parse_error" as const,
+                    error: e.error,
+                  })),
+                ]
+                  .sort((a, b) => a.rowIndex - b.rowIndex)
+                  .map((row) => (
+                    <TableRow key={row.rowIndex}>
+                      <TableCell>{row.rowIndex}</TableCell>
+                      <TableCell>
+                        {row.status === "ready" ? row.personName : "—"}
+                      </TableCell>
+                      <TableCell>
+                        {row.status === "ready" ? row.courseTitle : "—"}
+                      </TableCell>
+                      <TableCell>
+                        {row.status === "ready" ? row.kwalificatieLabel : "—"}
+                      </TableCell>
+                      <TableCell>
+                        {row.status === "ready" ? (
+                          <span className="text-green-700">
+                            +{row.kerntaakOnderdeelCount}
+                            {row.toSkip > 0
+                              ? ` (${row.toSkip} overgeslagen)`
+                              : ""}
+                          </span>
+                        ) : (
+                          <span className="text-red-600">{row.error}</span>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
               </TableBody>
             </Table>
             {errorMessage ? (

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/_components/import-kwalificaties-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/_components/import-kwalificaties-dialog.tsx
@@ -8,7 +8,7 @@ import {
   commitBulkImportKwalificatiesAction,
   previewBulkImportKwalificatiesAction,
 } from "~/app/_actions/kss/bulk-import-kwalificaties-action";
-import { KWALIFICATIE_COLUMN_MAPPING } from "~/app/_actions/kss/kwalificatie-bulk-import-parser";
+import { KWALIFICATIE_COLUMN_MAPPING } from "~/app/_actions/kss/kwalificatie-bulk-import-constants";
 import {
   type CSVData,
   SELECT_LABEL,

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/_components/location-info.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/_components/location-info.tsx
@@ -1,0 +1,89 @@
+import { ArrowLeftIcon } from "@heroicons/react/20/solid";
+import Link from "next/link";
+import { Code, Text, TextLink } from "~/app/(dashboard)/_components/text";
+import type { retrieveLocationByIdAsAdmin } from "~/lib/nwd";
+
+type Location = Awaited<ReturnType<typeof retrieveLocationByIdAsAdmin>>;
+
+export function LocationInfo({ location }: { location: Location }) {
+  return (
+    <div className="mb-8">
+      <Link
+        href="/secretariaat/locaties"
+        className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 mb-4 dark:text-gray-400 dark:hover:text-gray-200"
+      >
+        <ArrowLeftIcon className="h-4 w-4" />
+        Terug naar overzicht
+      </Link>
+
+      <div className="bg-white dark:bg-gray-800 shadow overflow-hidden sm:rounded-lg">
+        <div className="px-4 py-5 sm:px-6">
+          <h3 className="text-lg leading-6 font-medium text-gray-900 dark:text-white">
+            {location.name ?? "Naamloze locatie"}
+          </h3>
+          <Text className="mt-1 text-sm">
+            Handle: <Code>{location.handle}</Code>
+          </Text>
+        </div>
+        <div className="border-t border-gray-200 dark:border-gray-700">
+          <dl className="divide-y divide-gray-200 dark:divide-gray-700">
+            {location.websiteUrl ? (
+              <div className="px-4 py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+                <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                  Website
+                </dt>
+                <dd className="mt-1 text-sm sm:mt-0 sm:col-span-2">
+                  <TextLink href={location.websiteUrl} target="_blank">
+                    {location.websiteUrl}
+                  </TextLink>
+                </dd>
+              </div>
+            ) : null}
+            {location.email ? (
+              <div className="px-4 py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+                <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                  E-mail
+                </dt>
+                <dd className="mt-1 text-sm text-gray-900 dark:text-gray-100 sm:mt-0 sm:col-span-2">
+                  {location.email}
+                </dd>
+              </div>
+            ) : null}
+            {location.shortDescription ? (
+              <div className="px-4 py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+                <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                  Omschrijving
+                </dt>
+                <dd className="mt-1 text-sm text-gray-900 dark:text-gray-100 sm:mt-0 sm:col-span-2">
+                  {location.shortDescription}
+                </dd>
+              </div>
+            ) : null}
+            <div className="px-4 py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+              <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                Links
+              </dt>
+              <dd className="mt-1 text-sm sm:mt-0 sm:col-span-2 flex flex-wrap gap-x-4 gap-y-1">
+                <TextLink href="/vaarlocaties" target="_blank">
+                  Publieke pagina
+                </TextLink>
+                <TextLink
+                  href={`/locatie/${location.handle}/cohorten`}
+                  target="_blank"
+                >
+                  Operator-dashboard
+                </TextLink>
+                <TextLink
+                  href={`/locatie/${location.handle}/instellingen`}
+                  target="_blank"
+                >
+                  Instellingen
+                </TextLink>
+              </dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/_components/location-onboarding-actions.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/_components/location-onboarding-actions.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "~/app/(dashboard)/_components/button";
+import { AddLocationAdminDialog } from "./add-location-admin-dialog";
+import { ImportInstructorsDialog } from "./import-instructors-dialog";
+import { ImportKwalificatiesDialog } from "./import-kwalificaties-dialog";
+
+export function LocationOnboardingActions({
+  locationId,
+  locationName,
+  countries,
+}: {
+  locationId: string;
+  locationName: string | null;
+  countries: { code: string; name: string }[];
+}) {
+  const [adminOpen, setAdminOpen] = useState(false);
+  const [instructorsOpen, setInstructorsOpen] = useState(false);
+  const [kwalificatiesOpen, setKwalificatiesOpen] = useState(false);
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-3">
+        <Button outline onClick={() => setAdminOpen(true)}>
+          Locatiebeheerder toevoegen
+        </Button>
+        <Button outline onClick={() => setInstructorsOpen(true)}>
+          Instructeurs importeren
+        </Button>
+        <Button outline onClick={() => setKwalificatiesOpen(true)}>
+          Kwalificaties importeren
+        </Button>
+      </div>
+
+      <AddLocationAdminDialog
+        locationId={locationId}
+        locationName={locationName}
+        isOpen={adminOpen}
+        onClose={() => setAdminOpen(false)}
+      />
+      <ImportInstructorsDialog
+        locationId={locationId}
+        countries={countries}
+        isOpen={instructorsOpen}
+        setIsOpen={setInstructorsOpen}
+      />
+      <ImportKwalificatiesDialog
+        locationId={locationId}
+        isOpen={kwalificatiesOpen}
+        setIsOpen={setKwalificatiesOpen}
+      />
+    </>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/_components/location-overview-section.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/_components/location-overview-section.tsx
@@ -93,7 +93,7 @@ function ResourceList({
   items,
   emptyMessage,
 }: {
-  items: string[];
+  items: Array<{ id: string; label: string }>;
   emptyMessage: string;
 }) {
   if (items.length === 0) {
@@ -111,10 +111,10 @@ function ResourceList({
       <ul className="divide-y divide-zinc-200 dark:divide-zinc-700">
         {items.map((item) => (
           <li
-            key={item}
+            key={item.id}
             className="px-4 py-2.5 text-sm text-zinc-900 dark:text-zinc-100"
           >
-            {item}
+            {item.label}
           </li>
         ))}
       </ul>
@@ -131,14 +131,20 @@ export function LocationOverviewSection({
   courses: Course[];
   gearTypes: GearType[];
 }) {
-  const courseTitles = courses
-    .map((course) => course.title)
-    .filter((title): title is string => title != null)
-    .sort((a, b) => a.localeCompare(b, "nl"));
+  const courseItems = courses
+    .filter((course) => course.title != null)
+    .sort((a, b) => (a.title ?? "").localeCompare(b.title ?? "", "nl"))
+    .map((course) => ({
+      id: course.id,
+      label: course.title ?? course.handle,
+    }));
 
-  const boatTitles = gearTypes
-    .map((gearType) => gearType.title ?? gearType.handle)
-    .sort((a, b) => a.localeCompare(b, "nl"));
+  const boatItems = gearTypes
+    .map((gearType) => ({
+      id: gearType.id,
+      label: gearType.title ?? gearType.handle,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label, "nl"));
 
   return (
     <div className="space-y-10">
@@ -149,23 +155,23 @@ export function LocationOverviewSection({
 
       <section className="grid gap-10 lg:grid-cols-2">
         <div>
-          <Heading level={2}>Cursussen ({courseTitles.length})</Heading>
+          <Heading level={2}>Cursussen ({courseItems.length})</Heading>
           <Text className="mt-1 text-sm">
             Cursussen beschikbaar via geselecteerde disciplines.
           </Text>
           <ResourceList
-            items={courseTitles}
+            items={courseItems}
             emptyMessage="Nog geen cursussen — selecteer disciplines in de instellingen"
           />
         </div>
 
         <div>
-          <Heading level={2}>Vaartuigen ({boatTitles.length})</Heading>
+          <Heading level={2}>Vaartuigen ({boatItems.length})</Heading>
           <Text className="mt-1 text-sm">
             Vaartuigen die deze locatie aanbiedt.
           </Text>
           <ResourceList
-            items={boatTitles}
+            items={boatItems}
             emptyMessage="Nog geen vaartuigen — stel in via de instellingen"
           />
         </div>

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/_components/location-overview-section.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/_components/location-overview-section.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import {
+  type ColumnDef,
+  createColumnHelper,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { Heading } from "~/app/(dashboard)/_components/heading";
+import { Table, TableBody } from "~/app/(dashboard)/_components/table";
+import {
+  DefaultTableCell,
+  DefaultTableRows,
+  NoTableRows,
+} from "~/app/(dashboard)/_components/table-content";
+import { DefaultTableHead } from "~/app/(dashboard)/_components/table-head";
+import { Code, Text } from "~/app/(dashboard)/_components/text";
+import type {
+  listCourses,
+  listPersonsAtLocationAsAdmin,
+  listResourcesForLocation,
+} from "~/lib/nwd";
+
+type Admin = Awaited<ReturnType<typeof listPersonsAtLocationAsAdmin>>[number];
+type Course = Awaited<ReturnType<typeof listCourses>>[number];
+type GearType = Awaited<
+  ReturnType<typeof listResourcesForLocation>
+>["gearTypes"][number]["gearType"];
+
+const columnHelper = createColumnHelper<Admin>();
+
+const adminColumns = [
+  columnHelper.accessor(
+    (data) =>
+      [data.firstName, data.lastNamePrefix, data.lastName]
+        .filter(Boolean)
+        .join(" "),
+    {
+      id: "name",
+      header: "Naam",
+      cell: ({ getValue }) => (
+        <span className="font-medium text-zinc-900 dark:text-white">
+          {getValue()}
+        </span>
+      ),
+    },
+  ),
+  columnHelper.accessor("handle", {
+    header: "NWD-id",
+    cell: ({ getValue }) => <Code>{getValue()}</Code>,
+  }),
+];
+
+function ScrollBox({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mt-4 rounded-lg border border-zinc-200 dark:border-zinc-700">
+      <div className="max-h-64 overflow-y-auto">{children}</div>
+    </div>
+  );
+}
+
+function AdminsTable({ admins }: { admins: Admin[] }) {
+  const table = useReactTable({
+    data: admins,
+    columns: adminColumns as ColumnDef<Admin, string>[],
+    getRowId: (row) => row.id,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <ScrollBox>
+      <Table dense>
+        <DefaultTableHead table={table} />
+        <TableBody>
+          <NoTableRows table={table}>Nog geen locatiebeheerders</NoTableRows>
+          <DefaultTableRows table={table}>
+            {(cell, index, row) => (
+              <DefaultTableCell
+                key={cell.id}
+                cell={cell}
+                index={index}
+                row={row}
+              />
+            )}
+          </DefaultTableRows>
+        </TableBody>
+      </Table>
+    </ScrollBox>
+  );
+}
+
+function ResourceList({
+  items,
+  emptyMessage,
+}: {
+  items: string[];
+  emptyMessage: string;
+}) {
+  if (items.length === 0) {
+    return (
+      <ScrollBox>
+        <Text className="p-4 text-sm text-zinc-500 dark:text-zinc-400">
+          {emptyMessage}
+        </Text>
+      </ScrollBox>
+    );
+  }
+
+  return (
+    <ScrollBox>
+      <ul className="divide-y divide-zinc-200 dark:divide-zinc-700">
+        {items.map((item) => (
+          <li
+            key={item}
+            className="px-4 py-2.5 text-sm text-zinc-900 dark:text-zinc-100"
+          >
+            {item}
+          </li>
+        ))}
+      </ul>
+    </ScrollBox>
+  );
+}
+
+export function LocationOverviewSection({
+  admins,
+  courses,
+  gearTypes,
+}: {
+  admins: Admin[];
+  courses: Course[];
+  gearTypes: GearType[];
+}) {
+  const courseTitles = courses
+    .map((course) => course.title)
+    .filter((title): title is string => title != null)
+    .sort((a, b) => a.localeCompare(b, "nl"));
+
+  const boatTitles = gearTypes
+    .map((gearType) => gearType.title ?? gearType.handle)
+    .sort((a, b) => a.localeCompare(b, "nl"));
+
+  return (
+    <div className="space-y-10">
+      <section>
+        <Heading level={2}>Locatiebeheerders ({admins.length})</Heading>
+        <AdminsTable admins={admins} />
+      </section>
+
+      <section className="grid gap-10 lg:grid-cols-2">
+        <div>
+          <Heading level={2}>Cursussen ({courseTitles.length})</Heading>
+          <Text className="mt-1 text-sm">
+            Cursussen beschikbaar via geselecteerde disciplines.
+          </Text>
+          <ResourceList
+            items={courseTitles}
+            emptyMessage="Nog geen cursussen — selecteer disciplines in de instellingen"
+          />
+        </div>
+
+        <div>
+          <Heading level={2}>Vaartuigen ({boatTitles.length})</Heading>
+          <Text className="mt-1 text-sm">
+            Vaartuigen die deze locatie aanbiedt.
+          </Text>
+          <ResourceList
+            items={boatTitles}
+            emptyMessage="Nog geen vaartuigen — stel in via de instellingen"
+          />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/page.tsx
@@ -1,0 +1,71 @@
+import { notFound } from "next/navigation";
+import { Heading } from "~/app/(dashboard)/_components/heading";
+import { Text } from "~/app/(dashboard)/_components/text";
+import { isSystemAdmin } from "~/lib/authorization";
+import {
+  getUserOrThrow,
+  listCountries,
+  listCourses,
+  listPersonsAtLocationAsAdmin,
+  listResourcesForLocation,
+  retrieveLocationByIdAsAdmin,
+} from "~/lib/nwd";
+import { LocationInfo } from "./_components/location-info";
+import { LocationOnboardingActions } from "./_components/location-onboarding-actions";
+import { LocationOverviewSection } from "./_components/location-overview-section";
+
+export default async function LocatieDetailPage(props: {
+  params: Promise<{ id: string }>;
+}) {
+  const user = await getUserOrThrow();
+
+  if (!isSystemAdmin(user.email)) {
+    return (
+      <div className="mx-auto max-w-7xl">
+        <Heading level={1}>Geen toegang</Heading>
+        <Text className="mt-2">Je hebt geen toegang tot deze pagina.</Text>
+      </div>
+    );
+  }
+
+  const { id } = await props.params;
+
+  let location: Awaited<ReturnType<typeof retrieveLocationByIdAsAdmin>>;
+  try {
+    location = await retrieveLocationByIdAsAdmin(id);
+  } catch {
+    notFound();
+  }
+
+  const [admins, countries, resources, courses] = await Promise.all([
+    listPersonsAtLocationAsAdmin(id, { type: "location_admin" }),
+    listCountries(),
+    listResourcesForLocation(id),
+    listCourses(undefined, id),
+  ]);
+
+  return (
+    <div className="mx-auto max-w-7xl">
+      <LocationInfo location={location} />
+
+      <div className="mb-8">
+        <Heading level={2}>Onboarding</Heading>
+        <Text className="mt-2 mb-4">
+          Voeg locatiebeheerders en instructeurs toe, of importeer
+          kwalificaties voor bestaande instructeurs.
+        </Text>
+        <LocationOnboardingActions
+          locationId={location.id}
+          locationName={location.name}
+          countries={countries}
+        />
+      </div>
+
+      <LocationOverviewSection
+        admins={admins}
+        courses={courses}
+        gearTypes={resources.gearTypes.map(({ gearType }) => gearType)}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/[id]/page.tsx
@@ -51,8 +51,8 @@ export default async function LocatieDetailPage(props: {
       <div className="mb-8">
         <Heading level={2}>Onboarding</Heading>
         <Text className="mt-2 mb-4">
-          Voeg locatiebeheerders en instructeurs toe, of importeer
-          kwalificaties voor bestaande instructeurs.
+          Voeg locatiebeheerders en instructeurs toe, of importeer kwalificaties
+          voor bestaande instructeurs.
         </Text>
         <LocationOnboardingActions
           locationId={location.id}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/create-location-button.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/create-location-button.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { PlusIcon } from "@heroicons/react/16/solid";
+import { useState } from "react";
+import { Button } from "~/app/(dashboard)/_components/button";
+import { CreateLocationDialog } from "./create-location-dialog";
+
+export function CreateLocationButton() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <Button color="branding-dark" onClick={() => setIsOpen(true)}>
+        <PlusIcon />
+        Nieuwe vaarlocatie
+      </Button>
+      <CreateLocationDialog isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/create-location-dialog.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/create-location-dialog.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import slugify from "@sindresorhus/slugify";
+import { useRouter } from "next/navigation";
+import { useAction } from "next-safe-action/hooks";
+import { useState } from "react";
+import { toast } from "sonner";
+import { createLocationAsSystemAdminAction } from "~/app/_actions/location/create-location-action";
+import { DEFAULT_SERVER_ERROR_MESSAGE } from "~/app/_actions/utils";
+import {
+  Alert,
+  AlertActions,
+  AlertBody,
+  AlertDescription,
+  AlertTitle,
+} from "~/app/(dashboard)/_components/alert";
+import { Button } from "~/app/(dashboard)/_components/button";
+import {
+  Description,
+  Field,
+  Fieldset,
+  Label,
+} from "~/app/(dashboard)/_components/fieldset";
+import { Input } from "~/app/(dashboard)/_components/input";
+
+export function CreateLocationDialog({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+}) {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [handle, setHandle] = useState("");
+  const [handleTouched, setHandleTouched] = useState(false);
+  const [websiteUrl, setWebsiteUrl] = useState("");
+
+  const { execute, reset, isExecuting } = useAction(
+    createLocationAsSystemAdminAction,
+    {
+      onSuccess: ({ data }) => {
+        toast.success("Vaarlocatie aangemaakt.");
+        if (data?.id) {
+          router.push(`/secretariaat/locaties/${data.id}`);
+        }
+        closeDialog();
+      },
+      onError: ({ error }) => {
+        toast.error(error.serverError ?? DEFAULT_SERVER_ERROR_MESSAGE);
+      },
+    },
+  );
+
+  const closeDialog = () => {
+    setName("");
+    setHandle("");
+    setHandleTouched(false);
+    setWebsiteUrl("");
+    reset();
+    onClose();
+  };
+
+  const handleNameChange = (value: string) => {
+    setName(value);
+    if (!handleTouched) {
+      setHandle(slugify(value, { lowercase: true }));
+    }
+  };
+
+  return (
+    <Alert open={isOpen} onClose={closeDialog} size="md">
+      <AlertTitle>Nieuwe vaarlocatie</AlertTitle>
+      <AlertDescription>
+        Maak een nieuwe vaarlocatie aan. Je kunt daarna instructeurs en
+        locatiebeheerders toevoegen.
+      </AlertDescription>
+      <AlertBody>
+        <Fieldset>
+          <Field>
+            <Label>Naam</Label>
+            <Input
+              value={name}
+              onChange={(e) => handleNameChange(e.target.value)}
+              placeholder="Zeilschool de Optimist"
+            />
+          </Field>
+          <Field>
+            <Label>Handle</Label>
+            <Description>
+              Wordt gebruikt in URLs. Alleen kleine letters, cijfers en
+              streepjes.
+            </Description>
+            <Input
+              value={handle}
+              onChange={(e) => {
+                setHandleTouched(true);
+                setHandle(e.target.value);
+              }}
+              placeholder="zeilschool-de-optimist"
+            />
+          </Field>
+          <Field>
+            <Label>Website (optioneel)</Label>
+            <Input
+              value={websiteUrl}
+              onChange={(e) => setWebsiteUrl(e.target.value)}
+              placeholder="https://www.voorbeeld.nl"
+              type="url"
+            />
+          </Field>
+        </Fieldset>
+      </AlertBody>
+      <AlertActions>
+        <Button plain onClick={closeDialog}>
+          Annuleren
+        </Button>
+        <Button
+          color="branding-dark"
+          disabled={!name.trim() || !handle.trim() || isExecuting}
+          onClick={() => {
+            execute({
+              name: name.trim(),
+              handle: handle.trim(),
+              websiteUrl: websiteUrl.trim() || undefined,
+            });
+          }}
+        >
+          {isExecuting ? "Aanmaken..." : "Aanmaken"}
+        </Button>
+      </AlertActions>
+    </Alert>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
@@ -1,21 +1,17 @@
 "use client";
 
-import * as Headless from "@headlessui/react";
 import { EllipsisHorizontalIcon } from "@heroicons/react/20/solid";
-import type { User } from "@nawadi/core";
 import {
   createColumnHelper,
   getCoreRowModel,
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import clsx from "clsx";
 import { useAction } from "next-safe-action/hooks";
 import { useState } from "react";
 import { toast } from "sonner";
 import { addLocationAdminAsSystemAdminAction } from "~/app/_actions/location/add-location-admin-action";
 import { DEFAULT_SERVER_ERROR_MESSAGE } from "~/app/_actions/utils";
-import Spinner from "~/app/_components/spinner";
 import {
   Alert,
   AlertActions,
@@ -31,6 +27,10 @@ import {
   DropdownMenu,
 } from "~/app/(dashboard)/_components/dropdown";
 import { Field, Fieldset, Label } from "~/app/(dashboard)/_components/fieldset";
+import {
+  PersonSearchCombobox,
+  type SearchPerson,
+} from "~/app/(dashboard)/_components/person-search-combobox";
 import { Table, TableBody } from "~/app/(dashboard)/_components/table";
 import {
   DefaultTableCell,
@@ -49,170 +49,6 @@ import { usePersonSearch } from "~/app/(dashboard)/_hooks/swr/use-person-search"
 import type { listAllLocationsAsAdmin } from "~/lib/nwd";
 
 type Location = Awaited<ReturnType<typeof listAllLocationsAsAdmin>>[number];
-type SearchPerson = Awaited<
-  ReturnType<typeof User.Person.searchForAutocomplete>
->[number];
-
-const controlClasses = clsx(
-  "relative block w-full",
-  "before:absolute before:inset-px before:rounded-[calc(var(--radius-lg)-1px)] before:bg-white before:shadow-sm",
-  "dark:before:hidden",
-  "after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:ring-transparent after:ring-inset sm:focus-within:after:ring-2 sm:focus-within:after:ring-blue-500",
-  "has-data-disabled:opacity-50 has-data-disabled:before:bg-zinc-950/5 has-data-disabled:before:shadow-none",
-  "has-data-invalid:before:shadow-red-500/10",
-);
-
-const inputClasses = clsx(
-  "relative block w-full appearance-none rounded-lg py-[calc(--spacing(2.5)-1px)] sm:py-[calc(--spacing(1.5)-1px)]",
-  "pr-[calc(--spacing(10)-1px)] pl-[calc(--spacing(3.5)-1px)] sm:pr-[calc(--spacing(9)-1px)] sm:pl-[calc(--spacing(3)-1px)]",
-  "text-base/6 text-zinc-950 placeholder:text-zinc-500 sm:text-sm/6 dark:text-white",
-  "border border-zinc-950/10 data-hover:border-zinc-950/20 dark:border-white/10 dark:data-hover:border-white/20",
-  "bg-transparent dark:bg-white/5",
-  "focus:outline-hidden",
-  "data-invalid:border-red-500 data-invalid:data-hover:border-red-500 dark:data-invalid:border-red-500 dark:data-invalid:data-hover:border-red-500",
-  "data-disabled:border-zinc-950/20 dark:data-disabled:border-white/15 dark:data-disabled:bg-white/[2.5%] dark:data-hover:data-disabled:border-white/15",
-  "dark:scheme-dark",
-);
-
-const optionsClasses = clsx(
-  "[--anchor-gap:--spacing(2)] [--anchor-padding:--spacing(4)] sm:data-[anchor~=start]:[--anchor-offset:-4px]",
-  "isolate min-w-[calc(var(--input-width)+8px)] scroll-py-1 rounded-xl p-1 select-none empty:invisible",
-  "outline outline-transparent focus:outline-hidden",
-  "overflow-y-scroll overscroll-contain",
-  "bg-white/75 backdrop-blur-xl dark:bg-zinc-800/75",
-  "shadow-lg ring-1 ring-zinc-950/10 dark:ring-white/10 dark:ring-inset",
-  "transition-opacity duration-100 ease-in data-closed:data-leave:opacity-0 data-transition:pointer-events-none",
-);
-
-const optionClasses = clsx(
-  "group/option grid w-full cursor-default grid-cols-[1fr_--spacing(5)] items-baseline gap-x-2 rounded-lg py-2.5 pr-2 pl-3.5 sm:grid-cols-[1fr_--spacing(4)] sm:py-1.5 sm:pr-2 sm:pl-3",
-  "text-base/6 text-zinc-950 sm:text-sm/6 dark:text-white forced-colors:text-[CanvasText]",
-  "outline-hidden data-focus:bg-blue-500 data-focus:text-white",
-  "forced-color-adjust-none forced-colors:data-focus:bg-[Highlight] forced-colors:data-focus:text-[HighlightText]",
-  "data-disabled:opacity-50",
-);
-
-function PersonSearchCombobox({
-  selectedPersonName,
-  onSelect,
-  label,
-  isSearching,
-  results,
-  query,
-  debouncedQuery,
-  onQueryChange,
-}: {
-  selectedPersonName: string | null;
-  onSelect: (person: SearchPerson) => void;
-  label: string;
-  isSearching: boolean;
-  results: SearchPerson[];
-  query: string;
-  debouncedQuery: string | null;
-  onQueryChange: (query: string) => void;
-}) {
-  const isTyping = query.length > 0;
-
-  return (
-    <Headless.Combobox
-      immediate
-      onChange={(person: SearchPerson | null) => {
-        if (person) {
-          onSelect(person);
-        }
-        onQueryChange("");
-      }}
-      onClose={() => onQueryChange("")}
-    >
-      <span data-slot="control" className={controlClasses}>
-        <Headless.ComboboxInput
-          aria-label={label}
-          data-slot="control"
-          value={isTyping ? query : (selectedPersonName ?? "")}
-          onChange={(event) => {
-            onQueryChange(event.target.value);
-          }}
-          placeholder="Typ om te zoeken…"
-          autoComplete="off"
-          spellCheck={false}
-          className={inputClasses}
-        />
-        <Headless.ComboboxButton
-          className="group right-0 absolute inset-y-0 flex items-center px-2"
-          aria-label="Opties tonen"
-        >
-          <svg
-            className="stroke-zinc-500 dark:group-data-hover:stroke-zinc-300 dark:stroke-zinc-400 forced-colors:stroke-[CanvasText] group-data-disabled:stroke-zinc-600 group-data-hover:stroke-zinc-700 size-5 sm:size-4"
-            viewBox="0 0 16 16"
-            aria-hidden="true"
-            fill="none"
-          >
-            <path
-              d="M5.75 10.75L8 13L10.25 10.75"
-              strokeWidth={1.5}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-            <path
-              d="M10.25 5.25L8 3L5.75 5.25"
-              strokeWidth={1.5}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </Headless.ComboboxButton>
-      </span>
-      <Headless.ComboboxOptions
-        transition
-        anchor="bottom"
-        className={optionsClasses}
-      >
-        {isSearching && (
-          <div
-            className="flex items-center gap-2 px-3.5 py-2 text-sm text-zinc-500"
-            aria-live="polite"
-          >
-            <Spinner className="h-3 w-3" aria-hidden="true" /> Zoeken…
-          </div>
-        )}
-        {!isSearching && debouncedQuery && results.length === 0 && (
-          <div className="px-3.5 py-2 text-sm text-zinc-500" aria-live="polite">
-            Geen personen gevonden
-          </div>
-        )}
-        {results.map((person) => {
-          const name = [
-            person.firstName,
-            person.lastNamePrefix,
-            person.lastName,
-          ]
-            .filter(Boolean)
-            .join(" ");
-          return (
-            <Headless.ComboboxOption
-              key={person.id}
-              value={person}
-              className={optionClasses}
-            >
-              <span className="flex min-w-0 flex-col">
-                <span className="ml-2.5 truncate first:ml-0 sm:ml-2 sm:first:ml-0">
-                  {name}
-                </span>
-                <span className="flex flex-1 overflow-hidden text-zinc-500 group-data-focus/option:text-white before:w-2 before:min-w-0 before:shrink dark:text-zinc-400">
-                  <span className="flex-1 truncate">
-                    {person.email ?? "Geen e-mail"} · {person.handle}
-                    {person.dateOfBirth &&
-                      ` · Geb. ${new Intl.DateTimeFormat("nl-NL", { day: "numeric", month: "long", year: "numeric" }).format(new Date(person.dateOfBirth))}`}
-                  </span>
-                </span>
-              </span>
-            </Headless.ComboboxOption>
-          );
-        })}
-      </Headless.ComboboxOptions>
-    </Headless.Combobox>
-  );
-}
 
 const columnHelper = createColumnHelper<Location>();
 

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
@@ -3,13 +3,13 @@
 import * as Headless from "@headlessui/react";
 import { EllipsisHorizontalIcon } from "@heroicons/react/20/solid";
 import type { User } from "@nawadi/core";
-import clsx from "clsx";
 import {
   createColumnHelper,
   getCoreRowModel,
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
+import clsx from "clsx";
 import { useAction } from "next-safe-action/hooks";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -323,7 +323,10 @@ function RowActions({ location }: { location: Location }) {
             disabled={!selectedPersonId}
             onClick={() => {
               if (selectedPersonId) {
-                execute({ locationId: location.id, personId: selectedPersonId });
+                execute({
+                  locationId: location.id,
+                  personId: selectedPersonId,
+                });
               }
             }}
           >

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+import * as Headless from "@headlessui/react";
+import { EllipsisHorizontalIcon } from "@heroicons/react/20/solid";
+import type { User } from "@nawadi/core";
+import clsx from "clsx";
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { useAction } from "next-safe-action/hooks";
+import { useState } from "react";
+import { toast } from "sonner";
+import { addLocationAdminAsSystemAdminAction } from "~/app/_actions/location/add-location-admin-action";
+import { DEFAULT_SERVER_ERROR_MESSAGE } from "~/app/_actions/utils";
+import Spinner from "~/app/_components/spinner";
+import {
+  Alert,
+  AlertActions,
+  AlertBody,
+  AlertDescription,
+  AlertTitle,
+} from "~/app/(dashboard)/_components/alert";
+import { Button } from "~/app/(dashboard)/_components/button";
+import {
+  Dropdown,
+  DropdownButton,
+  DropdownItem,
+  DropdownMenu,
+} from "~/app/(dashboard)/_components/dropdown";
+import { Field, Fieldset, Label } from "~/app/(dashboard)/_components/fieldset";
+import { Table, TableBody } from "~/app/(dashboard)/_components/table";
+import {
+  DefaultTableCell,
+  DefaultTableRows,
+  NoTableRows,
+  PlaceholderTableRows,
+} from "~/app/(dashboard)/_components/table-content";
+import {
+  TableFooter,
+  TablePagination,
+  TableRowSelection,
+} from "~/app/(dashboard)/_components/table-footer";
+import { DefaultTableHead } from "~/app/(dashboard)/_components/table-head";
+import { Code } from "~/app/(dashboard)/_components/text";
+import { usePersonSearch } from "~/app/(dashboard)/_hooks/swr/use-person-search";
+import type { listAllLocationsAsAdmin } from "~/lib/nwd";
+
+type Location = Awaited<ReturnType<typeof listAllLocationsAsAdmin>>[number];
+type SearchPerson = Awaited<
+  ReturnType<typeof User.Person.searchForAutocomplete>
+>[number];
+
+const controlClasses = clsx(
+  "relative block w-full",
+  "before:absolute before:inset-px before:rounded-[calc(var(--radius-lg)-1px)] before:bg-white before:shadow-sm",
+  "dark:before:hidden",
+  "after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:ring-transparent after:ring-inset sm:focus-within:after:ring-2 sm:focus-within:after:ring-blue-500",
+  "has-data-disabled:opacity-50 has-data-disabled:before:bg-zinc-950/5 has-data-disabled:before:shadow-none",
+  "has-data-invalid:before:shadow-red-500/10",
+);
+
+const inputClasses = clsx(
+  "relative block w-full appearance-none rounded-lg py-[calc(--spacing(2.5)-1px)] sm:py-[calc(--spacing(1.5)-1px)]",
+  "pr-[calc(--spacing(10)-1px)] pl-[calc(--spacing(3.5)-1px)] sm:pr-[calc(--spacing(9)-1px)] sm:pl-[calc(--spacing(3)-1px)]",
+  "text-base/6 text-zinc-950 placeholder:text-zinc-500 sm:text-sm/6 dark:text-white",
+  "border border-zinc-950/10 data-hover:border-zinc-950/20 dark:border-white/10 dark:data-hover:border-white/20",
+  "bg-transparent dark:bg-white/5",
+  "focus:outline-hidden",
+  "data-invalid:border-red-500 data-invalid:data-hover:border-red-500 dark:data-invalid:border-red-500 dark:data-invalid:data-hover:border-red-500",
+  "data-disabled:border-zinc-950/20 dark:data-disabled:border-white/15 dark:data-disabled:bg-white/[2.5%] dark:data-hover:data-disabled:border-white/15",
+  "dark:scheme-dark",
+);
+
+const optionsClasses = clsx(
+  "[--anchor-gap:--spacing(2)] [--anchor-padding:--spacing(4)] sm:data-[anchor~=start]:[--anchor-offset:-4px]",
+  "isolate min-w-[calc(var(--input-width)+8px)] scroll-py-1 rounded-xl p-1 select-none empty:invisible",
+  "outline outline-transparent focus:outline-hidden",
+  "overflow-y-scroll overscroll-contain",
+  "bg-white/75 backdrop-blur-xl dark:bg-zinc-800/75",
+  "shadow-lg ring-1 ring-zinc-950/10 dark:ring-white/10 dark:ring-inset",
+  "transition-opacity duration-100 ease-in data-closed:data-leave:opacity-0 data-transition:pointer-events-none",
+);
+
+const optionClasses = clsx(
+  "group/option grid w-full cursor-default grid-cols-[1fr_--spacing(5)] items-baseline gap-x-2 rounded-lg py-2.5 pr-2 pl-3.5 sm:grid-cols-[1fr_--spacing(4)] sm:py-1.5 sm:pr-2 sm:pl-3",
+  "text-base/6 text-zinc-950 sm:text-sm/6 dark:text-white forced-colors:text-[CanvasText]",
+  "outline-hidden data-focus:bg-blue-500 data-focus:text-white",
+  "forced-color-adjust-none forced-colors:data-focus:bg-[Highlight] forced-colors:data-focus:text-[HighlightText]",
+  "data-disabled:opacity-50",
+);
+
+function PersonSearchCombobox({
+  selectedPersonName,
+  onSelect,
+  label,
+  isSearching,
+  results,
+  query,
+  debouncedQuery,
+  onQueryChange,
+}: {
+  selectedPersonName: string | null;
+  onSelect: (person: SearchPerson) => void;
+  label: string;
+  isSearching: boolean;
+  results: SearchPerson[];
+  query: string;
+  debouncedQuery: string | null;
+  onQueryChange: (query: string) => void;
+}) {
+  const isTyping = query.length > 0;
+
+  return (
+    <Headless.Combobox
+      immediate
+      onChange={(person: SearchPerson | null) => {
+        if (person) {
+          onSelect(person);
+        }
+        onQueryChange("");
+      }}
+      onClose={() => onQueryChange("")}
+    >
+      <span data-slot="control" className={controlClasses}>
+        <Headless.ComboboxInput
+          aria-label={label}
+          data-slot="control"
+          value={isTyping ? query : (selectedPersonName ?? "")}
+          onChange={(event) => {
+            onQueryChange(event.target.value);
+          }}
+          placeholder="Typ om te zoeken…"
+          autoComplete="off"
+          spellCheck={false}
+          className={inputClasses}
+        />
+        <Headless.ComboboxButton
+          className="group right-0 absolute inset-y-0 flex items-center px-2"
+          aria-label="Opties tonen"
+        >
+          <svg
+            className="stroke-zinc-500 dark:group-data-hover:stroke-zinc-300 dark:stroke-zinc-400 forced-colors:stroke-[CanvasText] group-data-disabled:stroke-zinc-600 group-data-hover:stroke-zinc-700 size-5 sm:size-4"
+            viewBox="0 0 16 16"
+            aria-hidden="true"
+            fill="none"
+          >
+            <path
+              d="M5.75 10.75L8 13L10.25 10.75"
+              strokeWidth={1.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M10.25 5.25L8 3L5.75 5.25"
+              strokeWidth={1.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </Headless.ComboboxButton>
+      </span>
+      <Headless.ComboboxOptions
+        transition
+        anchor="bottom"
+        className={optionsClasses}
+      >
+        {isSearching && (
+          <div
+            className="flex items-center gap-2 px-3.5 py-2 text-sm text-zinc-500"
+            aria-live="polite"
+          >
+            <Spinner className="h-3 w-3" aria-hidden="true" /> Zoeken…
+          </div>
+        )}
+        {!isSearching && debouncedQuery && results.length === 0 && (
+          <div className="px-3.5 py-2 text-sm text-zinc-500" aria-live="polite">
+            Geen personen gevonden
+          </div>
+        )}
+        {results.map((person) => {
+          const name = [
+            person.firstName,
+            person.lastNamePrefix,
+            person.lastName,
+          ]
+            .filter(Boolean)
+            .join(" ");
+          return (
+            <Headless.ComboboxOption
+              key={person.id}
+              value={person}
+              className={optionClasses}
+            >
+              <span className="flex min-w-0 flex-col">
+                <span className="ml-2.5 truncate first:ml-0 sm:ml-2 sm:first:ml-0">
+                  {name}
+                </span>
+                <span className="flex flex-1 overflow-hidden text-zinc-500 group-data-focus/option:text-white before:w-2 before:min-w-0 before:shrink dark:text-zinc-400">
+                  <span className="flex-1 truncate">
+                    {person.email ?? "Geen e-mail"} · {person.handle}
+                    {person.dateOfBirth &&
+                      ` · Geb. ${new Intl.DateTimeFormat("nl-NL", { day: "numeric", month: "long", year: "numeric" }).format(new Date(person.dateOfBirth))}`}
+                  </span>
+                </span>
+              </span>
+            </Headless.ComboboxOption>
+          );
+        })}
+      </Headless.ComboboxOptions>
+    </Headless.Combobox>
+  );
+}
+
+const columnHelper = createColumnHelper<Location>();
+
+const columns = [
+  columnHelper.accessor("name", {
+    header: "Naam",
+    cell: ({ getValue }) => (
+      <div className="min-w-0">
+        <span className="truncate font-medium text-zinc-900 dark:text-white">
+          {getValue() ?? "-"}
+        </span>
+      </div>
+    ),
+  }),
+  columnHelper.accessor("handle", {
+    header: "Handle",
+    cell: ({ getValue }) => <Code>{getValue()}</Code>,
+  }),
+  columnHelper.display({
+    id: "actions",
+    header: "",
+    cell: ({ row }) => <RowActions location={row.original} />,
+  }),
+];
+
+function RowActions({ location }: { location: Location }) {
+  const [isAdminDialogOpen, setIsAdminDialogOpen] = useState(false);
+  const [selectedPersonId, setSelectedPersonId] = useState<string | null>(null);
+  const [selectedPersonName, setSelectedPersonName] = useState<string | null>(
+    null,
+  );
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const {
+    data: searchResults,
+    debouncedQuery,
+    isLoading: isSearching,
+  } = usePersonSearch(searchQuery);
+
+  const { execute, reset } = useAction(addLocationAdminAsSystemAdminAction, {
+    onSuccess: () => {
+      toast.success("Locatiebeheerder toegevoegd.");
+      closeAdminDialog();
+    },
+    onError: ({ error }) => {
+      toast.error(error.serverError ?? DEFAULT_SERVER_ERROR_MESSAGE);
+    },
+  });
+
+  const closeAdminDialog = () => {
+    setIsAdminDialogOpen(false);
+    setSelectedPersonId(null);
+    setSelectedPersonName(null);
+    setSearchQuery("");
+    reset();
+  };
+
+  const handleSelectPerson = (person: SearchPerson) => {
+    setSelectedPersonId(person.id);
+    const name = [person.firstName, person.lastNamePrefix, person.lastName]
+      .filter(Boolean)
+      .join(" ");
+    setSelectedPersonName(name);
+  };
+
+  return (
+    <div className="flex justify-end">
+      <Dropdown>
+        <DropdownButton plain aria-label="Acties">
+          <EllipsisHorizontalIcon className="h-5 w-5" aria-hidden="true" />
+        </DropdownButton>
+        <DropdownMenu anchor="bottom end">
+          <DropdownItem onClick={() => setIsAdminDialogOpen(true)}>
+            Locatiebeheerder toevoegen…
+          </DropdownItem>
+        </DropdownMenu>
+      </Dropdown>
+
+      <Alert open={isAdminDialogOpen} onClose={closeAdminDialog} size="md">
+        <AlertTitle>Locatiebeheerder toevoegen</AlertTitle>
+        <AlertDescription>
+          Zoek en selecteer de persoon die je als locatiebeheerder wilt
+          toevoegen voor {location.name}.
+        </AlertDescription>
+        <AlertBody>
+          <Fieldset>
+            <Field>
+              <Label>Persoon</Label>
+              <PersonSearchCombobox
+                selectedPersonName={selectedPersonName}
+                onSelect={handleSelectPerson}
+                label="Zoek persoon"
+                isSearching={isSearching}
+                results={searchResults}
+                query={searchQuery}
+                debouncedQuery={debouncedQuery}
+                onQueryChange={setSearchQuery}
+              />
+            </Field>
+          </Fieldset>
+        </AlertBody>
+        <AlertActions>
+          <Button plain onClick={closeAdminDialog}>
+            Annuleren
+          </Button>
+          <Button
+            color="branding-dark"
+            disabled={!selectedPersonId}
+            onClick={() => {
+              if (selectedPersonId) {
+                execute({ locationId: location.id, personId: selectedPersonId });
+              }
+            }}
+          >
+            Toevoegen
+          </Button>
+        </AlertActions>
+      </Alert>
+    </div>
+  );
+}
+
+export default function LocatiesTable({
+  locations,
+  totalItems,
+  placeholderRows,
+}: {
+  locations: Location[];
+  totalItems: number;
+  placeholderRows?: number;
+}) {
+  const table = useReactTable({
+    data: locations,
+    columns,
+    getRowId: (row) => row.id,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  return (
+    <>
+      <Table
+        className="mt-8 [--gutter:--spacing(6)] lg:[--gutter:--spacing(10)]"
+        dense
+      >
+        <DefaultTableHead table={table} />
+        <TableBody>
+          <PlaceholderTableRows table={table} rows={placeholderRows}>
+            <NoTableRows table={table}>Geen locaties gevonden</NoTableRows>
+            <DefaultTableRows table={table}>
+              {(cell, index, row) => (
+                <DefaultTableCell
+                  key={cell.id}
+                  cell={cell}
+                  index={index}
+                  row={row}
+                />
+              )}
+            </DefaultTableRows>
+          </PlaceholderTableRows>
+        </TableBody>
+      </Table>
+
+      <TableFooter>
+        <TableRowSelection table={table} totalItems={totalItems} />
+        <TablePagination totalItems={totalItems} />
+      </TableFooter>
+    </>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
@@ -1,35 +1,11 @@
 "use client";
 
-import { EllipsisHorizontalIcon } from "@heroicons/react/20/solid";
 import {
   createColumnHelper,
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import { useAction } from "next-safe-action/hooks";
-import { useState } from "react";
-import { toast } from "sonner";
-import { addLocationAdminAsSystemAdminAction } from "~/app/_actions/location/add-location-admin-action";
-import { DEFAULT_SERVER_ERROR_MESSAGE } from "~/app/_actions/utils";
-import {
-  Alert,
-  AlertActions,
-  AlertBody,
-  AlertDescription,
-  AlertTitle,
-} from "~/app/(dashboard)/_components/alert";
-import { Button } from "~/app/(dashboard)/_components/button";
-import {
-  Dropdown,
-  DropdownButton,
-  DropdownItem,
-  DropdownMenu,
-} from "~/app/(dashboard)/_components/dropdown";
-import { Field, Fieldset, Label } from "~/app/(dashboard)/_components/fieldset";
-import {
-  PersonSearchCombobox,
-  type SearchPerson,
-} from "~/app/(dashboard)/_components/person-search-combobox";
+import Link from "next/link";
 import { Table, TableBody } from "~/app/(dashboard)/_components/table";
 import {
   DefaultTableCell,
@@ -44,7 +20,6 @@ import {
 } from "~/app/(dashboard)/_components/table-footer";
 import { DefaultTableHead } from "~/app/(dashboard)/_components/table-head";
 import { Code } from "~/app/(dashboard)/_components/text";
-import { usePersonSearch } from "~/app/(dashboard)/_hooks/swr/use-person-search";
 import type { listAllLocationsAsAdmin } from "~/lib/nwd";
 
 type Location = Awaited<ReturnType<typeof listAllLocationsAsAdmin>>[number];
@@ -54,11 +29,14 @@ const columnHelper = createColumnHelper<Location>();
 const columns = [
   columnHelper.accessor("name", {
     header: "Naam",
-    cell: ({ getValue }) => (
+    cell: ({ getValue, row }) => (
       <div className="min-w-0">
-        <span className="truncate font-medium text-zinc-900 dark:text-white">
+        <Link
+          href={`/secretariaat/locaties/${row.original.id}`}
+          className="truncate font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+        >
           {getValue() ?? "-"}
-        </span>
+        </Link>
       </div>
     ),
   }),
@@ -66,115 +44,7 @@ const columns = [
     header: "Handle",
     cell: ({ getValue }) => <Code>{getValue()}</Code>,
   }),
-  columnHelper.display({
-    id: "actions",
-    header: "",
-    cell: ({ row }) => <RowActions location={row.original} />,
-  }),
 ];
-
-function RowActions({ location }: { location: Location }) {
-  const [isAdminDialogOpen, setIsAdminDialogOpen] = useState(false);
-  const [selectedPersonId, setSelectedPersonId] = useState<string | null>(null);
-  const [selectedPersonName, setSelectedPersonName] = useState<string | null>(
-    null,
-  );
-  const [searchQuery, setSearchQuery] = useState("");
-
-  const {
-    data: searchResults,
-    debouncedQuery,
-    isLoading: isSearching,
-  } = usePersonSearch(searchQuery);
-
-  const { execute, reset, isExecuting } = useAction(
-    addLocationAdminAsSystemAdminAction,
-    {
-      onSuccess: () => {
-        toast.success("Locatiebeheerder toegevoegd.");
-        closeAdminDialog();
-      },
-      onError: ({ error }) => {
-        toast.error(error.serverError ?? DEFAULT_SERVER_ERROR_MESSAGE);
-      },
-    },
-  );
-
-  const closeAdminDialog = () => {
-    setIsAdminDialogOpen(false);
-    setSelectedPersonId(null);
-    setSelectedPersonName(null);
-    setSearchQuery("");
-    reset();
-  };
-
-  const handleSelectPerson = (person: SearchPerson) => {
-    setSelectedPersonId(person.id);
-    const name = [person.firstName, person.lastNamePrefix, person.lastName]
-      .filter(Boolean)
-      .join(" ");
-    setSelectedPersonName(name);
-  };
-
-  return (
-    <div className="flex justify-end">
-      <Dropdown>
-        <DropdownButton plain aria-label="Acties">
-          <EllipsisHorizontalIcon className="h-5 w-5" aria-hidden="true" />
-        </DropdownButton>
-        <DropdownMenu anchor="bottom end">
-          <DropdownItem onClick={() => setIsAdminDialogOpen(true)}>
-            Locatiebeheerder toevoegen…
-          </DropdownItem>
-        </DropdownMenu>
-      </Dropdown>
-
-      <Alert open={isAdminDialogOpen} onClose={closeAdminDialog} size="md">
-        <AlertTitle>Locatiebeheerder toevoegen</AlertTitle>
-        <AlertDescription>
-          Zoek en selecteer de persoon die je als locatiebeheerder wilt
-          toevoegen voor {location.name}.
-        </AlertDescription>
-        <AlertBody>
-          <Fieldset>
-            <Field>
-              <Label>Persoon</Label>
-              <PersonSearchCombobox
-                selectedPersonName={selectedPersonName}
-                onSelect={handleSelectPerson}
-                label="Zoek persoon"
-                isSearching={isSearching}
-                results={searchResults}
-                query={searchQuery}
-                debouncedQuery={debouncedQuery}
-                onQueryChange={setSearchQuery}
-              />
-            </Field>
-          </Fieldset>
-        </AlertBody>
-        <AlertActions>
-          <Button plain onClick={closeAdminDialog}>
-            Annuleren
-          </Button>
-          <Button
-            color="branding-dark"
-            disabled={!selectedPersonId || isExecuting}
-            onClick={() => {
-              if (selectedPersonId) {
-                execute({
-                  locationId: location.id,
-                  personId: selectedPersonId,
-                });
-              }
-            }}
-          >
-            {isExecuting ? "Toevoegen..." : "Toevoegen"}
-          </Button>
-        </AlertActions>
-      </Alert>
-    </div>
-  );
-}
 
 export default function LocatiesTable({
   locations,

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
@@ -4,7 +4,6 @@ import { EllipsisHorizontalIcon } from "@heroicons/react/20/solid";
 import {
   createColumnHelper,
   getCoreRowModel,
-  getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
 import { useAction } from "next-safe-action/hooks";
@@ -88,7 +87,7 @@ function RowActions({ location }: { location: Location }) {
     isLoading: isSearching,
   } = usePersonSearch(searchQuery);
 
-  const { execute, reset } = useAction(addLocationAdminAsSystemAdminAction, {
+  const { execute, reset, isExecuting } = useAction(addLocationAdminAsSystemAdminAction, {
     onSuccess: () => {
       toast.success("Locatiebeheerder toegevoegd.");
       closeAdminDialog();
@@ -156,7 +155,7 @@ function RowActions({ location }: { location: Location }) {
           </Button>
           <Button
             color="branding-dark"
-            disabled={!selectedPersonId}
+            disabled={!selectedPersonId || isExecuting}
             onClick={() => {
               if (selectedPersonId) {
                 execute({
@@ -166,7 +165,7 @@ function RowActions({ location }: { location: Location }) {
               }
             }}
           >
-            Toevoegen
+            {isExecuting ? "Toevoegen..." : "Toevoegen"}
           </Button>
         </AlertActions>
       </Alert>
@@ -188,7 +187,6 @@ export default function LocatiesTable({
     columns,
     getRowId: (row) => row.id,
     getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
   });
 
   return (

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/_components/table.tsx
@@ -87,15 +87,18 @@ function RowActions({ location }: { location: Location }) {
     isLoading: isSearching,
   } = usePersonSearch(searchQuery);
 
-  const { execute, reset, isExecuting } = useAction(addLocationAdminAsSystemAdminAction, {
-    onSuccess: () => {
-      toast.success("Locatiebeheerder toegevoegd.");
-      closeAdminDialog();
+  const { execute, reset, isExecuting } = useAction(
+    addLocationAdminAsSystemAdminAction,
+    {
+      onSuccess: () => {
+        toast.success("Locatiebeheerder toegevoegd.");
+        closeAdminDialog();
+      },
+      onError: ({ error }) => {
+        toast.error(error.serverError ?? DEFAULT_SERVER_ERROR_MESSAGE);
+      },
     },
-    onError: ({ error }) => {
-      toast.error(error.serverError ?? DEFAULT_SERVER_ERROR_MESSAGE);
-    },
-  });
+  );
 
   const closeAdminDialog = () => {
     setIsAdminDialogOpen(false);

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
@@ -5,13 +5,28 @@ import { isSystemAdmin } from "~/lib/authorization";
 import { getUserOrThrow, listAllLocationsAsAdmin } from "~/lib/nwd";
 import Table from "./_components/table";
 
-async function LocatiesTableData() {
+async function LocatiesTableData(props: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const searchParams = await props.searchParams;
   const locations = await listAllLocationsAsAdmin();
 
-  return <Table locations={locations} totalItems={locations.length} />;
+  const paginationLimit = searchParams?.limit
+    ? Number(searchParams.limit)
+    : 25;
+  const currentPage = searchParams?.page ? Number(searchParams.page) : 1;
+
+  const paginatedLocations = locations.slice(
+    (currentPage - 1) * paginationLimit,
+    currentPage * paginationLimit,
+  );
+
+  return <Table locations={paginatedLocations} totalItems={locations.length} />;
 }
 
-export default async function LocatiesPage() {
+export default async function LocatiesPage(props: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
   const user = await getUserOrThrow();
 
   if (!isSystemAdmin(user.email)) {
@@ -33,7 +48,7 @@ export default async function LocatiesPage() {
       <Suspense
         fallback={<Table locations={[]} totalItems={0} placeholderRows={10} />}
       >
-        <LocatiesTableData />
+        <LocatiesTableData searchParams={props.searchParams} />
       </Suspense>
     </div>
   );

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
@@ -1,0 +1,42 @@
+import { Suspense } from "react";
+import { Heading } from "~/app/(dashboard)/_components/heading";
+import { Text } from "~/app/(dashboard)/_components/text";
+import { isSystemAdmin } from "~/lib/authorization";
+import { getUserOrThrow, listAllLocationsAsAdmin } from "~/lib/nwd";
+import Table from "./_components/table";
+
+async function LocatiesTableData() {
+  const locations = await listAllLocationsAsAdmin();
+
+  return <Table locations={locations} totalItems={locations.length} />;
+}
+
+export default async function LocatiesPage() {
+  const user = await getUserOrThrow();
+
+  if (!isSystemAdmin(user.email)) {
+    return (
+      <div className="mx-auto max-w-7xl">
+        <Heading level={1}>Geen toegang</Heading>
+        <Text className="mt-2">Je hebt geen toegang tot deze pagina.</Text>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-7xl">
+      <div className="mb-8">
+        <Heading level={1}>Vaarlocaties</Heading>
+        <Text className="mt-2">
+          Overzicht van alle vaarlocaties.
+        </Text>
+      </div>
+
+      <Suspense
+        fallback={<Table locations={[]} totalItems={0} placeholderRows={10} />}
+      >
+        <LocatiesTableData />
+      </Suspense>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
@@ -11,9 +11,7 @@ async function LocatiesTableData(props: {
   const searchParams = await props.searchParams;
   const locations = await listAllLocationsAsAdmin();
 
-  const paginationLimit = searchParams?.limit
-    ? Number(searchParams.limit)
-    : 25;
+  const paginationLimit = searchParams?.limit ? Number(searchParams.limit) : 25;
   const currentPage = searchParams?.page ? Number(searchParams.page) : 1;
 
   const paginatedLocations = locations.slice(

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
@@ -27,9 +27,7 @@ export default async function LocatiesPage() {
     <div className="mx-auto max-w-7xl">
       <div className="mb-8">
         <Heading level={1}>Vaarlocaties</Heading>
-        <Text className="mt-2">
-          Overzicht van alle vaarlocaties.
-        </Text>
+        <Text className="mt-2">Overzicht van alle vaarlocaties.</Text>
       </div>
 
       <Suspense

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
@@ -38,9 +38,11 @@ async function LocatiesTableData(props: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const searchParams = await props.searchParams;
-  const { query, page: rawPage, limit: rawLimit } = searchParamsParser(
-    searchParams ?? {},
-  );
+  const {
+    query,
+    page: rawPage,
+    limit: rawLimit,
+  } = searchParamsParser(searchParams ?? {});
   const { page, limit } = sanitizePagination(rawPage, rawLimit);
 
   const locations = await listAllLocationsAsAdmin();
@@ -51,7 +53,10 @@ async function LocatiesTableData(props: {
   );
 
   return (
-    <Table locations={paginatedLocations} totalItems={filteredLocations.length} />
+    <Table
+      locations={paginatedLocations}
+      totalItems={filteredLocations.length}
+    />
   );
 }
 

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
@@ -5,6 +5,7 @@ import { Text } from "~/app/(dashboard)/_components/text";
 import { isSystemAdmin } from "~/lib/authorization";
 import { getUserOrThrow, listAllLocationsAsAdmin } from "~/lib/nwd";
 import Search from "../../_components/search";
+import { CreateLocationButton } from "./_components/create-location-button";
 import Table from "./_components/table";
 
 const searchParamsParser = createLoader({
@@ -76,9 +77,12 @@ export default async function LocatiesPage(props: {
 
   return (
     <div className="mx-auto max-w-7xl">
-      <div className="mb-8">
-        <Heading level={1}>Vaarlocaties</Heading>
-        <Text className="mt-2">Overzicht van alle vaarlocaties.</Text>
+      <div className="mb-8 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <Heading level={1}>Vaarlocaties</Heading>
+          <Text className="mt-2">Overzicht van alle vaarlocaties.</Text>
+        </div>
+        <CreateLocationButton />
       </div>
 
       <div className="mt-4 max-w-xl">

--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/locaties/page.tsx
@@ -1,25 +1,58 @@
+import { createLoader, parseAsInteger, parseAsString } from "nuqs/server";
 import { Suspense } from "react";
 import { Heading } from "~/app/(dashboard)/_components/heading";
 import { Text } from "~/app/(dashboard)/_components/text";
 import { isSystemAdmin } from "~/lib/authorization";
 import { getUserOrThrow, listAllLocationsAsAdmin } from "~/lib/nwd";
+import Search from "../../_components/search";
 import Table from "./_components/table";
+
+const searchParamsParser = createLoader({
+  query: parseAsString.withDefault(""),
+  page: parseAsInteger.withDefault(1),
+  limit: parseAsInteger.withDefault(25),
+});
+
+function sanitizePagination(page: number, limit: number) {
+  return {
+    page: Number.isFinite(page) && page > 0 ? page : 1,
+    limit: Number.isFinite(limit) && limit > 0 ? limit : 25,
+  };
+}
+
+function filterLocations(
+  locations: Awaited<ReturnType<typeof listAllLocationsAsAdmin>>,
+  query: string,
+) {
+  const q = query.trim().toLowerCase();
+  if (!q) return locations;
+
+  return locations.filter(
+    (location) =>
+      location.name?.toLowerCase().includes(q) ||
+      location.handle.toLowerCase().includes(q),
+  );
+}
 
 async function LocatiesTableData(props: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const searchParams = await props.searchParams;
+  const { query, page: rawPage, limit: rawLimit } = searchParamsParser(
+    searchParams ?? {},
+  );
+  const { page, limit } = sanitizePagination(rawPage, rawLimit);
+
   const locations = await listAllLocationsAsAdmin();
-
-  const paginationLimit = searchParams?.limit ? Number(searchParams.limit) : 25;
-  const currentPage = searchParams?.page ? Number(searchParams.page) : 1;
-
-  const paginatedLocations = locations.slice(
-    (currentPage - 1) * paginationLimit,
-    currentPage * paginationLimit,
+  const filteredLocations = filterLocations(locations, query);
+  const paginatedLocations = filteredLocations.slice(
+    (page - 1) * limit,
+    page * limit,
   );
 
-  return <Table locations={paginatedLocations} totalItems={locations.length} />;
+  return (
+    <Table locations={paginatedLocations} totalItems={filteredLocations.length} />
+  );
 }
 
 export default async function LocatiesPage(props: {
@@ -41,6 +74,10 @@ export default async function LocatiesPage(props: {
       <div className="mb-8">
         <Heading level={1}>Vaarlocaties</Heading>
         <Text className="mt-2">Overzicht van alle vaarlocaties.</Text>
+      </div>
+
+      <div className="mt-4 max-w-xl">
+        <Search placeholder="Zoek op naam of handle…" />
       </div>
 
       <Suspense

--- a/apps/web/src/app/(dashboard)/_components/person-search-combobox.tsx
+++ b/apps/web/src/app/(dashboard)/_components/person-search-combobox.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import * as Headless from "@headlessui/react";
+import type { User } from "@nawadi/core";
+import clsx from "clsx";
+import Spinner from "~/app/_components/spinner";
+
+export type SearchPerson = Awaited<
+  ReturnType<typeof User.Person.searchForAutocomplete>
+>[number];
+
+const controlClasses = clsx(
+  "relative block w-full",
+  "before:absolute before:inset-px before:rounded-[calc(var(--radius-lg)-1px)] before:bg-white before:shadow-sm",
+  "dark:before:hidden",
+  "after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:ring-transparent after:ring-inset sm:focus-within:after:ring-2 sm:focus-within:after:ring-blue-500",
+  "has-data-disabled:opacity-50 has-data-disabled:before:bg-zinc-950/5 has-data-disabled:before:shadow-none",
+  "has-data-invalid:before:shadow-red-500/10",
+);
+
+const inputClasses = clsx(
+  "relative block w-full appearance-none rounded-lg py-[calc(--spacing(2.5)-1px)] sm:py-[calc(--spacing(1.5)-1px)]",
+  "pr-[calc(--spacing(10)-1px)] pl-[calc(--spacing(3.5)-1px)] sm:pr-[calc(--spacing(9)-1px)] sm:pl-[calc(--spacing(3)-1px)]",
+  "text-base/6 text-zinc-950 placeholder:text-zinc-500 sm:text-sm/6 dark:text-white",
+  "border border-zinc-950/10 data-hover:border-zinc-950/20 dark:border-white/10 dark:data-hover:border-white/20",
+  "bg-transparent dark:bg-white/5",
+  "focus:outline-hidden",
+  "data-invalid:border-red-500 data-invalid:data-hover:border-red-500 dark:data-invalid:border-red-500 dark:data-invalid:data-hover:border-red-500",
+  "data-disabled:border-zinc-950/20 dark:data-disabled:border-white/15 dark:data-disabled:bg-white/[2.5%] dark:data-hover:data-disabled:border-white/15",
+  "dark:scheme-dark",
+);
+
+const optionsClasses = clsx(
+  "[--anchor-gap:--spacing(2)] [--anchor-padding:--spacing(4)] sm:data-[anchor~=start]:[--anchor-offset:-4px]",
+  "isolate min-w-[calc(var(--input-width)+8px)] scroll-py-1 rounded-xl p-1 select-none empty:invisible",
+  "outline outline-transparent focus:outline-hidden",
+  "overflow-y-scroll overscroll-contain",
+  "bg-white/75 backdrop-blur-xl dark:bg-zinc-800/75",
+  "shadow-lg ring-1 ring-zinc-950/10 dark:ring-white/10 dark:ring-inset",
+  "transition-opacity duration-100 ease-in data-closed:data-leave:opacity-0 data-transition:pointer-events-none",
+);
+
+const optionClasses = clsx(
+  "group/option grid w-full cursor-default grid-cols-[1fr_--spacing(5)] items-baseline gap-x-2 rounded-lg py-2.5 pr-2 pl-3.5 sm:grid-cols-[1fr_--spacing(4)] sm:py-1.5 sm:pr-2 sm:pl-3",
+  "text-base/6 text-zinc-950 sm:text-sm/6 dark:text-white forced-colors:text-[CanvasText]",
+  "outline-hidden data-focus:bg-blue-500 data-focus:text-white",
+  "forced-color-adjust-none forced-colors:data-focus:bg-[Highlight] forced-colors:data-focus:text-[HighlightText]",
+  "data-disabled:opacity-50",
+);
+
+export function PersonSearchCombobox({
+  selectedPersonName,
+  onSelect,
+  label,
+  isSearching,
+  results,
+  query,
+  debouncedQuery,
+  onQueryChange,
+}: {
+  selectedPersonName: string | null;
+  onSelect: (person: SearchPerson) => void;
+  label: string;
+  isSearching: boolean;
+  results: SearchPerson[];
+  query: string;
+  debouncedQuery: string | null;
+  onQueryChange: (query: string) => void;
+}) {
+  const isTyping = query.length > 0;
+
+  return (
+    <Headless.Combobox
+      immediate
+      onChange={(person: SearchPerson | null) => {
+        if (person) {
+          onSelect(person);
+        }
+        onQueryChange("");
+      }}
+      onClose={() => onQueryChange("")}
+    >
+      <span data-slot="control" className={controlClasses}>
+        <Headless.ComboboxInput
+          aria-label={label}
+          data-slot="control"
+          value={isTyping ? query : (selectedPersonName ?? "")}
+          onChange={(event) => {
+            onQueryChange(event.target.value);
+          }}
+          placeholder="Typ om te zoeken…"
+          autoComplete="off"
+          spellCheck={false}
+          className={inputClasses}
+        />
+        <Headless.ComboboxButton
+          className="group right-0 absolute inset-y-0 flex items-center px-2"
+          aria-label="Opties tonen"
+        >
+          <svg
+            className="stroke-zinc-500 dark:group-data-hover:stroke-zinc-300 dark:stroke-zinc-400 forced-colors:stroke-[CanvasText] group-data-disabled:stroke-zinc-600 group-data-hover:stroke-zinc-700 size-5 sm:size-4"
+            viewBox="0 0 16 16"
+            aria-hidden="true"
+            fill="none"
+          >
+            <path
+              d="M5.75 10.75L8 13L10.25 10.75"
+              strokeWidth={1.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M10.25 5.25L8 3L5.75 5.25"
+              strokeWidth={1.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </Headless.ComboboxButton>
+      </span>
+      <Headless.ComboboxOptions
+        transition
+        anchor="bottom"
+        className={optionsClasses}
+      >
+        {isSearching && (
+          <div
+            className="flex items-center gap-2 px-3.5 py-2 text-sm text-zinc-500"
+            aria-live="polite"
+          >
+            <Spinner className="h-3 w-3" aria-hidden="true" /> Zoeken…
+          </div>
+        )}
+        {!isSearching && debouncedQuery && results.length === 0 && (
+          <div className="px-3.5 py-2 text-sm text-zinc-500" aria-live="polite">
+            Geen personen gevonden
+          </div>
+        )}
+        {results.map((person) => {
+          const name = [
+            person.firstName,
+            person.lastNamePrefix,
+            person.lastName,
+          ]
+            .filter(Boolean)
+            .join(" ");
+          return (
+            <Headless.ComboboxOption
+              key={person.id}
+              value={person}
+              className={optionClasses}
+            >
+              <span className="flex min-w-0 flex-col">
+                <span className="ml-2.5 truncate first:ml-0 sm:ml-2 sm:first:ml-0">
+                  {name}
+                </span>
+                <span className="flex flex-1 overflow-hidden text-zinc-500 group-data-focus/option:text-white before:w-2 before:min-w-0 before:shrink dark:text-zinc-400">
+                  <span className="flex-1 truncate">
+                    {person.email ?? "Geen e-mail"} · {person.handle}
+                    {person.dateOfBirth &&
+                      ` · Geb. ${new Intl.DateTimeFormat("nl-NL", { day: "numeric", month: "long", year: "numeric" }).format(new Date(person.dateOfBirth))}`}
+                  </span>
+                </span>
+              </span>
+            </Headless.ComboboxOption>
+          );
+        })}
+      </Headless.ComboboxOptions>
+    </Headless.Combobox>
+  );
+}

--- a/apps/web/src/app/(dashboard)/_components/person-search-combobox.tsx
+++ b/apps/web/src/app/(dashboard)/_components/person-search-combobox.tsx
@@ -51,6 +51,7 @@ const optionClasses = clsx(
 export function PersonSearchCombobox({
   selectedPersonName,
   onSelect,
+  onClearSelection,
   label,
   isSearching,
   results,
@@ -60,6 +61,7 @@ export function PersonSearchCombobox({
 }: {
   selectedPersonName: string | null;
   onSelect: (person: SearchPerson) => void;
+  onClearSelection?: () => void;
   label: string;
   isSearching: boolean;
   results: SearchPerson[];
@@ -86,6 +88,9 @@ export function PersonSearchCombobox({
           data-slot="control"
           value={isTyping ? query : (selectedPersonName ?? "")}
           onChange={(event) => {
+            if (selectedPersonName) {
+              onClearSelection?.();
+            }
             onQueryChange(event.target.value);
           }}
           placeholder="Typ om te zoeken…"

--- a/apps/web/src/app/(dashboard)/_components/text.tsx
+++ b/apps/web/src/app/(dashboard)/_components/text.tsx
@@ -19,11 +19,15 @@ export function Text({
 
 export function TextLink({
   className,
+  target,
+  rel,
   ...props
 }: React.ComponentPropsWithoutRef<typeof Link>) {
   return (
     <Link
       {...props}
+      target={target}
+      rel={target === "_blank" ? (rel ?? "noopener noreferrer") : rel}
       className={clsx(
         className,
         "text-zinc-950 underline decoration-zinc-950/50 data-hover:decoration-zinc-950 dark:text-white dark:decoration-white/50 dark:data-hover:decoration-white",

--- a/apps/web/src/app/_actions/kss/bulk-import-kwalificaties-action.ts
+++ b/apps/web/src/app/_actions/kss/bulk-import-kwalificaties-action.ts
@@ -1,0 +1,91 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { zfd } from "zod-form-data";
+import {
+  commitKwalificatieBulkImportAsSystemAdmin,
+  previewKwalificatieBulkImportAsSystemAdmin,
+} from "~/lib/nwd";
+import { actionClientWithMeta } from "../safe-action";
+import {
+  csvColumnLiteral,
+  csvDataSchema,
+  SELECT_LABEL,
+} from "../person/person-bulk-csv-mappings";
+import { parseKwalificatieRows } from "./kwalificatie-bulk-import-parser";
+
+const previewInputSchema = zfd
+  .formData(z.record(csvColumnLiteral, zfd.text()))
+  .or(z.void());
+
+const previewArgsSchema: [locationId: z.ZodString, csvData: typeof csvDataSchema] =
+  [z.string().uuid(), csvDataSchema];
+
+export const previewBulkImportKwalificatiesAction = actionClientWithMeta
+  .metadata({ name: "kss.preview-bulk-import-kwalificaties" })
+  .inputSchema(previewInputSchema)
+  .bindArgsSchemas(previewArgsSchema)
+  .action(
+    async ({
+      parsedInput: indexToColumnSelection,
+      bindArgsParsedInputs: [locationId, csvData],
+    }) => {
+      if (!indexToColumnSelection) {
+        if (!csvData?.rows?.[0]) {
+          throw new Error("Geen data gevonden.");
+        }
+        return {
+          kind: "needs-mapping" as const,
+          columns: csvData.rows[0],
+        };
+      }
+
+      const { rows, parseErrors } = parseKwalificatieRows(
+        csvData,
+        indexToColumnSelection as Record<string, string>,
+      );
+
+      if (rows.length === 0 && parseErrors.length > 0) {
+        return {
+          kind: "parse_errors" as const,
+          parseErrors,
+        };
+      }
+
+      const preview = await previewKwalificatieBulkImportAsSystemAdmin({
+        locationId,
+        rows,
+      });
+
+      return {
+        kind: "previewed" as const,
+        previewToken: preview.previewToken,
+        results: preview.results,
+        summary: preview.summary,
+        parseErrors,
+      };
+    },
+  );
+
+const commitInputSchema = z.object({
+  previewToken: z.string().uuid(),
+  locationId: z.string().uuid(),
+  defaultOpmerkingen: z.string().optional(),
+});
+
+export const commitBulkImportKwalificatiesAction = actionClientWithMeta
+  .metadata({ name: "kss.commit-bulk-import-kwalificaties" })
+  .inputSchema(commitInputSchema)
+  .action(async ({ parsedInput }) => {
+    const result = await commitKwalificatieBulkImportAsSystemAdmin({
+      previewToken: parsedInput.previewToken,
+      defaultOpmerkingen: parsedInput.defaultOpmerkingen,
+    });
+
+    revalidatePath("/secretariaat/locaties", "page");
+    revalidatePath(`/secretariaat/locaties/${parsedInput.locationId}`, "page");
+    revalidatePath("/secretariaat/instructeur", "page");
+
+    return result;
+  });

--- a/apps/web/src/app/_actions/kss/bulk-import-kwalificaties-action.ts
+++ b/apps/web/src/app/_actions/kss/bulk-import-kwalificaties-action.ts
@@ -7,20 +7,21 @@ import {
   commitKwalificatieBulkImportAsSystemAdmin,
   previewKwalificatieBulkImportAsSystemAdmin,
 } from "~/lib/nwd";
-import { actionClientWithMeta } from "../safe-action";
 import {
   csvColumnLiteral,
   csvDataSchema,
-  SELECT_LABEL,
 } from "../person/person-bulk-csv-mappings";
+import { actionClientWithMeta } from "../safe-action";
 import { parseKwalificatieRows } from "./kwalificatie-bulk-import-parser";
 
 const previewInputSchema = zfd
   .formData(z.record(csvColumnLiteral, zfd.text()))
   .or(z.void());
 
-const previewArgsSchema: [locationId: z.ZodString, csvData: typeof csvDataSchema] =
-  [z.string().uuid(), csvDataSchema];
+const previewArgsSchema: [
+  locationId: z.ZodString,
+  csvData: typeof csvDataSchema,
+] = [z.string().uuid(), csvDataSchema];
 
 export const previewBulkImportKwalificatiesAction = actionClientWithMeta
   .metadata({ name: "kss.preview-bulk-import-kwalificaties" })
@@ -61,7 +62,19 @@ export const previewBulkImportKwalificatiesAction = actionClientWithMeta
       return {
         kind: "previewed" as const,
         previewToken: preview.previewToken,
-        results: preview.results,
+        results: preview.results.map((r) =>
+          r.status === "ready"
+            ? {
+                rowIndex: r.rowIndex,
+                status: r.status,
+                personName: r.personName,
+                courseTitle: r.courseTitle,
+                kwalificatieLabel: r.kwalificatieLabel,
+                kerntaakOnderdeelCount: r.kerntaakOnderdeelCount,
+                toSkip: r.toSkip,
+              }
+            : r,
+        ),
         summary: preview.summary,
         parseErrors,
       };

--- a/apps/web/src/app/_actions/kss/kwalificatie-bulk-import-constants.ts
+++ b/apps/web/src/app/_actions/kss/kwalificatie-bulk-import-constants.ts
@@ -1,0 +1,10 @@
+/** Client-safe constants for kwalificatie bulk import UI (no @nawadi/core). */
+export const KWALIFICATIE_COLUMN_MAPPING = [
+  "E-mailadres",
+  "NWD-id",
+  "Cursus",
+  "Richting",
+  "Niveau",
+  "Kerntaak",
+  "Opmerkingen",
+] as const;

--- a/apps/web/src/app/_actions/kss/kwalificatie-bulk-import-parser.ts
+++ b/apps/web/src/app/_actions/kss/kwalificatie-bulk-import-parser.ts
@@ -1,6 +1,9 @@
-import { z } from "zod";
-import { SELECT_LABEL } from "../person/person-bulk-csv-mappings";
+import {
+  type KwalificatieImportRow,
+  kwalificatieRichtingSchema,
+} from "@nawadi/core";
 import type { CSVData } from "../person/person-bulk-csv-mappings";
+import { SELECT_LABEL } from "../person/person-bulk-csv-mappings";
 
 export const KWALIFICATIE_COLUMN_MAPPING = [
   "E-mailadres",
@@ -12,35 +15,22 @@ export const KWALIFICATIE_COLUMN_MAPPING = [
   "Opmerkingen",
 ] as const;
 
-const richtingSchema = z.enum(["instructeur", "leercoach", "pvb_beoordelaar"]);
+export type KwalificatieParseError = {
+  rowIndex: number;
+  error: string;
+};
+
+export type KwalificatieParseResult = {
+  rows: KwalificatieImportRow[];
+  parseErrors: KwalificatieParseError[];
+};
 
 export function parseKwalificatieRows(
   csvData: CSVData,
   indexToColumnSelection: Record<string, string>,
-): {
-  rows: Array<{
-    rowIndex: number;
-    email?: string;
-    nwdId?: string;
-    courseTitle: string;
-    richting: "instructeur" | "leercoach" | "pvb_beoordelaar";
-    niveau: number;
-    kerntaakTitel?: string;
-    opmerkingen?: string;
-  }>;
-  parseErrors: Array<{ rowIndex: number; error: string }>;
-} {
-  const rows: Array<{
-    rowIndex: number;
-    email?: string;
-    nwdId?: string;
-    courseTitle: string;
-    richting: "instructeur" | "leercoach" | "pvb_beoordelaar";
-    niveau: number;
-    kerntaakTitel?: string;
-    opmerkingen?: string;
-  }> = [];
-  const parseErrors: Array<{ rowIndex: number; error: string }> = [];
+): KwalificatieParseResult {
+  const rows: KwalificatieImportRow[] = [];
+  const parseErrors: KwalificatieParseError[] = [];
 
   if (!csvData.rows) {
     return { rows, parseErrors };
@@ -87,7 +77,7 @@ export function parseKwalificatieRows(
       continue;
     }
 
-    const richtingResult = richtingSchema.safeParse(richtingRaw);
+    const richtingResult = kwalificatieRichtingSchema.safeParse(richtingRaw);
     if (!richtingResult.success) {
       parseErrors.push({
         rowIndex,

--- a/apps/web/src/app/_actions/kss/kwalificatie-bulk-import-parser.ts
+++ b/apps/web/src/app/_actions/kss/kwalificatie-bulk-import-parser.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+import { SELECT_LABEL } from "../person/person-bulk-csv-mappings";
+import type { CSVData } from "../person/person-bulk-csv-mappings";
+
+export const KWALIFICATIE_COLUMN_MAPPING = [
+  "E-mailadres",
+  "NWD-id",
+  "Cursus",
+  "Richting",
+  "Niveau",
+  "Kerntaak",
+  "Opmerkingen",
+] as const;
+
+const richtingSchema = z.enum(["instructeur", "leercoach", "pvb_beoordelaar"]);
+
+export function parseKwalificatieRows(
+  csvData: CSVData,
+  indexToColumnSelection: Record<string, string>,
+): {
+  rows: Array<{
+    rowIndex: number;
+    email?: string;
+    nwdId?: string;
+    courseTitle: string;
+    richting: "instructeur" | "leercoach" | "pvb_beoordelaar";
+    niveau: number;
+    kerntaakTitel?: string;
+    opmerkingen?: string;
+  }>;
+  parseErrors: Array<{ rowIndex: number; error: string }>;
+} {
+  const rows: Array<{
+    rowIndex: number;
+    email?: string;
+    nwdId?: string;
+    courseTitle: string;
+    richting: "instructeur" | "leercoach" | "pvb_beoordelaar";
+    niveau: number;
+    kerntaakTitel?: string;
+    opmerkingen?: string;
+  }> = [];
+  const parseErrors: Array<{ rowIndex: number; error: string }> = [];
+
+  if (!csvData.rows) {
+    return { rows, parseErrors };
+  }
+
+  const columnIndexToField = new Map<number, string>();
+  for (const [key, value] of Object.entries(indexToColumnSelection)) {
+    if (value === SELECT_LABEL) continue;
+    const match = /^include-column-(\d+)$/.exec(key);
+    if (match?.[1]) {
+      columnIndexToField.set(Number(match[1]), value);
+    }
+  }
+
+  for (let i = 0; i < csvData.rows.length; i++) {
+    const rawRow = csvData.rows[i];
+    if (!rawRow) continue;
+
+    const fields: Record<string, string> = {};
+    for (const [colIndex, fieldName] of columnIndexToField) {
+      const val = rawRow[colIndex]?.trim();
+      if (val) fields[fieldName] = val;
+    }
+
+    const rowIndex = i + 1;
+    const email = fields["E-mailadres"]?.toLowerCase();
+    const nwdId = fields["NWD-id"];
+    const courseTitle = fields.Cursus;
+    const richtingRaw = fields.Richting?.toLowerCase();
+    const niveauRaw = fields.Niveau;
+    const kerntaakTitel = fields.Kerntaak;
+    const opmerkingen = fields.Opmerkingen;
+
+    if (!email && !nwdId) {
+      parseErrors.push({
+        rowIndex,
+        error: "E-mailadres of NWD-id is verplicht",
+      });
+      continue;
+    }
+
+    if (!courseTitle) {
+      parseErrors.push({ rowIndex, error: "Cursus is verplicht" });
+      continue;
+    }
+
+    const richtingResult = richtingSchema.safeParse(richtingRaw);
+    if (!richtingResult.success) {
+      parseErrors.push({
+        rowIndex,
+        error: "Richting moet instructeur, leercoach of pvb_beoordelaar zijn",
+      });
+      continue;
+    }
+
+    const niveau = Number(niveauRaw);
+    if (!Number.isInteger(niveau) || niveau < 1 || niveau > 5) {
+      parseErrors.push({
+        rowIndex,
+        error: "Niveau moet een geheel getal tussen 1 en 5 zijn",
+      });
+      continue;
+    }
+
+    rows.push({
+      rowIndex,
+      email,
+      nwdId,
+      courseTitle,
+      richting: richtingResult.data,
+      niveau,
+      kerntaakTitel,
+      opmerkingen,
+    });
+  }
+
+  return { rows, parseErrors };
+}

--- a/apps/web/src/app/_actions/kss/kwalificatie-bulk-import-parser.ts
+++ b/apps/web/src/app/_actions/kss/kwalificatie-bulk-import-parser.ts
@@ -5,16 +5,6 @@ import {
 import type { CSVData } from "../person/person-bulk-csv-mappings";
 import { SELECT_LABEL } from "../person/person-bulk-csv-mappings";
 
-export const KWALIFICATIE_COLUMN_MAPPING = [
-  "E-mailadres",
-  "NWD-id",
-  "Cursus",
-  "Richting",
-  "Niveau",
-  "Kerntaak",
-  "Opmerkingen",
-] as const;
-
 export type KwalificatieParseError = {
   rowIndex: number;
   error: string;

--- a/apps/web/src/app/_actions/location/add-location-admin-action.ts
+++ b/apps/web/src/app/_actions/location/add-location-admin-action.ts
@@ -1,0 +1,36 @@
+"use server";
+
+import { User } from "@nawadi/core";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { isSystemAdmin } from "~/lib/authorization";
+import { getUserOrThrow } from "~/lib/nwd";
+import { actionClientWithMeta } from "../safe-action";
+
+export const addLocationAdminAsSystemAdminAction = actionClientWithMeta
+  .metadata({ name: "location.add-admin-as-system-admin" })
+  .inputSchema(
+    z.object({
+      locationId: z.string().uuid(),
+      personId: z.string().uuid(),
+    }),
+  )
+  .action(async ({ parsedInput: { locationId, personId } }) => {
+    const user = await getUserOrThrow();
+    if (!isSystemAdmin(user.email)) {
+      throw new Error("Geen toegang");
+    }
+
+    await User.Person.createLocationLink({
+      personId,
+      locationId,
+    });
+
+    await User.Actor.upsert({
+      personId,
+      locationId,
+      type: "location_admin",
+    });
+
+    revalidatePath("/secretariaat/locaties", "page");
+  });

--- a/apps/web/src/app/_actions/location/add-location-admin-action.ts
+++ b/apps/web/src/app/_actions/location/add-location-admin-action.ts
@@ -1,10 +1,10 @@
 "use server";
 
-import { User } from "@nawadi/core";
+import { User, withSupabaseClient } from "@nawadi/core";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { isSystemAdmin } from "~/lib/authorization";
-import { getUserOrThrow } from "~/lib/nwd";
+import { getUserOrThrow, supabaseConfig } from "~/lib/nwd";
 import { actionClientWithMeta } from "../safe-action";
 
 export const addLocationAdminAsSystemAdminAction = actionClientWithMeta
@@ -21,15 +21,17 @@ export const addLocationAdminAsSystemAdminAction = actionClientWithMeta
       throw new Error("Geen toegang");
     }
 
-    await User.Person.createLocationLink({
-      personId,
-      locationId,
-    });
+    await withSupabaseClient(supabaseConfig, async () => {
+      await User.Person.createLocationLink({
+        personId,
+        locationId,
+      });
 
-    await User.Actor.upsert({
-      personId,
-      locationId,
-      type: "location_admin",
+      await User.Actor.upsert({
+        personId,
+        locationId,
+        type: "location_admin",
+      });
     });
 
     revalidatePath("/secretariaat/locaties", "page");

--- a/apps/web/src/app/_actions/location/add-location-admin-action.ts
+++ b/apps/web/src/app/_actions/location/add-location-admin-action.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { User, withSupabaseClient } from "@nawadi/core";
+import { User, withSupabaseClient, withTransaction } from "@nawadi/core";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { isSystemAdmin } from "~/lib/authorization";
@@ -22,15 +22,17 @@ export const addLocationAdminAsSystemAdminAction = actionClientWithMeta
     }
 
     await withSupabaseClient(supabaseConfig, async () => {
-      await User.Person.createLocationLink({
-        personId,
-        locationId,
-      });
+      await withTransaction(async () => {
+        await User.Person.ensureLocationLinkForAdmin({
+          personId,
+          locationId,
+        });
 
-      await User.Actor.upsert({
-        personId,
-        locationId,
-        type: "location_admin",
+        await User.Actor.upsert({
+          personId,
+          locationId,
+          type: "location_admin",
+        });
       });
     });
 

--- a/apps/web/src/app/_actions/location/add-location-admin-action.ts
+++ b/apps/web/src/app/_actions/location/add-location-admin-action.ts
@@ -1,6 +1,11 @@
 "use server";
 
-import { User, withSupabaseClient, withTransaction } from "@nawadi/core";
+import {
+  Location,
+  User,
+  withSupabaseClient,
+  withTransaction,
+} from "@nawadi/core";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { isSystemAdmin } from "~/lib/authorization";
@@ -23,6 +28,18 @@ export const addLocationAdminAsSystemAdminAction = actionClientWithMeta
 
     await withSupabaseClient(supabaseConfig, async () => {
       await withTransaction(async () => {
+        const existingAdmin = await Location.Person.getActorByPersonIdAndType({
+          locationId,
+          personId,
+          actorType: "location_admin",
+        });
+
+        if (existingAdmin) {
+          throw new Error(
+            "Deze persoon is al locatiebeheerder voor deze locatie",
+          );
+        }
+
         await User.Person.ensureLocationLinkForAdmin({
           personId,
           locationId,
@@ -37,4 +54,5 @@ export const addLocationAdminAsSystemAdminAction = actionClientWithMeta
     });
 
     revalidatePath("/secretariaat/locaties", "page");
+    revalidatePath(`/secretariaat/locaties/${locationId}`, "page");
   });

--- a/apps/web/src/app/_actions/location/create-location-action.ts
+++ b/apps/web/src/app/_actions/location/create-location-action.ts
@@ -1,0 +1,52 @@
+"use server";
+
+import { Location, withSupabaseClient } from "@nawadi/core";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { isSystemAdmin } from "~/lib/authorization";
+import { getUserOrThrow, supabaseConfig } from "~/lib/nwd";
+import { actionClientWithMeta } from "../safe-action";
+
+const createLocationSchema = z.object({
+  name: z.string().trim().min(1, "Naam is verplicht"),
+  handle: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .min(3, "Handle moet minimaal 3 tekens zijn")
+    .max(48, "Handle mag maximaal 48 tekens zijn")
+    .regex(/^[a-z0-9-]+$/, "Handle mag alleen kleine letters, cijfers en streepjes bevatten"),
+  websiteUrl: z
+    .string()
+    .trim()
+    .url("Ongeldige URL")
+    .optional()
+    .or(z.literal("")),
+});
+
+export const createLocationAsSystemAdminAction = actionClientWithMeta
+  .metadata({ name: "location.create-as-system-admin" })
+  .inputSchema(createLocationSchema)
+  .action(async ({ parsedInput }) => {
+    const user = await getUserOrThrow();
+    if (!isSystemAdmin(user.email)) {
+      throw new Error("Geen toegang");
+    }
+
+    const websiteUrl =
+      parsedInput.websiteUrl && parsedInput.websiteUrl.length > 0
+        ? parsedInput.websiteUrl
+        : undefined;
+
+    const result = await withSupabaseClient(supabaseConfig, async () => {
+      return Location.Onboarding.createForOnboarding({
+        name: parsedInput.name,
+        handle: parsedInput.handle,
+        websiteUrl,
+      });
+    });
+
+    revalidatePath("/secretariaat/locaties", "page");
+
+    return { id: result.id };
+  });

--- a/apps/web/src/app/_actions/location/create-location-action.ts
+++ b/apps/web/src/app/_actions/location/create-location-action.ts
@@ -15,7 +15,10 @@ const createLocationSchema = z.object({
     .toLowerCase()
     .min(3, "Handle moet minimaal 3 tekens zijn")
     .max(48, "Handle mag maximaal 48 tekens zijn")
-    .regex(/^[a-z0-9-]+$/, "Handle mag alleen kleine letters, cijfers en streepjes bevatten"),
+    .regex(
+      /^[a-z0-9-]+$/,
+      "Handle mag alleen kleine letters, cijfers en streepjes bevatten",
+    ),
   websiteUrl: z
     .string()
     .trim()

--- a/apps/web/src/app/_actions/secretariat/bulk-import-instructors-action.ts
+++ b/apps/web/src/app/_actions/secretariat/bulk-import-instructors-action.ts
@@ -1,0 +1,146 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { zfd } from "zod-form-data";
+import {
+  commitBulkImportAsSystemAdmin,
+  previewBulkImportAsSystemAdmin,
+} from "~/lib/nwd";
+import { actionClientWithMeta } from "../safe-action";
+import { type ParsedPersonRow, parseRowsTolerant } from "../person/bulk-import-parser";
+import {
+  countriesSchema,
+  csvColumnLiteral,
+  csvDataSchema,
+} from "../person/person-bulk-csv-mappings";
+
+const previewInputSchema = zfd
+  .formData(z.record(csvColumnLiteral, zfd.text()))
+  .or(z.void());
+
+const previewArgsSchema: [
+  locationId: z.ZodString,
+  csvData: typeof csvDataSchema,
+  countries: typeof countriesSchema,
+] = [z.string().uuid(), csvDataSchema, countriesSchema];
+
+type PreviewParseResult =
+  | { kind: "needs-mapping"; columns: string[] }
+  | {
+      kind: "previewed";
+      previewToken: string;
+      attempt: 1 | 2 | 3;
+      parsedRows: ParsedPersonRow[];
+      parseErrors: { rowIndex: number; error: string; values: string[] }[];
+      matches: unknown;
+    };
+
+export const previewBulkImportInstructorsAsSystemAdminAction =
+  actionClientWithMeta
+    .metadata({ name: "secretariat.preview-bulk-import-instructors" })
+    .inputSchema(previewInputSchema)
+    .bindArgsSchemas(previewArgsSchema)
+    .action<PreviewParseResult>(
+      async ({
+        parsedInput: indexToColumnSelection,
+        bindArgsParsedInputs: [locationId, csvData, countries],
+      }) => {
+        if (!indexToColumnSelection) {
+          if (!csvData?.rows?.[0]) {
+            throw new Error("Geen data gevonden.");
+          }
+          return {
+            kind: "needs-mapping",
+            columns: csvData.rows[0],
+          };
+        }
+
+        const { parsedRows, parseErrors } = parseRowsTolerant(
+          csvData,
+          indexToColumnSelection as Record<string, string>,
+          countries,
+        );
+
+        const previewResult = await previewBulkImportAsSystemAdmin({
+          locationId,
+          roles: ["instructor"],
+          csvCandidates: parsedRows.map((row) => ({
+            rowIndex: row.rowIndex,
+            email: row.email,
+            firstName: row.firstName,
+            lastNamePrefix: row.lastNamePrefix,
+            lastName: row.lastName,
+            dateOfBirth: row.dateOfBirth.toISOString().slice(0, 10),
+            birthCity: row.birthCity,
+            birthCountry: row.birthCountry,
+          })),
+          parseErrors,
+        });
+
+        return {
+          kind: "previewed",
+          previewToken: previewResult.previewToken,
+          attempt: previewResult.attempt as 1 | 2 | 3,
+          parsedRows,
+          parseErrors,
+          matches: previewResult.matches,
+        };
+      },
+    );
+
+const decisionSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("create_new"),
+    shareNewPersonWithGroup: z.string().optional(),
+  }),
+  z.object({ kind: z.literal("use_existing"), personId: z.string().uuid() }),
+  z.object({
+    kind: z.literal("skip"),
+    reason: z
+      .enum([
+        "cohort_conflict",
+        "cross_row_conflict",
+        "parse_error",
+        "operator",
+      ])
+      .default("operator"),
+  }),
+]);
+
+const commitInputSchema = z.object({
+  previewToken: z.string().uuid(),
+  locationId: z.string().uuid(),
+  decisions: z.record(z.string(), decisionSchema),
+  candidateInputsByRowIndex: z.record(
+    z.string(),
+    z.object({
+      email: z.string().email(),
+      firstName: z.string(),
+      lastNamePrefix: z.string().nullable(),
+      lastName: z.string(),
+      dateOfBirth: z.string(),
+      birthCity: z.string(),
+      birthCountry: z.string(),
+    }),
+  ),
+});
+
+export const commitBulkImportInstructorsAsSystemAdminAction =
+  actionClientWithMeta
+    .metadata({ name: "secretariat.commit-bulk-import-instructors" })
+    .inputSchema(commitInputSchema)
+    .action(async ({ parsedInput }) => {
+      const result = await commitBulkImportAsSystemAdmin({
+        previewToken: parsedInput.previewToken,
+        locationId: parsedInput.locationId,
+        roles: ["instructor"],
+        decisions: parsedInput.decisions,
+        candidateInputsByRowIndex: parsedInput.candidateInputsByRowIndex,
+      });
+
+      revalidatePath("/secretariaat/locaties", "page");
+      revalidatePath(`/secretariaat/locaties/${parsedInput.locationId}`, "page");
+
+      return result;
+    });

--- a/apps/web/src/app/_actions/secretariat/bulk-import-instructors-action.ts
+++ b/apps/web/src/app/_actions/secretariat/bulk-import-instructors-action.ts
@@ -7,13 +7,16 @@ import {
   commitBulkImportAsSystemAdmin,
   previewBulkImportAsSystemAdmin,
 } from "~/lib/nwd";
-import { actionClientWithMeta } from "../safe-action";
-import { type ParsedPersonRow, parseRowsTolerant } from "../person/bulk-import-parser";
+import {
+  type ParsedPersonRow,
+  parseRowsTolerant,
+} from "../person/bulk-import-parser";
 import {
   countriesSchema,
   csvColumnLiteral,
   csvDataSchema,
 } from "../person/person-bulk-csv-mappings";
+import { actionClientWithMeta } from "../safe-action";
 
 const previewInputSchema = zfd
   .formData(z.record(csvColumnLiteral, zfd.text()))
@@ -140,7 +143,10 @@ export const commitBulkImportInstructorsAsSystemAdminAction =
       });
 
       revalidatePath("/secretariaat/locaties", "page");
-      revalidatePath(`/secretariaat/locaties/${parsedInput.locationId}`, "page");
+      revalidatePath(
+        `/secretariaat/locaties/${parsedInput.locationId}`,
+        "page",
+      );
 
       return result;
     });

--- a/apps/web/src/lib/nwd.ts
+++ b/apps/web/src/lib/nwd.ts
@@ -1273,6 +1273,82 @@ export const listAllLocationsAsAdmin = cache(async () => {
   });
 });
 
+export const retrieveLocationByIdAsAdmin = async (locationId: string) => {
+  return makeRequest(async () => {
+    const requestingUser = await getUserOrThrow();
+    const { isSystemAdmin } = await import("~/lib/authorization");
+
+    if (!isSystemAdmin(requestingUser.email)) {
+      throw new Error("Unauthorized");
+    }
+
+    return await Location.fromId(locationId);
+  });
+};
+
+export const listPersonsAtLocationAsAdmin = async (
+  locationId: string,
+  filter: { type?: "student" | "instructor" | "location_admin" },
+) => {
+  return makeRequest(async () => {
+    const requestingUser = await getUserOrThrow();
+    const { isSystemAdmin } = await import("~/lib/authorization");
+
+    if (!isSystemAdmin(requestingUser.email)) {
+      throw new Error("Unauthorized");
+    }
+
+    return Location.Person.list({
+      locationId,
+      filter: { type: filter.type },
+    });
+  });
+};
+
+async function assertSystemAdmin() {
+  const requestingUser = await getUserOrThrow();
+  const { isSystemAdmin } = await import("~/lib/authorization");
+
+  if (!isSystemAdmin(requestingUser.email)) {
+    throw new Error("Unauthorized");
+  }
+
+  return requestingUser;
+}
+
+/**
+ * Bulk-import previews require a performer person id for audit rows. Secretariat
+ * staff accounts may lack a linked person; provision one on first use.
+ */
+async function resolvePerformerPersonIdForSystemAdmin(
+  authUser: Awaited<ReturnType<typeof getUserOrThrow>>,
+): Promise<string> {
+  if (authUser.persons.length > 0) {
+    const person =
+      authUser.persons.find((p) => p.isPrimary) ?? authUser.persons[0]!;
+    return person.id;
+  }
+
+  const displayName =
+    authUser.displayName?.trim() ||
+    authUser.email?.split("@")[0] ||
+    "Secretariaat";
+
+  const created = await User.Person.getOrCreate({
+    userId: authUser.authUserId,
+    firstName: displayName,
+    lastName: "NWD",
+    lastNamePrefix: null,
+    dateOfBirth: "1970-01-01",
+    birthCity: "Onbekend",
+    birthCountry: "NL",
+  });
+
+  await User.Person.setPrimary({ personId: created.id });
+
+  return created.id;
+}
+
 export const createStudentForLocation = async (
   locationId: string,
   personInput: {
@@ -4883,6 +4959,208 @@ function findCandidateForCreate(
       row.dateOfBirth === input.dateOfBirth,
   );
   return match ?? null;
+}
+
+export async function previewBulkImportAsSystemAdmin({
+  locationId,
+  roles,
+  csvCandidates,
+  parseErrors,
+}: {
+  locationId: string;
+  roles: ActorType[];
+  csvCandidates: Array<{
+    rowIndex: number;
+    email: string | null;
+    firstName: string;
+    lastNamePrefix: string | null;
+    lastName: string | null;
+    dateOfBirth: string;
+    birthCity: string;
+    birthCountry: string;
+  }>;
+  parseErrors: Array<{ rowIndex: number; error: string }>;
+}) {
+  return makeRequest(async () => {
+    await assertSystemAdmin();
+    const authUser = await getUserOrThrow();
+    const performerPersonId = await resolvePerformerPersonIdForSystemAdmin(
+      authUser,
+    );
+
+    const filteredRoles = roles.filter(
+      (r): r is "student" | "instructor" | "location_admin" =>
+        r === "student" || r === "instructor" || r === "location_admin",
+    );
+    if (filteredRoles.length === 0) {
+      throw new Error("At least one role required");
+    }
+
+    return User.Person.previewBulkImport({
+      locationId,
+      performedByPersonId: performerPersonId,
+      roles: filteredRoles as [
+        "student" | "instructor" | "location_admin",
+        ...("student" | "instructor" | "location_admin")[],
+      ],
+      candidates: csvCandidates,
+      parseErrors,
+    });
+  });
+}
+
+export async function commitBulkImportAsSystemAdmin({
+  previewToken,
+  locationId,
+  roles,
+  decisions,
+  candidateInputsByRowIndex,
+}: {
+  previewToken: string;
+  locationId: string;
+  roles: ActorType[];
+  decisions: Record<
+    string,
+    | { kind: "create_new"; shareNewPersonWithGroup?: string }
+    | { kind: "use_existing"; personId: string }
+    | {
+        kind: "skip";
+        reason?:
+          | "cohort_conflict"
+          | "cross_row_conflict"
+          | "parse_error"
+          | "operator";
+      }
+  >;
+  candidateInputsByRowIndex: Record<
+    string,
+    {
+      email: string;
+      firstName: string;
+      lastNamePrefix: string | null;
+      lastName: string;
+      dateOfBirth: string;
+      birthCity: string;
+      birthCountry: string;
+    }
+  >;
+}) {
+  return makeRequest(async () => {
+    await assertSystemAdmin();
+    const authUser = await getUserOrThrow();
+    const performerPersonId = await resolvePerformerPersonIdForSystemAdmin(
+      authUser,
+    );
+
+    const filteredRoles = roles.filter(
+      (r): r is "student" | "instructor" | "location_admin" =>
+        r === "student" || r === "instructor" || r === "location_admin",
+    );
+    if (filteredRoles.length === 0) {
+      throw new Error("At least one role required");
+    }
+    const rolesNonEmpty = filteredRoles as [ActorType, ...ActorType[]];
+
+    return User.Person.commitBulkImport({
+      previewToken,
+      performedByPersonId: performerPersonId,
+      decisions,
+      createPerson: async (input) => {
+        const candidate = findCandidateForCreate(
+          input,
+          candidateInputsByRowIndex,
+        );
+        if (!candidate) {
+          throw new Error(
+            "Kon de pasted rij niet terugvinden — neem contact op met NWD",
+          );
+        }
+
+        const created = await Location.Onboarding.createPersonAndLinkInstructor(
+          {
+            locationId,
+            email: candidate.email || undefined,
+            firstName: candidate.firstName,
+            lastNamePrefix: candidate.lastNamePrefix,
+            lastName: candidate.lastName,
+            dateOfBirth: candidate.dateOfBirth,
+            birthCity: candidate.birthCity,
+            birthCountry: candidate.birthCountry,
+          },
+        );
+
+        for (const role of rolesNonEmpty) {
+          if (role !== "instructor") {
+            await User.Actor.upsert({
+              locationId,
+              type: role,
+              personId: created.personId,
+            });
+          }
+        }
+
+        return { personId: created.personId };
+      },
+    });
+  });
+}
+
+export async function previewKwalificatieBulkImportAsSystemAdmin({
+  locationId,
+  rows,
+}: {
+  locationId: string;
+  rows: Array<{
+    rowIndex: number;
+    email?: string;
+    nwdId?: string;
+    courseTitle: string;
+    richting: "instructeur" | "leercoach" | "pvb_beoordelaar";
+    niveau: number;
+    kerntaakTitel?: string;
+    opmerkingen?: string;
+  }>;
+}) {
+  return makeRequest(async () => {
+    await assertSystemAdmin();
+    const authUser = await getUserOrThrow();
+    const performerPersonId = await resolvePerformerPersonIdForSystemAdmin(
+      authUser,
+    );
+
+    return KSS.BulkImportKwalificaties.previewBulkImport({
+      locationId,
+      performedByPersonId: performerPersonId,
+      rows,
+    });
+  });
+}
+
+export async function commitKwalificatieBulkImportAsSystemAdmin({
+  previewToken,
+  defaultOpmerkingen,
+}: {
+  previewToken: string;
+  defaultOpmerkingen?: string;
+}) {
+  return makeRequest(async () => {
+    await assertSystemAdmin();
+    const authUser = await getUserOrThrow();
+    const performerPersonId = await resolvePerformerPersonIdForSystemAdmin(
+      authUser,
+    );
+    const performerPerson =
+      authUser.persons.find((p) => p.id === performerPersonId) ??
+      authUser.persons[0];
+    const actor = performerPerson?.actors.find((a) => a.type === "system");
+
+    return KSS.BulkImportKwalificaties.commitBulkImport({
+      previewToken,
+      performedByPersonId: performerPersonId,
+      toegevoegdDoorActorId: actor?.id,
+      defaultOpmerkingen,
+    });
+  });
 }
 
 export async function listLocationDuplicatePairs({

--- a/apps/web/src/lib/nwd.ts
+++ b/apps/web/src/lib/nwd.ts
@@ -1260,6 +1260,19 @@ export const listAllLocations = cache(async () => {
   });
 });
 
+export const listAllLocationsAsAdmin = cache(async () => {
+  return makeRequest(async () => {
+    const requestingUser = await getUserOrThrow();
+    const { isSystemAdmin } = await import("~/lib/authorization");
+
+    if (!isSystemAdmin(requestingUser.email)) {
+      throw new Error("Unauthorized");
+    }
+
+    return await Location.list();
+  });
+});
+
 export const createStudentForLocation = async (
   locationId: string,
   personInput: {

--- a/apps/web/src/lib/nwd.ts
+++ b/apps/web/src/lib/nwd.ts
@@ -1262,12 +1262,7 @@ export const listAllLocations = cache(async () => {
 
 export const listAllLocationsAsAdmin = cache(async () => {
   return makeRequest(async () => {
-    const requestingUser = await getUserOrThrow();
-    const { isSystemAdmin } = await import("~/lib/authorization");
-
-    if (!isSystemAdmin(requestingUser.email)) {
-      throw new Error("Unauthorized");
-    }
+    await assertSystemAdmin();
 
     return await Location.list();
   });
@@ -1275,12 +1270,7 @@ export const listAllLocationsAsAdmin = cache(async () => {
 
 export const retrieveLocationByIdAsAdmin = async (locationId: string) => {
   return makeRequest(async () => {
-    const requestingUser = await getUserOrThrow();
-    const { isSystemAdmin } = await import("~/lib/authorization");
-
-    if (!isSystemAdmin(requestingUser.email)) {
-      throw new Error("Unauthorized");
-    }
+    await assertSystemAdmin();
 
     return await Location.fromId(locationId);
   });
@@ -1291,12 +1281,7 @@ export const listPersonsAtLocationAsAdmin = async (
   filter: { type?: "student" | "instructor" | "location_admin" },
 ) => {
   return makeRequest(async () => {
-    const requestingUser = await getUserOrThrow();
-    const { isSystemAdmin } = await import("~/lib/authorization");
-
-    if (!isSystemAdmin(requestingUser.email)) {
-      throw new Error("Unauthorized");
-    }
+    await assertSystemAdmin();
 
     return Location.Person.list({
       locationId,
@@ -1325,7 +1310,10 @@ async function resolvePerformerPersonIdForSystemAdmin(
 ): Promise<string> {
   if (authUser.persons.length > 0) {
     const person =
-      authUser.persons.find((p) => p.isPrimary) ?? authUser.persons[0]!;
+      authUser.persons.find((p) => p.isPrimary) ?? authUser.persons[0];
+    if (!person) {
+      throw new Error("Expected at least one person for user");
+    }
     return person.id;
   }
 
@@ -4982,11 +4970,9 @@ export async function previewBulkImportAsSystemAdmin({
   parseErrors: Array<{ rowIndex: number; error: string }>;
 }) {
   return makeRequest(async () => {
-    await assertSystemAdmin();
-    const authUser = await getUserOrThrow();
-    const performerPersonId = await resolvePerformerPersonIdForSystemAdmin(
-      authUser,
-    );
+    const authUser = await assertSystemAdmin();
+    const performerPersonId =
+      await resolvePerformerPersonIdForSystemAdmin(authUser);
 
     const filteredRoles = roles.filter(
       (r): r is "student" | "instructor" | "location_admin" =>
@@ -5046,11 +5032,9 @@ export async function commitBulkImportAsSystemAdmin({
   >;
 }) {
   return makeRequest(async () => {
-    await assertSystemAdmin();
-    const authUser = await getUserOrThrow();
-    const performerPersonId = await resolvePerformerPersonIdForSystemAdmin(
-      authUser,
-    );
+    const authUser = await assertSystemAdmin();
+    const performerPersonId =
+      await resolvePerformerPersonIdForSystemAdmin(authUser);
 
     const filteredRoles = roles.filter(
       (r): r is "student" | "instructor" | "location_admin" =>
@@ -5060,6 +5044,25 @@ export async function commitBulkImportAsSystemAdmin({
       throw new Error("At least one role required");
     }
     const rolesNonEmpty = filteredRoles as [ActorType, ...ActorType[]];
+
+    const createPersonInput = (candidate: {
+      email: string;
+      firstName: string;
+      lastNamePrefix: string | null;
+      lastName: string;
+      dateOfBirth: string;
+      birthCity: string;
+      birthCountry: string;
+    }) => ({
+      locationId,
+      email: candidate.email || undefined,
+      firstName: candidate.firstName,
+      lastNamePrefix: candidate.lastNamePrefix,
+      lastName: candidate.lastName,
+      dateOfBirth: candidate.dateOfBirth,
+      birthCity: candidate.birthCity,
+      birthCountry: candidate.birthCountry,
+    });
 
     return User.Person.commitBulkImport({
       previewToken,
@@ -5076,28 +5079,33 @@ export async function commitBulkImportAsSystemAdmin({
           );
         }
 
-        const created = await Location.Onboarding.createPersonAndLinkInstructor(
-          {
-            locationId,
-            email: candidate.email || undefined,
-            firstName: candidate.firstName,
-            lastNamePrefix: candidate.lastNamePrefix,
-            lastName: candidate.lastName,
-            dateOfBirth: candidate.dateOfBirth,
-            birthCity: candidate.birthCity,
-            birthCountry: candidate.birthCountry,
-          },
-        );
+        if (rolesNonEmpty.includes("instructor")) {
+          const created =
+            await Location.Onboarding.createPersonAndLinkInstructor(
+              createPersonInput(candidate),
+            );
 
-        for (const role of rolesNonEmpty) {
-          if (role !== "instructor") {
-            await User.Actor.upsert({
-              locationId,
-              type: role,
-              personId: created.personId,
-            });
+          for (const role of rolesNonEmpty) {
+            if (role !== "instructor") {
+              await User.Actor.upsert({
+                locationId,
+                type: role,
+                personId: created.personId,
+              });
+            }
           }
+
+          return { personId: created.personId };
         }
+
+        const created = await Location.Onboarding.createPersonWithRoles({
+          ...createPersonInput(candidate),
+          roles: rolesNonEmpty as (
+            | "student"
+            | "instructor"
+            | "location_admin"
+          )[],
+        });
 
         return { personId: created.personId };
       },
@@ -5122,11 +5130,9 @@ export async function previewKwalificatieBulkImportAsSystemAdmin({
   }>;
 }) {
   return makeRequest(async () => {
-    await assertSystemAdmin();
-    const authUser = await getUserOrThrow();
-    const performerPersonId = await resolvePerformerPersonIdForSystemAdmin(
-      authUser,
-    );
+    const authUser = await assertSystemAdmin();
+    const performerPersonId =
+      await resolvePerformerPersonIdForSystemAdmin(authUser);
 
     return KSS.BulkImportKwalificaties.previewBulkImport({
       locationId,
@@ -5144,11 +5150,9 @@ export async function commitKwalificatieBulkImportAsSystemAdmin({
   defaultOpmerkingen?: string;
 }) {
   return makeRequest(async () => {
-    await assertSystemAdmin();
-    const authUser = await getUserOrThrow();
-    const performerPersonId = await resolvePerformerPersonIdForSystemAdmin(
-      authUser,
-    );
+    const authUser = await assertSystemAdmin();
+    const performerPersonId =
+      await resolvePerformerPersonIdForSystemAdmin(authUser);
     const performerPerson =
       authUser.persons.find((p) => p.id === performerPersonId) ??
       authUser.persons[0];

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -4,6 +4,10 @@ export * as Certificate from "./certificate/index.ts";
 export * as Cohort from "./cohort/index.ts";
 export * as Course from "./course/index.ts";
 export * as Curriculum from "./curriculum/index.ts";
+export {
+  type KwalificatieImportRow,
+  kwalificatieRichtingSchema,
+} from "./kss/bulk-import-kwalificaties.ts";
 export * as KSS from "./kss/index.ts";
 export * as Leercoach from "./leercoach/index.ts";
 export * as Location from "./location/index.ts";

--- a/packages/core/src/models/kss/bulk-import-kwalificaties.ts
+++ b/packages/core/src/models/kss/bulk-import-kwalificaties.ts
@@ -1,6 +1,6 @@
 import { schema as s } from "@nawadi/db";
 import dayjs from "dayjs";
-import { and, eq, isNull, or, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, or, sql } from "drizzle-orm";
 import { z } from "zod";
 import { useQuery, withTransaction } from "../../contexts/index.ts";
 import {
@@ -10,7 +10,15 @@ import {
   wrapCommand,
 } from "../../utils/index.ts";
 
-const richtingSchema = z.enum(["instructeur", "leercoach", "pvb_beoordelaar"]);
+export const kwalificatieRichtingSchema = z.enum([
+  "instructeur",
+  "leercoach",
+  "pvb_beoordelaar",
+]);
+
+const richtingSchema = kwalificatieRichtingSchema;
+
+const MAX_IMPORT_ROWS = 500;
 
 const importRowSchema = z.object({
   rowIndex: z.number().int().nonnegative(),
@@ -57,7 +65,7 @@ export const previewBulkImport = wrapCommand(
     z.object({
       locationId: uuidSchema,
       performedByPersonId: uuidSchema,
-      rows: z.array(importRowSchema),
+      rows: z.array(importRowSchema).max(MAX_IMPORT_ROWS),
     }),
     z.object({
       previewToken: z.string().uuid(),
@@ -100,7 +108,10 @@ export const previewBulkImport = wrapCommand(
           niveau: s.niveau.rang,
         })
         .from(s.kerntaakOnderdeel)
-        .innerJoin(s.kerntaak, eq(s.kerntaakOnderdeel.kerntaakId, s.kerntaak.id))
+        .innerJoin(
+          s.kerntaak,
+          eq(s.kerntaakOnderdeel.kerntaakId, s.kerntaak.id),
+        )
         .innerJoin(
           s.kwalificatieprofiel,
           eq(s.kerntaak.kwalificatieprofielId, s.kwalificatieprofiel.id),
@@ -110,21 +121,49 @@ export const previewBulkImport = wrapCommand(
       let totalToAdd = 0;
       let totalToSkip = 0;
 
+      const instructorLookup = await loadInstructorLookup(
+        query,
+        input.locationId,
+        input.rows,
+      );
+      const instructiegroepByCourseRichting =
+        await loadInstructiegroepByCourseRichting(query);
+      const existingKwalificatieIds = await loadExistingKwalificatieIds(
+        query,
+        instructorLookup.personIds,
+        courses.map((c) => c.id),
+      );
+
       for (const row of input.rows) {
-        const person = await resolvePersonAtLocation(
-          query,
-          input.locationId,
-          row,
-        );
-        if (!person) {
+        const personResult = instructorLookup.resolve(row);
+        if (personResult.kind === "missing_identifier") {
+          results.push({
+            rowIndex: row.rowIndex,
+            status: "error",
+            error: "E-mailadres of NWD-id is verplicht",
+          });
+          continue;
+        }
+        if (personResult.kind === "ambiguous") {
           results.push({
             rowIndex: row.rowIndex,
             status: "error",
             error:
-              "Persoon niet gevonden op deze locatie (zoek op e-mail of NWD-id)",
+              "Meerdere personen gevonden — gebruik alleen e-mail of alleen NWD-id",
           });
           continue;
         }
+        if (personResult.kind === "not_found") {
+          results.push({
+            rowIndex: row.rowIndex,
+            status: "error",
+            error:
+              "Persoon niet gevonden als instructeur op deze locatie (zoek op e-mail of NWD-id)",
+          });
+          continue;
+        }
+
+        const person = personResult.person;
 
         const course =
           courseByTitle.get(row.courseTitle.toLowerCase()) ??
@@ -139,23 +178,9 @@ export const previewBulkImport = wrapCommand(
           continue;
         }
 
-        const instructiegroep = await query
-          .select({ id: s.instructieGroep.id })
-          .from(s.instructieGroep)
-          .innerJoin(
-            s.instructieGroepCursus,
-            eq(s.instructieGroep.id, s.instructieGroepCursus.instructieGroepId),
-          )
-          .where(
-            and(
-              eq(s.instructieGroepCursus.courseId, course.id),
-              eq(s.instructieGroep.richting, row.richting),
-            ),
-          )
-          .limit(1)
-          .then((rows) => rows[0]);
-
-        if (!instructiegroep) {
+        if (
+          !instructiegroepByCourseRichting.has(`${course.id}:${row.richting}`)
+        ) {
           results.push({
             rowIndex: row.rowIndex,
             status: "error",
@@ -189,21 +214,9 @@ export const previewBulkImport = wrapCommand(
           continue;
         }
 
-        const existing = await query
-          .select({
-            kerntaakOnderdeelId: s.persoonKwalificatie.kerntaakOnderdeelId,
-          })
-          .from(s.persoonKwalificatie)
-          .where(
-            and(
-              eq(s.persoonKwalificatie.personId, person.id),
-              eq(s.persoonKwalificatie.courseId, course.id),
-            ),
-          );
-
-        const existingIds = new Set(
-          existing.map((e) => e.kerntaakOnderdeelId),
-        );
+        const existingIds =
+          existingKwalificatieIds.get(`${person.id}:${course.id}`) ??
+          new Set<string>();
 
         const toAdd: ResolvedKwalificatie[] = [];
         let toSkip = 0;
@@ -222,6 +235,7 @@ export const previewBulkImport = wrapCommand(
         }
 
         if (toAdd.length === 0) {
+          totalToSkip += toSkip;
           results.push({
             rowIndex: row.rowIndex,
             status: "error",
@@ -362,7 +376,7 @@ export const commitBulkImport = wrapCommand(
             throw new Error("Preview is al verwerkt of geblokkeerd");
           }
 
-          const values = readyRows.flatMap((row) =>
+          const rawValues = readyRows.flatMap((row) =>
             row.toAdd.map((item) => ({
               personId: item.personId,
               courseId: item.courseId,
@@ -377,8 +391,41 @@ export const commitBulkImport = wrapCommand(
             })),
           );
 
+          const courseIds = [...new Set(rawValues.map((v) => v.courseId))];
+          const activeCourseIds =
+            courseIds.length === 0
+              ? new Set<string>()
+              : new Set(
+                  (
+                    await tx
+                      .select({ id: s.course.id })
+                      .from(s.course)
+                      .where(
+                        and(
+                          inArray(s.course.id, courseIds),
+                          isNull(s.course.deletedAt),
+                        ),
+                      )
+                  ).map((c) => c.id),
+                );
+
+          const seen = new Set<string>();
+          const values = rawValues.filter((item) => {
+            if (!activeCourseIds.has(item.courseId)) {
+              return false;
+            }
+            const key = `${item.personId}:${item.courseId}:${item.kerntaakOnderdeelId}`;
+            if (seen.has(key)) {
+              return false;
+            }
+            seen.add(key);
+            return true;
+          });
+
           let added = 0;
-          const skipped = readyRows.reduce((sum, row) => sum + row.toSkip, 0);
+          const skipped =
+            readyRows.reduce((sum, row) => sum + row.toSkip, 0) +
+            (rawValues.length - values.length);
 
           if (values.length > 0) {
             const inserted = await tx
@@ -441,31 +488,108 @@ function resolveMatchingKerntaakOnderdelen(
   return { matching: candidates };
 }
 
-async function resolvePersonAtLocation(
+async function loadInstructiegroepByCourseRichting(
+  query: ReturnType<typeof useQuery>,
+) {
+  const rows = await query
+    .select({
+      courseId: s.instructieGroepCursus.courseId,
+      richting: s.instructieGroep.richting,
+    })
+    .from(s.instructieGroepCursus)
+    .innerJoin(
+      s.instructieGroep,
+      eq(s.instructieGroepCursus.instructieGroepId, s.instructieGroep.id),
+    );
+
+  return new Set(rows.map((row) => `${row.courseId}:${row.richting}`));
+}
+
+async function loadExistingKwalificatieIds(
+  query: ReturnType<typeof useQuery>,
+  personIds: string[],
+  courseIds: string[],
+) {
+  const map = new Map<string, Set<string>>();
+
+  if (personIds.length === 0 || courseIds.length === 0) {
+    return map;
+  }
+
+  const rows = await query
+    .select({
+      personId: s.persoonKwalificatie.personId,
+      courseId: s.persoonKwalificatie.courseId,
+      kerntaakOnderdeelId: s.persoonKwalificatie.kerntaakOnderdeelId,
+    })
+    .from(s.persoonKwalificatie)
+    .where(
+      and(
+        inArray(s.persoonKwalificatie.personId, personIds),
+        inArray(s.persoonKwalificatie.courseId, courseIds),
+      ),
+    );
+
+  for (const row of rows) {
+    const key = `${row.personId}:${row.courseId}`;
+    const set = map.get(key) ?? new Set<string>();
+    set.add(row.kerntaakOnderdeelId);
+    map.set(key, set);
+  }
+
+  return map;
+}
+
+type InstructorPerson = {
+  id: string;
+  firstName: string;
+  lastNamePrefix: string | null;
+  lastName: string | null;
+  email: string | null;
+  handle: string | null;
+};
+
+type PersonLookupResult =
+  | { kind: "found"; person: InstructorPerson }
+  | { kind: "not_found" }
+  | { kind: "ambiguous" }
+  | { kind: "missing_identifier" };
+
+async function loadInstructorLookup(
   query: ReturnType<typeof useQuery>,
   locationId: string,
-  row: KwalificatieImportRow,
+  rows: KwalificatieImportRow[],
 ) {
-  if (!row.email && !row.nwdId) {
-    return null;
+  const emails = [
+    ...new Set(rows.map((row) => row.email).filter(Boolean)),
+  ] as string[];
+  const nwdIds = [
+    ...new Set(rows.map((row) => row.nwdId).filter(Boolean)),
+  ] as string[];
+
+  if (emails.length === 0 && nwdIds.length === 0) {
+    return {
+      personIds: [] as string[],
+      resolve: (): PersonLookupResult => ({ kind: "missing_identifier" }),
+    };
   }
 
-  const conditions = [];
-
-  if (row.email) {
-    conditions.push(eq(s.user.email, row.email));
+  const matchConditions = [];
+  if (emails.length > 0) {
+    matchConditions.push(inArray(s.user.email, emails));
+  }
+  if (nwdIds.length > 0) {
+    matchConditions.push(inArray(s.person.handle, nwdIds));
   }
 
-  if (row.nwdId) {
-    conditions.push(eq(s.person.handle, row.nwdId));
-  }
-
-  const persons = await query
+  const instructors = await query
     .select({
       id: s.person.id,
       firstName: s.person.firstName,
       lastNamePrefix: s.person.lastNamePrefix,
       lastName: s.person.lastName,
+      email: s.user.email,
+      handle: s.person.handle,
     })
     .from(s.person)
     .innerJoin(
@@ -476,18 +600,73 @@ async function resolvePersonAtLocation(
         eq(s.personLocationLink.status, "linked"),
       ),
     )
+    .innerJoin(
+      s.actor,
+      and(
+        eq(s.actor.personId, s.person.id),
+        eq(s.actor.locationId, locationId),
+        eq(s.actor.type, "instructor"),
+        isNull(s.actor.deletedAt),
+      ),
+    )
     .leftJoin(s.user, eq(s.user.authUserId, s.person.userId))
     .where(
       and(
         isNull(s.person.deletedAt),
-        conditions.length > 0 ? or(...conditions) : undefined,
+        matchConditions.length > 0 ? or(...matchConditions) : undefined,
       ),
-    )
-    .limit(2);
+    );
 
-  if (persons.length !== 1) {
-    return null;
+  const byEmail = new Map<string, InstructorPerson[]>();
+  const byHandle = new Map<string, InstructorPerson[]>();
+
+  for (const person of instructors) {
+    if (person.email) {
+      const list = byEmail.get(person.email) ?? [];
+      list.push(person);
+      byEmail.set(person.email, list);
+    }
+    if (person.handle) {
+      const handleList = byHandle.get(person.handle) ?? [];
+      handleList.push(person);
+      byHandle.set(person.handle, handleList);
+    }
   }
 
-  return persons[0] ?? null;
+  const resolve = (row: KwalificatieImportRow): PersonLookupResult => {
+    if (!row.email && !row.nwdId) {
+      return { kind: "missing_identifier" };
+    }
+
+    const matches = new Map<string, InstructorPerson>();
+    if (row.email) {
+      for (const person of byEmail.get(row.email) ?? []) {
+        matches.set(person.id, person);
+      }
+    }
+    if (row.nwdId) {
+      for (const person of byHandle.get(row.nwdId) ?? []) {
+        matches.set(person.id, person);
+      }
+    }
+
+    if (matches.size === 0) {
+      return { kind: "not_found" };
+    }
+    if (matches.size > 1) {
+      return { kind: "ambiguous" };
+    }
+
+    const person = [...matches.values()][0];
+    if (!person) {
+      return { kind: "not_found" };
+    }
+
+    return { kind: "found", person };
+  };
+
+  return {
+    personIds: instructors.map((person) => person.id),
+    resolve,
+  };
 }

--- a/packages/core/src/models/kss/bulk-import-kwalificaties.ts
+++ b/packages/core/src/models/kss/bulk-import-kwalificaties.ts
@@ -1,0 +1,493 @@
+import { schema as s } from "@nawadi/db";
+import dayjs from "dayjs";
+import { and, eq, isNull, or, sql } from "drizzle-orm";
+import { z } from "zod";
+import { useQuery, withTransaction } from "../../contexts/index.ts";
+import {
+  possibleSingleRow,
+  uuidSchema,
+  withZod,
+  wrapCommand,
+} from "../../utils/index.ts";
+
+const richtingSchema = z.enum(["instructeur", "leercoach", "pvb_beoordelaar"]);
+
+const importRowSchema = z.object({
+  rowIndex: z.number().int().nonnegative(),
+  email: z.string().trim().toLowerCase().email().optional(),
+  nwdId: z.string().trim().optional(),
+  courseTitle: z.string().trim().min(1),
+  richting: richtingSchema,
+  niveau: z.number().int().min(1).max(5),
+  kerntaakTitel: z.string().trim().optional(),
+  opmerkingen: z.string().trim().optional(),
+});
+
+export type KwalificatieImportRow = z.infer<typeof importRowSchema>;
+
+type ResolvedKwalificatie = {
+  personId: string;
+  courseId: string;
+  kerntaakOnderdeelId: string;
+  opmerkingen?: string;
+};
+
+type PreviewRowResult =
+  | {
+      rowIndex: number;
+      status: "ready";
+      personName: string;
+      courseTitle: string;
+      kwalificatieLabel: string;
+      kerntaakOnderdeelCount: number;
+      toAdd: ResolvedKwalificatie[];
+      toSkip: number;
+    }
+  | {
+      rowIndex: number;
+      status: "error";
+      error: string;
+    };
+
+const BULK_KWALIFICATIE_PREVIEW_TTL_MINUTES = 60;
+
+export const previewBulkImport = wrapCommand(
+  "kss.bulkImportKwalificaties.preview",
+  withZod(
+    z.object({
+      locationId: uuidSchema,
+      performedByPersonId: uuidSchema,
+      rows: z.array(importRowSchema),
+    }),
+    z.object({
+      previewToken: z.string().uuid(),
+      results: z.array(z.custom<PreviewRowResult>()),
+      summary: z.object({
+        ready: z.number().int(),
+        errors: z.number().int(),
+        totalKwalificatiesToAdd: z.number().int(),
+        totalKwalificatiesToSkip: z.number().int(),
+      }),
+    }),
+    async (input) => {
+      const query = useQuery();
+      const results: PreviewRowResult[] = [];
+
+      const courses = await query
+        .select({
+          id: s.course.id,
+          title: s.course.title,
+          handle: s.course.handle,
+        })
+        .from(s.course)
+        .where(isNull(s.course.deletedAt));
+
+      const courseByTitle = new Map(
+        courses.map((c) => [c.title?.toLowerCase() ?? "", c]),
+      );
+      const courseByHandle = new Map(
+        courses.map((c) => [c.handle.toLowerCase(), c]),
+      );
+
+      const kerntaakOnderdelen = await query
+        .select({
+          id: s.kerntaakOnderdeel.id,
+          type: s.kerntaakOnderdeel.type,
+          kerntaakTitel: s.kerntaak.titel,
+          kwalificatieprofielId: s.kwalificatieprofiel.id,
+          kwalificatieprofielTitel: s.kwalificatieprofiel.titel,
+          richting: s.kwalificatieprofiel.richting,
+          niveau: s.niveau.rang,
+        })
+        .from(s.kerntaakOnderdeel)
+        .innerJoin(s.kerntaak, eq(s.kerntaakOnderdeel.kerntaakId, s.kerntaak.id))
+        .innerJoin(
+          s.kwalificatieprofiel,
+          eq(s.kerntaak.kwalificatieprofielId, s.kwalificatieprofiel.id),
+        )
+        .innerJoin(s.niveau, eq(s.kwalificatieprofiel.niveauId, s.niveau.id));
+
+      let totalToAdd = 0;
+      let totalToSkip = 0;
+
+      for (const row of input.rows) {
+        const person = await resolvePersonAtLocation(
+          query,
+          input.locationId,
+          row,
+        );
+        if (!person) {
+          results.push({
+            rowIndex: row.rowIndex,
+            status: "error",
+            error:
+              "Persoon niet gevonden op deze locatie (zoek op e-mail of NWD-id)",
+          });
+          continue;
+        }
+
+        const course =
+          courseByTitle.get(row.courseTitle.toLowerCase()) ??
+          courseByHandle.get(row.courseTitle.toLowerCase());
+
+        if (!course) {
+          results.push({
+            rowIndex: row.rowIndex,
+            status: "error",
+            error: `Cursus niet gevonden: ${row.courseTitle}`,
+          });
+          continue;
+        }
+
+        const instructiegroep = await query
+          .select({ id: s.instructieGroep.id })
+          .from(s.instructieGroep)
+          .innerJoin(
+            s.instructieGroepCursus,
+            eq(s.instructieGroep.id, s.instructieGroepCursus.instructieGroepId),
+          )
+          .where(
+            and(
+              eq(s.instructieGroepCursus.courseId, course.id),
+              eq(s.instructieGroep.richting, row.richting),
+            ),
+          )
+          .limit(1)
+          .then((rows) => rows[0]);
+
+        if (!instructiegroep) {
+          results.push({
+            rowIndex: row.rowIndex,
+            status: "error",
+            error: `Cursus is niet gekoppeld aan een instructiegroep voor richting ${row.richting}`,
+          });
+          continue;
+        }
+
+        const matchingResult = resolveMatchingKerntaakOnderdelen(
+          kerntaakOnderdelen,
+          row,
+        );
+
+        if ("error" in matchingResult) {
+          results.push({
+            rowIndex: row.rowIndex,
+            status: "error",
+            error: matchingResult.error,
+          });
+          continue;
+        }
+
+        const matchingOnderdelen = matchingResult.matching;
+
+        if (matchingOnderdelen.length === 0) {
+          results.push({
+            rowIndex: row.rowIndex,
+            status: "error",
+            error: `Geen kerntaak-onderdelen gevonden voor ${row.richting} niveau ${row.niveau}`,
+          });
+          continue;
+        }
+
+        const existing = await query
+          .select({
+            kerntaakOnderdeelId: s.persoonKwalificatie.kerntaakOnderdeelId,
+          })
+          .from(s.persoonKwalificatie)
+          .where(
+            and(
+              eq(s.persoonKwalificatie.personId, person.id),
+              eq(s.persoonKwalificatie.courseId, course.id),
+            ),
+          );
+
+        const existingIds = new Set(
+          existing.map((e) => e.kerntaakOnderdeelId),
+        );
+
+        const toAdd: ResolvedKwalificatie[] = [];
+        let toSkip = 0;
+
+        for (const ko of matchingOnderdelen) {
+          if (existingIds.has(ko.id)) {
+            toSkip++;
+            continue;
+          }
+          toAdd.push({
+            personId: person.id,
+            courseId: course.id,
+            kerntaakOnderdeelId: ko.id,
+            opmerkingen: row.opmerkingen,
+          });
+        }
+
+        if (toAdd.length === 0) {
+          results.push({
+            rowIndex: row.rowIndex,
+            status: "error",
+            error: "Alle kwalificaties bestaan al voor deze persoon en cursus",
+          });
+          continue;
+        }
+
+        totalToAdd += toAdd.length;
+        totalToSkip += toSkip;
+
+        const profielLabel = matchingOnderdelen[0]?.kwalificatieprofielTitel;
+
+        results.push({
+          rowIndex: row.rowIndex,
+          status: "ready",
+          personName: [person.firstName, person.lastNamePrefix, person.lastName]
+            .filter(Boolean)
+            .join(" "),
+          courseTitle: course.title ?? course.handle,
+          kwalificatieLabel: `${profielLabel ?? row.richting} (niveau ${row.niveau})`,
+          kerntaakOnderdeelCount: toAdd.length,
+          toAdd,
+          toSkip,
+        });
+      }
+
+      const expiresAt = new Date(
+        Date.now() + BULK_KWALIFICATIE_PREVIEW_TTL_MINUTES * 60 * 1000,
+      ).toISOString();
+
+      const [preview] = await query
+        .insert(s.bulkImportPreview)
+        .values({
+          locationId: input.locationId,
+          createdByPersonId: input.performedByPersonId,
+          targetCohortId: null,
+          detectionSnapshot: {},
+          rowsParsed: {
+            kind: "kwalificatie_import",
+            rows: results,
+          },
+          attempt: 1,
+          status: "active",
+          expiresAt,
+        })
+        .returning({ token: s.bulkImportPreview.token });
+
+      if (!preview) {
+        throw new Error("Kon preview niet opslaan");
+      }
+
+      const ready = results.filter((r) => r.status === "ready").length;
+      const errors = results.filter((r) => r.status === "error").length;
+
+      return {
+        previewToken: preview.token,
+        results,
+        summary: {
+          ready,
+          errors,
+          totalKwalificatiesToAdd: totalToAdd,
+          totalKwalificatiesToSkip: totalToSkip,
+        },
+      };
+    },
+  ),
+);
+
+export const commitBulkImport = wrapCommand(
+  "kss.bulkImportKwalificaties.commit",
+  withZod(
+    z.object({
+      previewToken: uuidSchema,
+      performedByPersonId: uuidSchema,
+      toegevoegdDoorActorId: uuidSchema.optional(),
+      defaultOpmerkingen: z.string().optional(),
+    }),
+    z.object({
+      added: z.number().int(),
+      skipped: z.number().int(),
+    }),
+    async (input) => {
+      const query = useQuery();
+
+      const previewRow = await query
+        .select()
+        .from(s.bulkImportPreview)
+        .where(eq(s.bulkImportPreview.token, input.previewToken))
+        .then(possibleSingleRow);
+
+      if (!previewRow) {
+        throw new Error("Preview niet gevonden of verlopen");
+      }
+      if (previewRow.status !== "active") {
+        throw new Error("Preview is al verwerkt of geblokkeerd");
+      }
+      if (previewRow.createdByPersonId !== input.performedByPersonId) {
+        throw new Error("Preview hoort niet bij deze gebruiker");
+      }
+      if (dayjs(previewRow.expiresAt).isBefore(dayjs())) {
+        throw new Error("Preview verlopen — plak opnieuw");
+      }
+
+      const payload = previewRow.rowsParsed as {
+        kind: string;
+        rows: PreviewRowResult[];
+      };
+
+      if (payload.kind !== "kwalificatie_import") {
+        throw new Error("Ongeldige preview");
+      }
+
+      const readyRows = payload.rows.filter(
+        (r): r is Extract<PreviewRowResult, { status: "ready" }> =>
+          r.status === "ready",
+      );
+
+      return withTransaction(
+        async () => {
+          const tx = useQuery();
+
+          const locked = await tx
+            .update(s.bulkImportPreview)
+            .set({
+              status: "committed",
+              committedAt: sql`NOW()`,
+            })
+            .where(
+              and(
+                eq(s.bulkImportPreview.token, input.previewToken),
+                eq(s.bulkImportPreview.status, "active"),
+              ),
+            )
+            .returning({ token: s.bulkImportPreview.token });
+
+          if (locked.length === 0) {
+            throw new Error("Preview is al verwerkt of geblokkeerd");
+          }
+
+          const values = readyRows.flatMap((row) =>
+            row.toAdd.map((item) => ({
+              personId: item.personId,
+              courseId: item.courseId,
+              kerntaakOnderdeelId: item.kerntaakOnderdeelId,
+              verkregenReden: "onbekend" as const,
+              opmerkingen:
+                item.opmerkingen ??
+                input.defaultOpmerkingen ??
+                "Geïmporteerd via secretariaat",
+              toegevoegdDoor: input.toegevoegdDoorActorId,
+              toegevoegdOp: new Date().toISOString(),
+            })),
+          );
+
+          let added = 0;
+          const skipped = readyRows.reduce((sum, row) => sum + row.toSkip, 0);
+
+          if (values.length > 0) {
+            const inserted = await tx
+              .insert(s.persoonKwalificatie)
+              .values(values)
+              .onConflictDoNothing({
+                target: [
+                  s.persoonKwalificatie.personId,
+                  s.persoonKwalificatie.courseId,
+                  s.persoonKwalificatie.kerntaakOnderdeelId,
+                ],
+              })
+              .returning({ id: s.persoonKwalificatie.id });
+
+            added = inserted.length;
+          }
+
+          return { added, skipped };
+        },
+        { isolationLevel: "read committed" },
+      );
+    },
+  ),
+);
+
+type KerntaakOnderdeelRow = {
+  id: string;
+  type: "portfolio" | "praktijk";
+  kerntaakTitel: string;
+  kwalificatieprofielId: string;
+  kwalificatieprofielTitel: string;
+  richting: "instructeur" | "leercoach" | "pvb_beoordelaar";
+  niveau: number;
+};
+
+function resolveMatchingKerntaakOnderdelen(
+  kerntaakOnderdelen: KerntaakOnderdeelRow[],
+  row: KwalificatieImportRow,
+): { matching: KerntaakOnderdeelRow[] } | { error: string } {
+  let candidates = kerntaakOnderdelen.filter(
+    (ko) => ko.richting === row.richting && ko.niveau === row.niveau,
+  );
+
+  if (row.kerntaakTitel) {
+    candidates = candidates.filter(
+      (ko) =>
+        ko.kerntaakTitel.toLowerCase() === row.kerntaakTitel?.toLowerCase(),
+    );
+    return { matching: candidates };
+  }
+
+  const profielIds = new Set(candidates.map((ko) => ko.kwalificatieprofielId));
+  if (profielIds.size > 1) {
+    return {
+      error:
+        "Meerdere kwalificatieprofielen gevonden voor deze richting en niveau — vul de Kerntaak-kolom in",
+    };
+  }
+
+  return { matching: candidates };
+}
+
+async function resolvePersonAtLocation(
+  query: ReturnType<typeof useQuery>,
+  locationId: string,
+  row: KwalificatieImportRow,
+) {
+  if (!row.email && !row.nwdId) {
+    return null;
+  }
+
+  const conditions = [];
+
+  if (row.email) {
+    conditions.push(eq(s.user.email, row.email));
+  }
+
+  if (row.nwdId) {
+    conditions.push(eq(s.person.handle, row.nwdId));
+  }
+
+  const persons = await query
+    .select({
+      id: s.person.id,
+      firstName: s.person.firstName,
+      lastNamePrefix: s.person.lastNamePrefix,
+      lastName: s.person.lastName,
+    })
+    .from(s.person)
+    .innerJoin(
+      s.personLocationLink,
+      and(
+        eq(s.personLocationLink.personId, s.person.id),
+        eq(s.personLocationLink.locationId, locationId),
+        eq(s.personLocationLink.status, "linked"),
+      ),
+    )
+    .leftJoin(s.user, eq(s.user.authUserId, s.person.userId))
+    .where(
+      and(
+        isNull(s.person.deletedAt),
+        conditions.length > 0 ? or(...conditions) : undefined,
+      ),
+    )
+    .limit(2);
+
+  if (persons.length !== 1) {
+    return null;
+  }
+
+  return persons[0] ?? null;
+}

--- a/packages/core/src/models/kss/index.ts
+++ b/packages/core/src/models/kss/index.ts
@@ -3,4 +3,5 @@ export * from "./instructiegroep.schema.ts";
 export * as InstructieGroep from "./instructiegroep.ts";
 export * from "./kwalificatieprofiel.schema.ts";
 export * as Kwalificatieprofiel from "./kwalificatieprofiel.ts";
+export * as BulkImportKwalificaties from "./bulk-import-kwalificaties.ts";
 export * as Kwalificaties from "./kwalificaties.ts";

--- a/packages/core/src/models/kss/index.ts
+++ b/packages/core/src/models/kss/index.ts
@@ -1,7 +1,12 @@
 // Export schemas for external use
+
+export * as BulkImportKwalificaties from "./bulk-import-kwalificaties.ts";
+export {
+  type KwalificatieImportRow,
+  kwalificatieRichtingSchema,
+} from "./bulk-import-kwalificaties.ts";
 export * from "./instructiegroep.schema.ts";
 export * as InstructieGroep from "./instructiegroep.ts";
 export * from "./kwalificatieprofiel.schema.ts";
 export * as Kwalificatieprofiel from "./kwalificatieprofiel.ts";
-export * as BulkImportKwalificaties from "./bulk-import-kwalificaties.ts";
 export * as Kwalificaties from "./kwalificaties.ts";

--- a/packages/core/src/models/location/index.ts
+++ b/packages/core/src/models/location/index.ts
@@ -1,2 +1,3 @@
 export * from "./location.ts";
+export * as Onboarding from "./onboarding.ts";
 export * as Person from "./person.ts";

--- a/packages/core/src/models/location/onboarding.ts
+++ b/packages/core/src/models/location/onboarding.ts
@@ -84,40 +84,50 @@ export const linkInstructor = wrapCommand(
   ),
 );
 
+const createPersonInputSchema = z.object({
+  locationId: uuidSchema,
+  email: z.string().trim().toLowerCase().email().optional(),
+  firstName: z.string().trim().min(1),
+  lastNamePrefix: z.string().trim().nullable(),
+  lastName: z.string().trim().min(1),
+  dateOfBirth: z.string(),
+  birthCity: z.string().trim().min(1),
+  birthCountry: z.string().trim().min(2),
+});
+
+const actorRoleSchema = z.enum(["student", "instructor", "location_admin"]);
+
+async function createPersonRecord(
+  input: z.infer<typeof createPersonInputSchema>,
+) {
+  let userId: string | undefined;
+
+  if (input.email) {
+    const user = await User.getOrCreateFromEmail({
+      email: input.email,
+      displayName: input.firstName,
+    });
+    userId = user.id;
+  }
+
+  return User.Person.getOrCreate({
+    userId,
+    firstName: input.firstName,
+    lastName: input.lastName,
+    lastNamePrefix: input.lastNamePrefix,
+    dateOfBirth: input.dateOfBirth,
+    birthCity: input.birthCity,
+    birthCountry: input.birthCountry,
+  });
+}
+
 export const createPersonAndLinkInstructor = wrapCommand(
   "location.onboarding.createPersonAndLinkInstructor",
   withZod(
-    z.object({
-      locationId: uuidSchema,
-      email: z.string().trim().toLowerCase().email().optional(),
-      firstName: z.string().trim().min(1),
-      lastNamePrefix: z.string().trim().nullable(),
-      lastName: z.string().trim().min(1),
-      dateOfBirth: z.string(),
-      birthCity: z.string().trim().min(1),
-      birthCountry: z.string().trim().min(2),
-    }),
+    createPersonInputSchema,
     z.object({ personId: uuidSchema }),
     async (input) => {
-      let userId: string | undefined;
-
-      if (input.email) {
-        const user = await User.getOrCreateFromEmail({
-          email: input.email,
-          displayName: input.firstName,
-        });
-        userId = user.id;
-      }
-
-      const person = await User.Person.getOrCreate({
-        userId,
-        firstName: input.firstName,
-        lastName: input.lastName,
-        lastNamePrefix: input.lastNamePrefix,
-        dateOfBirth: input.dateOfBirth,
-        birthCity: input.birthCity,
-        birthCountry: input.birthCountry,
-      });
+      const person = await createPersonRecord(input);
 
       await User.Person.linkToLocation({
         personId: person.id,
@@ -129,6 +139,34 @@ export const createPersonAndLinkInstructor = wrapCommand(
         locationId: input.locationId,
         type: "instructor",
       });
+
+      return { personId: person.id };
+    },
+  ),
+);
+
+export const createPersonWithRoles = wrapCommand(
+  "location.onboarding.createPersonWithRoles",
+  withZod(
+    createPersonInputSchema.extend({
+      roles: z.array(actorRoleSchema).min(1),
+    }),
+    z.object({ personId: uuidSchema }),
+    async (input) => {
+      const person = await createPersonRecord(input);
+
+      await User.Person.linkToLocation({
+        personId: person.id,
+        locationId: input.locationId,
+      });
+
+      for (const role of input.roles) {
+        await User.Actor.upsert({
+          personId: person.id,
+          locationId: input.locationId,
+          type: role,
+        });
+      }
 
       return { personId: person.id };
     },

--- a/packages/core/src/models/location/onboarding.ts
+++ b/packages/core/src/models/location/onboarding.ts
@@ -1,0 +1,136 @@
+import { schema as s } from "@nawadi/db";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { useQuery } from "../../contexts/index.ts";
+import { uuidSchema, withZod, wrapCommand } from "../../utils/index.ts";
+import { User } from "../index.ts";
+import { create as createLocation } from "./location.ts";
+
+export const createForOnboarding = wrapCommand(
+  "location.onboarding.create",
+  withZod(
+    z.object({
+      handle: z
+        .string()
+        .trim()
+        .toLowerCase()
+        .min(3)
+        .regex(/^[a-z0-9-]+$/),
+      name: z.string().trim().min(1),
+      websiteUrl: z.string().url().optional(),
+    }),
+    z.object({ id: uuidSchema }),
+    async (input) => {
+      const query = useQuery();
+
+      const existing = await query
+        .select({ id: s.location.id })
+        .from(s.location)
+        .where(eq(s.location.handle, input.handle))
+        .limit(1);
+
+      if (existing.length > 0) {
+        throw new Error(
+          "Deze handle is al in gebruik — kies een andere handle",
+        );
+      }
+
+      return createLocation({
+        handle: input.handle,
+        name: input.name,
+        websiteUrl: input.websiteUrl,
+      });
+    },
+  ),
+);
+
+export const linkLocationAdmin = wrapCommand(
+  "location.onboarding.linkLocationAdmin",
+  withZod(
+    z.object({ personId: uuidSchema, locationId: uuidSchema }),
+    z.void(),
+    async (input) => {
+      await User.Person.ensureLocationLinkForAdmin({
+        personId: input.personId,
+        locationId: input.locationId,
+      });
+
+      await User.Actor.upsert({
+        personId: input.personId,
+        locationId: input.locationId,
+        type: "location_admin",
+      });
+    },
+  ),
+);
+
+export const linkInstructor = wrapCommand(
+  "location.onboarding.linkInstructor",
+  withZod(
+    z.object({ personId: uuidSchema, locationId: uuidSchema }),
+    z.void(),
+    async (input) => {
+      await User.Person.linkToLocation({
+        personId: input.personId,
+        locationId: input.locationId,
+      });
+
+      await User.Actor.upsert({
+        personId: input.personId,
+        locationId: input.locationId,
+        type: "instructor",
+      });
+    },
+  ),
+);
+
+export const createPersonAndLinkInstructor = wrapCommand(
+  "location.onboarding.createPersonAndLinkInstructor",
+  withZod(
+    z.object({
+      locationId: uuidSchema,
+      email: z.string().trim().toLowerCase().email().optional(),
+      firstName: z.string().trim().min(1),
+      lastNamePrefix: z.string().trim().nullable(),
+      lastName: z.string().trim().min(1),
+      dateOfBirth: z.string(),
+      birthCity: z.string().trim().min(1),
+      birthCountry: z.string().trim().min(2),
+    }),
+    z.object({ personId: uuidSchema }),
+    async (input) => {
+      let userId: string | undefined;
+
+      if (input.email) {
+        const user = await User.getOrCreateFromEmail({
+          email: input.email,
+          displayName: input.firstName,
+        });
+        userId = user.id;
+      }
+
+      const person = await User.Person.getOrCreate({
+        userId,
+        firstName: input.firstName,
+        lastName: input.lastName,
+        lastNamePrefix: input.lastNamePrefix,
+        dateOfBirth: input.dateOfBirth,
+        birthCity: input.birthCity,
+        birthCountry: input.birthCountry,
+      });
+
+      await User.Person.linkToLocation({
+        personId: person.id,
+        locationId: input.locationId,
+      });
+
+      await User.Actor.upsert({
+        personId: person.id,
+        locationId: input.locationId,
+        type: "instructor",
+      });
+
+      return { personId: person.id };
+    },
+  ),
+);

--- a/packages/core/src/models/user/person.ts
+++ b/packages/core/src/models/user/person.ts
@@ -917,39 +917,37 @@ export const linkToLocation = wrapCommand(
   ),
 );
 
-
 export const ensureLocationLinkForAdmin = wrapCommand(
   "user.person.ensureLocationLinkForAdmin",
   withZod(
-      z.object({ personId: uuidSchema, locationId: uuidSchema }),
-      z.void(),
-      async (input) => {
-        const query = useQuery();
+    z.object({ personId: uuidSchema, locationId: uuidSchema }),
+    z.void(),
+    async (input) => {
+      const query = useQuery();
 
-        await query
-          .insert(s.personLocationLink)
-          .values({
-            personId: input.personId,
-            locationId: input.locationId,
+      await query
+        .insert(s.personLocationLink)
+        .values({
+          personId: input.personId,
+          locationId: input.locationId,
+          status: "linked",
+          permissionLevel: "none",
+        })
+        .onConflictDoUpdate({
+          target: [
+            s.personLocationLink.personId,
+            s.personLocationLink.locationId,
+          ],
+          set: {
             status: "linked",
-            permissionLevel: "none",
-          })
-          .onConflictDoUpdate({
-            target: [
-              s.personLocationLink.personId,
-              s.personLocationLink.locationId,
-            ],
-            set: {
-              status: "linked",
-              revokedAt: null,
-              removedAt: null,
-              linkedAt: sql`NOW()`
-            },
-          });
-      },
+            revokedAt: null,
+            removedAt: null,
+            linkedAt: sql`NOW()`,
+          },
+        });
+    },
   ),
 );
-
 
 /**
  * Score a set of pasted candidate rows against the operator's location's

--- a/packages/core/src/models/user/person.ts
+++ b/packages/core/src/models/user/person.ts
@@ -917,6 +917,40 @@ export const linkToLocation = wrapCommand(
   ),
 );
 
+
+export const ensureLocationLinkForAdmin = wrapCommand(
+  "user.person.ensureLocationLinkForAdmin",
+  withZod(
+      z.object({ personId: uuidSchema, locationId: uuidSchema }),
+      z.void(),
+      async (input) => {
+        const query = useQuery();
+
+        await query
+          .insert(s.personLocationLink)
+          .values({
+            personId: input.personId,
+            locationId: input.locationId,
+            status: "linked",
+            permissionLevel: "none",
+          })
+          .onConflictDoUpdate({
+            target: [
+              s.personLocationLink.personId,
+              s.personLocationLink.locationId,
+            ],
+            set: {
+              status: "linked",
+              revokedAt: null,
+              removedAt: null,
+              linkedAt: sql`NOW()`
+            },
+          });
+      },
+  ),
+);
+
+
 /**
  * Score a set of pasted candidate rows against the operator's location's
  * linked-active persons. Returns matches grouped by row index plus the


### PR DESCRIPTION
## Summary

Adds a **secretariaat location onboarding hub** so NWD staff can set up vaarlocaties without CLI access.

- **`/secretariaat/locaties`** — list locations (search + pagination), create new location (handle, name, website)
- **`/secretariaat/locaties/[id]`** — onboarding detail page with:
  - Location info + links (public page, operator dashboard `/cohorten`, instellingen)
  - Locatiebeheerders overview + add via person search
  - Cursussen and vaartuigen overview
  - Bulk instructor import (reuses operator paste → map → preview → commit flow)
  - Bulk KSS kwalificatie import (CSV paste → map → preview → commit)

### Core (`packages/core`)

- `Location.Onboarding` — create location, link admin/instructor, create person + link roles (`createPersonWithRoles`)
- `KSS.BulkImportKwalificaties` — preview/commit kwalificatie CSV with instructor-only matching, batched DB lookups, 500-row cap, commit-time course validation

### Web

- Sysadmin-scoped actions in `nwd.ts` with `assertSystemAdmin` + auto-provision performer person for accounts without linked person
- Shared `PersonSearchCombobox` extracted for merge-persons and locatiebeheerder dialogs
- `create-bulk-dialog` extended with `authVariant: "secretariat"` for instructor import reuse

### Review hardening (Bugbot + CodeRabbit)

- Instructor bulk import respects selected roles (no accidental instructor actor for admin-only imports)
- Kwalificatie import: show client parse errors in preview, instructor-only person lookup, ambiguous-match messaging, skip-count fix for fully duplicate rows
- Strip internal UUIDs from kwalificatie preview API response
- Person search combobox clears stale selection when user types a new query
- Duplicate locatiebeheerder assignment blocked with error toast
- `TextLink` adds `rel="noopener noreferrer"` for `target="_blank"`
- Stable React keys for course/boat lists; dialog remount via state not ref-during-render

### Vercel build fix

- Split `KWALIFICATIE_COLUMN_MAPPING` into `kwalificatie-bulk-import-constants.ts` so the client dialog does not import `@nawadi/core` via the parser
- Keeps CodeRabbit #4 intent: `kwalificatieRichtingSchema` stays shared from core on the server-only parser path
- Fixes Turbopack errors (`Can't resolve 'dns'/'fs'/'net'`) on preview deploys


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/buchungapp/codesmith/nationaal-watersportdiploma/pr/485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785966043&installation_id=137554715&pr_number=485&repository=buchungapp%2Fnationaal-watersportdiploma&return_to=https%3A%2F%2Fgithub.com%2Fbuchungapp%2Fnationaal-watersportdiploma%2Fpull%2F485&signature=2c111a4bc33ff1eb2d1cfad75ae50ac3a7c5a3087d5d19fe68c3a5c44f133812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> System-admin-only flows that create locations, assign location_admin/instructor roles, bulk-create/link persons, and write kwalificaties—errors or auth gaps would affect production identity and qualification data.
> 
> **Overview**
> Adds **secretariaat** management for vaarlocaties so system admins can onboard locations from the UI instead of CLI scripts.
> 
> **List & create** (`/secretariaat/locaties`): searchable/paginated overview, dialog to create a location (name/handle/website), and links into a per-location hub. Pages and server helpers are gated with `isSystemAdmin`; `listAllLocationsAsAdmin` lists all locations (not only active).
> 
> **Detail hub** (`/secretariaat/locaties/[id]`): location summary, quick links to public/operator/settings views, onboarding actions, and read-only overviews of locatiebeheerders, cursussen, and vaartuigen.
> 
> **Onboarding actions**: add a locatiebeheerder via person search; bulk-import instructeurs by reusing the existing person bulk dialog with a new `authVariant="secretariat"` that calls system-admin preview/commit actions; bulk-import kwalificaties via paste → column mapping → preview → commit.
> 
> **Backend**: new `Location.Onboarding` commands (create location, link admin/instructor, create person + instructor link) and `KSS.BulkImportKwalificaties` with preview tokens, expiry, and transactional commit into `persoonKwalificatie`. `~/lib/nwd` adds system-admin bulk-import wrappers and auto-provisions a performer person for audit when secretariat staff lack one.
> 
> **Refactors**: shared `PersonSearchCombobox` (used by merge-persons and add-admin); sidebar **Vaarlocaties** active state fixed (`locaties` vs mistaken `cohorten`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e73159240517e916b2b619f47652892005893fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added a secretariaat “Vaarlocaties” listing with search, pagination, and a location detail dashboard (overview, admins, and resources).
  * Added location management actions: create locations, add location admins, and bulk import instructors/qualifications with preview + commit and column mapping/validation.
  * Introduced dialogs for location onboarding (add admin, import instructors, import qualifications).
* **Bug Fixes**
  * Corrected sidebar active highlighting for the “Vaarlocaties” route.
  * Improved person selection behavior by clearing the selection reliably when updating search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->