### PR TITLE
import script for jachtzeilen A and B levels across all waterways

### DIFF
--- a/docs/designs/jachtzeilen-2601-import.md
+++ b/docs/designs/jachtzeilen-2601-import.md
@@ -1,0 +1,104 @@
+# Jachtzeilen 2601 import
+
+This import creates nine active curricula from the reviewed Jachtzeilen CSV:
+
+| Program | Competencies | Modules | Gear types |
+| --- | ---: | ---: | ---: |
+| Binnenwater 4 | 78 | 14 | 11 |
+| Binnenwater A | 81 | 14 | 11 |
+| Binnenwater B | 81 | 14 | 11 |
+| Ruim Binnenwater A | 88 | 15 | 11 |
+| Ruim Binnenwater B | 88 | 15 | 11 |
+| Waddenzee en Zeeuwse Stromen A | 92 | 17 | 11 |
+| Waddenzee en Zeeuwse Stromen B | 92 | 17 | 11 |
+| Zee A | 91 | 16 | 11 |
+| Zee B | 91 | 16 | 11 |
+
+All curricula use revision `2601` and start at `2026-01-01T00:00:00Z`.
+The reviewed CSV SHA-256 is
+`52a399b2dd2766efe251cb841e373eb083daa1ff1c0b1d594793b8a1dda064c6`.
+
+## Content rules
+
+- `V` is required and `O` is optional.
+- Blank V/O values are optional.
+- `Windoriëntatie` is an explicit exception and is required in all nine
+  curricula despite its blank V/O cell.
+- `O/V` is required for Binnenwater and Ruim Binnenwater and optional for
+  Waddenzee en Zeeuwse Stromen and Zee.
+- Empty requirement cells omit the competency; empty modules are omitted.
+- The combined lagerwal row is linked to both existing aankomen and afvaren
+  competencies.
+- Existing modules, competencies, and the exact 11 gear types from the
+  corresponding `2501` curricula are reused.
+- RR&P is created as `reisvoorbereiding-routering-en-planning`, titled
+  `Reisvoorbereiding, Routering en Planning (RR&P)`, directly after
+  `Reglementen`.
+- The two approved shared competency-title corrections are compare-and-set.
+- Requirement normalization is allowlist-only. Changed source links are stored
+  in the import manifest with complete before/after text; unchanged links are
+  represented by a count and hash.
+
+## Production-like local verification
+
+Export the sanitized catalog snapshot through the read-only production service:
+
+```sh
+pnpm --filter @nawadi/scripts jachtzeilen:catalog-snapshot -- \
+  export \
+  --service=nawadi_prod_ro \
+  --file=.jachtzeilen-catalog-snapshot.json
+```
+
+Load it into an isolated local PostgreSQL database:
+
+```sh
+pnpm --filter @nawadi/scripts jachtzeilen:catalog-snapshot -- \
+  load \
+  --file=.jachtzeilen-catalog-snapshot.json \
+  --pg-uri=postgresql://postgres:postgres@127.0.0.1:54322/nawadi_jachtzeilen_import_test \
+  --execute
+```
+
+Run the full lifecycle test:
+
+```sh
+pnpm --filter @nawadi/scripts import:jachtzeilen-ab -- \
+  verify-local \
+  --file=/absolute/path/to/jachtzeilen.csv \
+  --pg-uri=postgresql://postgres:postgres@127.0.0.1:54322/nawadi_jachtzeilen_import_test \
+  --execute
+```
+
+This verifies the initial import, exact counts and activation date, an
+idempotent rerun, fail-closed behavior, manifest generation, rollback, and
+re-import. It writes an attestation containing the tested catalog hash.
+
+## Production execution
+
+First run a read-only plan against the intended database. Production execution
+requires the exact catalog hash from the local attestation:
+
+```sh
+pnpm --filter @nawadi/scripts import:jachtzeilen-ab -- \
+  import \
+  --file=/absolute/path/to/jachtzeilen.csv \
+  --pg-uri="$PGURI" \
+  --expected-catalog-hash=SHA256_FROM_LOCAL_ATTESTATION \
+  --execute
+```
+
+The import runs in one serializable transaction and fails closed on unexpected
+programs, curricula, links, requirements, requiredness, titles, source hash, or
+catalog hash.
+
+Rollback is allowed for active imported curricula only while no students or
+certificates are linked:
+
+```sh
+pnpm --filter @nawadi/scripts import:jachtzeilen-ab -- \
+  rollback \
+  --manifest=/absolute/path/to/import-manifest.json \
+  --pg-uri="$PGURI" \
+  --execute
+```

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -14,7 +14,8 @@
     "persons:duplicates:analyze": "tsx src/analyze-duplicate-persons.ts",
     "persons:duplicates:merge": "tsx src/batch-merge-duplicates.ts",
     "dev:seed-bulk-import": "tsx src/seed-bulk-import-fixtures.ts",
-    "import:jachtzeilen-ab": "tsx src/import-jachtzeilen-ab-programs.ts"
+    "import:jachtzeilen-ab": "tsx --tsconfig ../../tsconfig.source-runtime.json src/import-jachtzeilen-ab-programs.ts",
+    "jachtzeilen:catalog-snapshot": "tsx --tsconfig ../../tsconfig.source-runtime.json src/manage-jachtzeilen-catalog-snapshot.ts"
   },
   "dependencies": {
     "@nawadi/core": "workspace:^",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -13,7 +13,8 @@
     "typecheck": "tsc --noEmit",
     "persons:duplicates:analyze": "tsx src/analyze-duplicate-persons.ts",
     "persons:duplicates:merge": "tsx src/batch-merge-duplicates.ts",
-    "dev:seed-bulk-import": "tsx src/seed-bulk-import-fixtures.ts"
+    "dev:seed-bulk-import": "tsx src/seed-bulk-import-fixtures.ts",
+    "import:jachtzeilen-ab": "tsx src/import-jachtzeilen-ab-programs.ts"
   },
   "dependencies": {
     "@nawadi/core": "workspace:^",

--- a/packages/scripts/src/import-jachtzeilen-ab-programs.test.ts
+++ b/packages/scripts/src/import-jachtzeilen-ab-programs.test.ts
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  assertResolvedContentDecisions,
+  buildSourceImportPlan,
+  normalizeRequirement,
+  type ParsedSourceRow,
+  parseCliOptions,
+  parseWideJachtzeilenSheet,
+  resolveProgramHandle,
+} from "./import-jachtzeilen-ab-programs.ts";
+import type { JachtzeilenAbContentDecisions } from "./jachtzeilen-ab-content-decisions.ts";
+
+const resolvedDecisions = {
+  revision: "2601",
+  ambiguousOvRequired: "required-inland-optional-waddenzee-and-sea",
+  blankVoRequired: false,
+  combinedLagerwal: "split-existing-competencies",
+  rrp: "create-rrp-competency",
+} satisfies JachtzeilenAbContentDecisions;
+
+function makeWideRows(input?: {
+  moduleTitle?: string;
+  competencyTitle?: string;
+  vo?: string;
+  requirements?: string[];
+}): unknown[][] {
+  return [
+    [
+      "",
+      "",
+      "Discipline",
+      "Binnenwater",
+      "Binnenwater",
+      "Binnenwater",
+      "Ruim Binnenwater",
+      "Ruim Binnenwater",
+      "Wad en Zeegaten",
+      "Wad en Zeegaten",
+      "Zee",
+      "Zee",
+    ],
+    [
+      "Module",
+      "Verplicht op Optioneel (V/O)",
+      "Competentie",
+      "Niveau 4",
+      "Niveau A",
+      "Niveau B",
+      "Niveau A",
+      "Niveau B",
+      "Niveau A",
+      "Niveau B",
+      "Niveau A",
+      "Niveau B",
+    ],
+    [
+      input?.moduleTitle ?? "Basis",
+      input?.vo ?? "V",
+      input?.competencyTitle ?? "Aanslaan zeilen",
+      ...(input?.requirements ?? Array.from({ length: 9 }, () => "Eis")),
+    ],
+  ];
+}
+
+function parseFixture(input?: Parameters<typeof makeWideRows>[0]) {
+  return parseWideJachtzeilenSheet(makeWideRows(input), {
+    targetCount: 9,
+    sourceLinkCount: 9,
+  });
+}
+
+function buildFixturePlan(
+  sourceRows: ParsedSourceRow[],
+  materializedLinkCount = sourceRows.length,
+) {
+  return buildSourceImportPlan({
+    sourceRows,
+    sourceHash: "test",
+    decisions: resolvedDecisions,
+    expected: {
+      targetCount: 9,
+      materializedLinkCount,
+    },
+  });
+}
+
+test("wide parser imports Binnenwater 4 and all eight A/B columns", () => {
+  const rows = parseFixture();
+
+  assert.equal(rows.length, 9);
+  assert.deepEqual(
+    new Set(rows.map((row) => row.niveau)),
+    new Set(["4", "a", "b"]),
+  );
+  assert.equal(
+    rows.filter((row) => row.niveau === "4")[0]?.vaarwater,
+    "Binnenwater",
+  );
+  assert.deepEqual(
+    new Set(rows.map((row) => row.vaarwater)),
+    new Set([
+      "Binnenwater",
+      "Ruim Binnenwater",
+      "Waddenzee en Zeeuwse Stromen",
+      "Zee",
+    ]),
+  );
+});
+
+test("program handles use the exact existing course handle", () => {
+  assert.equal(
+    resolveProgramHandle("Binnenwater", "4"),
+    "jacht-kajuitzeilen-binnenwater-volwassenen-4",
+  );
+  assert.equal(
+    resolveProgramHandle("Binnenwater", "a"),
+    "jacht-kajuitzeilen-binnenwater-volwassenen-a",
+  );
+  assert.equal(
+    resolveProgramHandle("Waddenzee en Zeeuwse Stromen", "b"),
+    "jacht-kajuitzeilen-waddenzee-en-zeeuwse-stromen-volwassenen-b",
+  );
+});
+
+test("O/V is required inland and optional on Waddenzee and Zee", () => {
+  const plan = buildFixturePlan(parseFixture({ vo: "O/V" }));
+
+  assert.ok(
+    plan.rows
+      .filter(
+        (row) =>
+          row.vaarwater === "Binnenwater" ||
+          row.vaarwater === "Ruim Binnenwater",
+      )
+      .every((row) => row.isRequired),
+  );
+  assert.ok(
+    plan.rows
+      .filter(
+        (row) =>
+          row.vaarwater === "Waddenzee en Zeeuwse Stromen" ||
+          row.vaarwater === "Zee",
+      )
+      .every((row) => !row.isRequired),
+  );
+});
+
+test("blank V/O values are optional", () => {
+  const plan = buildFixturePlan(parseFixture({ vo: "" }));
+  assert.ok(plan.rows.every((row) => !row.isRequired));
+});
+
+test("Windorientatie is required despite its blank V/O value", () => {
+  const plan = buildFixturePlan(
+    parseFixture({
+      moduleTitle: "Varen onder zeil",
+      competencyTitle: "Windorientatie",
+      vo: "",
+    }),
+  );
+  assert.ok(plan.rows.every((row) => row.isRequired));
+});
+
+test("combined lagerwal row splits into the two existing competencies", () => {
+  const sourceRows = parseFixture({
+    moduleTitle: "Plat- en rondbodemzeilen",
+    competencyTitle: 'Aankomen en afvaren lagerwal zonder motor "onder zeil"',
+    vo: "",
+  });
+  const plan = buildFixturePlan(sourceRows, 18);
+
+  assert.equal(plan.sourceRows.length, 9);
+  assert.equal(plan.rows.length, 18);
+  assert.deepEqual(
+    new Set(plan.rows.map((row) => row.competency.handle)),
+    new Set([
+      "aankomen-aan-een-lagerwal-zonder-motor-op-zeil",
+      "afvaren-van-een-lagerwal-zonder-motor-op-zeil",
+    ]),
+  );
+});
+
+test("known CSV title variants reuse production competency handles", () => {
+  const plan = buildFixturePlan(
+    parseFixture({
+      moduleTitle: "Varen onder zeil",
+      competencyTitle: "Sturen onder zeil",
+    }),
+  );
+
+  assert.deepEqual(
+    new Set(plan.rows.map((row) => row.competency.handle)),
+    new Set(["sturen-op-zeil"]),
+  );
+  assert.ok(plan.rows.every((row) => !row.competency.createIfMissing));
+});
+
+test("RR&P uses the approved new title and handle", () => {
+  const plan = buildFixturePlan(
+    parseFixture({
+      moduleTitle: "Theorie",
+      competencyTitle: "RR&P",
+      vo: "",
+    }),
+  );
+  assert.deepEqual(
+    new Set(plan.rows.map((row) => row.competency.handle)),
+    new Set(["reisvoorbereiding-routering-en-planning"]),
+  );
+  assert.ok(
+    plan.rows.every(
+      (row) =>
+        row.competency.title ===
+          "Reisvoorbereiding, Routering en Planning (RR&P)" &&
+        row.competency.createIfMissing,
+    ),
+  );
+});
+
+test("requirement normalization is allowlisted and auditable", () => {
+  const normalized = normalizeRequirement(
+    "  kan  aan komen op bij een wal  \r\n\r\n\r\nLet op op scheepvaart  ",
+  );
+  assert.equal(
+    normalized.normalized,
+    "Kan aankomen bij een wal\n\nLet op de scheepvaart.",
+  );
+  assert.deepEqual(
+    new Set(normalized.corrections),
+    new Set([
+      "line-endings",
+      "trim-whitespace",
+      "collapse-inline-whitespace",
+      "collapse-blank-lines",
+      "approved-spelling-or-grammar",
+      "sentence-start-capitalization",
+      "terminal-punctuation",
+    ]),
+  );
+});
+
+test("unresolved content decisions stop the import", () => {
+  assert.throws(
+    () =>
+      assertResolvedContentDecisions({
+        revision: "2601",
+        ambiguousOvRequired: null,
+        blankVoRequired: null,
+        combinedLagerwal: null,
+        rrp: null,
+      }),
+    /Unresolved content decisions/,
+  );
+});
+
+test("CLI is dry-run by default and production writes are explicit", () => {
+  assert.deepEqual(parseCliOptions(["plan", "--file=/tmp/source.csv"]), {
+    command: "plan",
+    execute: false,
+    filePath: "/tmp/source.csv",
+  });
+  assert.deepEqual(
+    parseCliOptions([
+      "import",
+      "--file=/tmp/source.csv",
+      "--expected-catalog-hash=abc",
+      "--execute",
+    ]),
+    {
+      command: "import",
+      execute: true,
+      filePath: "/tmp/source.csv",
+      expectedCatalogHash: "abc",
+    },
+  );
+});

--- a/packages/scripts/src/import-jachtzeilen-ab-programs.ts
+++ b/packages/scripts/src/import-jachtzeilen-ab-programs.ts
@@ -1,1040 +1,2246 @@
-import {
-  Course,
-  Curriculum,
-  useQuery,
-  withDatabase,
-  withSupabaseClient,
-  withTransaction,
-} from "@nawadi/core";
-import "dotenv/config";
-import assert from "node:assert";
-import fs from "node:fs";
-import { pathToFileURL } from "node:url";
+#!/usr/bin/env tsx
+
+// cspell:ignore afvaren aankomen binnenwater boxvaren diplomalijn droogvallen
+// cspell:ignore genaker jachtzeilen kajuitzeilen lagerwal lazylines manoeuvre
+// cspell:ignore mooring rondbodemzeilen ruim spinaker vaarwater wad zeegaten
+// cspell:ignore beffcient belectriciteit bgecoordineert bgecoördineert
+// cspell:ignore blekkege bsti bveiliig bzwanehals bzonodig Ieggen Mojibake
+
+import { useQuery, withDatabase, withTransaction } from "@nawadi/core";
 import { schema } from "@nawadi/db";
 import slugify from "@sindresorhus/slugify";
-import { eq } from "drizzle-orm";
-import inquirer from "inquirer";
-import pkg from "xlsx";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import "dotenv/config";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import xlsx from "xlsx";
+import {
+  JACHTZEILEN_AB_CONTENT_DECISIONS,
+  type JachtzeilenAbContentDecisions,
+} from "./jachtzeilen-ab-content-decisions.ts";
+import { readJachtzeilenCatalogFingerprint } from "./jachtzeilen-catalog-snapshot.ts";
 
-const { read, utils } = pkg;
+const { read, utils } = xlsx;
 
-function loadWorkbookFromPath(filePath: string) {
-  const normalizedPath = filePath.trim().replace(/^["']|["']$/g, "");
+export const EXPECTED_SOURCE_SHA256 =
+  "52a399b2dd2766efe251cb841e373eb083daa1ff1c0b1d594793b8a1dda064c6";
+export const EXPECTED_SOURCE_LINK_COUNT = 773;
+export const EXPECTED_MATERIALIZED_LINK_COUNT = 782;
+export const EXPECTED_TARGET_COUNT = 9;
+export const EXPECTED_GEAR_TYPE_COUNT = 11;
+export const IMPORT_STARTED_AT = "2026-01-01T00:00:00.000Z";
 
-  if (!fs.existsSync(normalizedPath)) {
-    throw new Error(`File not found: ${normalizedPath}`);
-  }
+const SOURCE_COMBINED_LAGERWAL =
+  'Aankomen en afvaren lagerwal zonder motor "onder zeil"';
+const SOURCE_RRP = "RR&P";
+const SOURCE_WINDORIENTATION = "Windorientatie";
+const RRP_HANDLE = "reisvoorbereiding-routering-en-planning";
+const RRP_TITLE = "Reisvoorbereiding, Routering en Planning (RR&P)";
+const REGLEMENTEN_WEIGHT = 906;
+const RRP_WEIGHT = 907;
 
-  // xlsx ESM build does not wire up Node fs for readFile(); read via buffer instead.
-  const buffer = fs.readFileSync(normalizedPath);
-  return read(buffer, { type: "buffer" });
-}
+const EXPECTED_LINK_COUNTS_BY_PROGRAM = {
+  "jacht-kajuitzeilen-binnenwater-volwassenen-4": 78,
+  "jacht-kajuitzeilen-binnenwater-volwassenen-a": 81,
+  "jacht-kajuitzeilen-binnenwater-volwassenen-b": 81,
+  "jacht-kajuitzeilen-ruim-binnenwater-volwassenen-a": 88,
+  "jacht-kajuitzeilen-ruim-binnenwater-volwassenen-b": 88,
+  "jacht-kajuitzeilen-waddenzee-en-zeeuwse-stromen-volwassenen-a": 92,
+  "jacht-kajuitzeilen-waddenzee-en-zeeuwse-stromen-volwassenen-b": 92,
+  "jacht-kajuitzeilen-zee-volwassenen-a": 91,
+  "jacht-kajuitzeilen-zee-volwassenen-b": 91,
+} as const;
 
-const REVISION = "2601";
-const REVISION_STARTED_AT = "2026-01-01T00:00:00.000Z";
+const SHARED_COMPETENCY_TITLE_CORRECTIONS = [
+  {
+    handle: "aanlegen-en-afvaren-met-spiegel-naar-de-wal-met-mooring-lazylines",
+    oldTitle:
+      "Aanlegen en afvaren met spiegel naar de wal met mooring-/lazylines",
+    newTitle:
+      "Aanleggen en afvaren met spiegel naar de wal met mooring-/lazy lines",
+  },
+  {
+    handle: "windorientatie",
+    oldTitle: "Windorientatie",
+    newTitle: "Windoriëntatie",
+  },
+] as const;
 
-const MODULE_HANDLE_OVERRIDES: Record<string, string> = {
-  basis: "basis-jz",
-  theorie: "theorie-jz",
-  "basis-jz": "basis-jz",
-  "theorie-jz": "theorie-jz",
+const COMPETENCY_HANDLE_ALIASES: Record<string, string> = {
+  "Aanlegen en afvaren met spiegel naar de wal met mooring-/lazy lines":
+    "aanlegen-en-afvaren-met-spiegel-naar-de-wal-met-mooring-lazylines",
+  "Ankeren (zeilend)": "ankeren-op-zeil",
+  "Man over boord onder zeil": "man-over-boord-op-zeil",
+  "Omgaan met zeer harde wind (1 bft harder dan voor het niveau aangewezen)":
+    "omgaan-met-zeer-harde-wind",
+  "Sturen op de motor": "sturen-op-motor",
+  "Sturen onder zeil": "sturen-op-zeil",
 };
 
-const VAARWATER_ALIASES: Record<string, string> = {
+const MODULE_HANDLE_ALIASES: Record<string, string> = {
+  Basis: "basis",
+  Theorie: "theorie",
+};
+
+const COURSE_HANDLE_BY_VAARWATER = {
+  Binnenwater: "jacht-kajuitzeilen-binnenwater-volwassenen",
+  "Ruim Binnenwater": "jacht-kajuitzeilen-ruim-binnenwater-volwassenen",
+  "Waddenzee en Zeeuwse Stromen":
+    "jacht-kajuitzeilen-waddenzee-en-zeeuwse-stromen-volwassenen",
+  Zee: "jacht-kajuitzeilen-zee-volwassenen",
+} as const;
+
+const VAARWATER_ALIASES: Record<string, Vaarwater> = {
   "Wad en Zeegaten": "Waddenzee en Zeeuwse Stromen",
 };
 
+type Vaarwater = keyof typeof COURSE_HANDLE_BY_VAARWATER;
 type Niveau = "4" | "a" | "b";
+type VoValue = "V" | "O" | "O/V" | "";
+type Command = "plan" | "import" | "rollback" | "verify-local";
 
-export interface ImportRow {
-  vaarwater: string;
-  niveau: Niveau;
-  moduleTitle: string;
-  moduleHandle: string;
-  competencyTitle: string;
-  competencyHandle: string;
-  isRequired: boolean;
-  eis: string;
-  programHandle: string;
-}
+export type RequirementCorrection =
+  | "line-endings"
+  | "trim-whitespace"
+  | "collapse-inline-whitespace"
+  | "collapse-blank-lines"
+  | "approved-spelling-or-grammar"
+  | "sentence-start-capitalization"
+  | "terminal-punctuation";
+
+type ResolvedContentDecisions = Omit<
+  JachtzeilenAbContentDecisions,
+  "ambiguousOvRequired" | "blankVoRequired" | "combinedLagerwal" | "rrp"
+> & {
+  ambiguousOvRequired: NonNullable<
+    JachtzeilenAbContentDecisions["ambiguousOvRequired"]
+  >;
+  blankVoRequired: boolean;
+  combinedLagerwal: NonNullable<
+    JachtzeilenAbContentDecisions["combinedLagerwal"]
+  >;
+  rrp: NonNullable<JachtzeilenAbContentDecisions["rrp"]>;
+};
 
 interface DataColumn {
   columnIndex: number;
-  vaarwater: string;
+  vaarwater: Vaarwater;
   niveau: Niveau;
 }
 
-interface EntityRecord<T = { id: string }> {
-  handle: string;
-  exists: boolean;
-  entity: T | null;
-  affectedRows: ImportRow[];
-}
-
-interface ProgramEntityRecord extends EntityRecord {
-  handle: string;
-  title: string;
-  vaarwater: string;
+export interface ParsedSourceRow {
+  sourceRow: number;
+  vaarwater: Vaarwater;
   niveau: Niveau;
-}
-
-type ModuleEntity = NonNullable<
-  Awaited<ReturnType<typeof Course.Module.fromHandle>>
->;
-type CompetencyEntity = NonNullable<
-  Awaited<ReturnType<typeof Course.Competency.fromHandle>>
->;
-
-interface ModuleEntityRecord extends EntityRecord<ModuleEntity> {
-  title: string;
-}
-
-interface CompetencyEntityRecord extends EntityRecord<CompetencyEntity> {
-  title: string;
   moduleTitle: string;
+  competencyTitle: string;
+  vo: VoValue;
+  originalRequirement: string;
+  requirement: string;
+  corrections: RequirementCorrection[];
 }
 
-export interface ImportPlan {
+interface CompetencyReference {
+  handle: string;
+  title: string;
+  type: "knowledge" | "skill";
+  createIfMissing: boolean;
+}
+
+export interface ImportRow extends ParsedSourceRow {
+  moduleHandle: string;
+  competency: CompetencyReference;
+  isRequired: boolean;
+  courseHandle: string;
+  programHandle: string;
+}
+
+export interface SourceImportPlan {
+  revision: string;
+  sourceHash: string;
+  sourceRows: ParsedSourceRow[];
   rows: ImportRow[];
-  parseStats: {
-    defaultedKeuzeCount: number;
-    skippedEmptyEis: number;
+  targets: Map<string, ImportRow[]>;
+  normalization: {
+    changed: Array<{
+      sourceRow: number;
+      programHandle: string;
+      moduleTitle: string;
+      competencyTitle: string;
+      original: string;
+      normalized: string;
+      corrections: RequirementCorrection[];
+    }>;
+    unchanged: {
+      count: number;
+      sha256: string;
+    };
   };
-  programs: Map<string, ProgramEntityRecord>;
-  modules: Map<string, ModuleEntityRecord>;
-  competencies: Map<string, CompetencyEntityRecord>;
-  moduleWeights: Map<string, number>;
-  competencyWeights: Map<string, number>;
 }
 
-/** Next module weight in a new hundred-block, skipping any taken value. */
-export function allocateNextModuleWeight(
-  existingModuleWeights: readonly number[],
-  taken: ReadonlySet<number>,
-): number {
-  const maxModule = existingModuleWeights.length
-    ? Math.max(...existingModuleWeights)
-    : 0;
-  let candidate = Math.ceil((maxModule + 1) / 100) * 100;
-  if (candidate <= maxModule) {
-    candidate = maxModule + 100;
-  }
-  while (taken.has(candidate)) {
-    candidate += 100;
-  }
-  return candidate;
+interface DatabaseTargetPlan {
+  programHandle: string;
+  courseHandle: string;
+  courseId: string;
+  degreeId: string;
+  rows: ImportRow[];
+  moduleIds: Map<string, string>;
+  gearTypeIds: string[];
+  existingProgramId: string | null;
+  existingCurriculumId: string | null;
+  existingCurriculumStartedAt: string | null;
 }
 
-/** Next competency weight directly after its module (e.g. 601–603 under module 600). */
-export function allocateNextCompetencyWeight(
-  moduleWeight: number,
-  taken: ReadonlySet<number>,
-): number {
-  const inBand = [...taken].filter(
-    (weight) => weight > moduleWeight && weight < moduleWeight + 100,
-  );
-  let candidate =
-    inBand.length > 0 ? Math.max(...inBand) + 1 : moduleWeight + 1;
-  while (taken.has(candidate)) {
-    candidate += 1;
-  }
-  if (candidate >= moduleWeight + 100) {
-    throw new Error(
-      `No free competency weight for module weight ${moduleWeight}`,
-    );
-  }
-  return candidate;
+interface DatabaseImportPlan {
+  source: SourceImportPlan;
+  targets: DatabaseTargetPlan[];
+  competencyIds: Map<string, string>;
+  competenciesToCreate: CompetencyReference[];
+  catalogHash: string;
 }
 
-function uniqueInOrder<T>(values: T[]): T[] {
-  const seen = new Set<T>();
-  const result: T[] = [];
-  for (const value of values) {
-    if (seen.has(value)) continue;
-    seen.add(value);
-    result.push(value);
+export interface ImportManifest {
+  kind: "jachtzeilen-ab-import";
+  version: 2;
+  createdAt: string;
+  sourceHash: string;
+  catalogHash: string;
+  revision: string;
+  startedAt: string;
+  createdProgramIds: string[];
+  createdCurriculumIds: string[];
+  createdCompetencyIds: string[];
+  shiftedCompetencyWeights: Array<{
+    competencyId: string;
+    handle: string;
+    from: number;
+    to: number;
+  }>;
+  correctedCompetencyTitles: Array<{
+    competencyId: string;
+    handle: string;
+    from: string;
+    to: string;
+  }>;
+  normalization: SourceImportPlan["normalization"];
+  targets: Array<{
+    programHandle: string;
+    programId: string;
+    curriculumId: string;
+    courseHandle: string;
+    competencyCount: number;
+    moduleCount: number;
+    gearTypeCount: number;
+    curriculumWasCreated: boolean;
+    previousStartedAt: string | null;
+    createdModuleIds: string[];
+    createdCompetencyLinkIds: string[];
+    createdGearTypeIds: string[];
+  }>;
+}
+
+interface CliOptions {
+  command: Command;
+  execute: boolean;
+  filePath?: string;
+  manifestPath?: string;
+  pgUri?: string;
+  expectedCatalogHash?: string;
+  attestationPath?: string;
+}
+
+function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
   }
-  return result;
 }
 
-async function loadTakenWeights(): Promise<Set<number>> {
-  const query = useQuery();
-  const [moduleRows, competencyRows] = await Promise.all([
-    query.select({ weight: schema.module.weight }).from(schema.module),
-    query.select({ weight: schema.competency.weight }).from(schema.competency),
-  ]);
-  return new Set([
-    ...moduleRows.map((row) => row.weight),
-    ...competencyRows.map((row) => row.weight),
-  ]);
+function unique<T>(values: Iterable<T>): T[] {
+  return [...new Set(values)];
 }
 
-async function buildModuleWeights(
-  modules: Map<string, ModuleEntityRecord>,
-  rows: ImportRow[],
-): Promise<Map<string, number>> {
-  const weights = new Map<string, number>();
-  const query = useQuery();
-  const moduleRows = await query
-    .select({ weight: schema.module.weight })
-    .from(schema.module);
-  const existingModuleWeights = moduleRows.map((row) => row.weight);
-  const taken = await loadTakenWeights();
-  const assignedModuleWeights: number[] = [];
+function sameInstant(left: string | null, right: string | null): boolean {
+  if (left === null || right === null) return left === right;
+  return new Date(left).valueOf() === new Date(right).valueOf();
+}
 
-  for (const handle of uniqueInOrder(rows.map((row) => row.moduleHandle))) {
-    const module = modules.get(handle);
-    if (!module) continue;
+function normalizeText(value: unknown): string {
+  return String(value ?? "")
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .trim();
+}
 
-    if (module.exists && module.entity) {
-      weights.set(handle, module.entity.weight);
-      continue;
+const APPROVED_REQUIREMENT_REPLACEMENTS: Array<{
+  pattern: RegExp;
+  replacement: string;
+}> = [
+  { pattern: /\baan komen\b/g, replacement: "aankomen" },
+  { pattern: /\bAan komen\b/g, replacement: "Aankomen" },
+  { pattern: /\baankomen op bij\b/g, replacement: "aankomen bij" },
+  { pattern: /\bgeeft is tot\b/g, replacement: "geeft totdat" },
+  { pattern: /\belectriciteit\b/g, replacement: "elektriciteit" },
+  { pattern: /\bHygiene-checklist\b/g, replacement: "hygiënechecklist" },
+  { pattern: /\ballergieen\b/g, replacement: "allergieën" },
+  { pattern: /\bcreeert\b/g, replacement: "creëert" },
+  { pattern: /\bstuurinrichtting\b/g, replacement: "stuurinrichting" },
+  { pattern: /\bnavigatieappartuur\b/g, replacement: "navigatieapparatuur" },
+  { pattern: /\baanwijzigingen\b/g, replacement: "aanwijzingen" },
+  { pattern: /\beffcient\b/g, replacement: "efficiënt" },
+  { pattern: /\befficiente\b/g, replacement: "efficiënte" },
+  { pattern: /\bcoordineert\b/g, replacement: "coördineert" },
+  { pattern: /\bgecoordineert\b/g, replacement: "gecoördineerd" },
+  { pattern: /\bgecoördineert\b/g, replacement: "gecoördineerd" },
+  {
+    pattern: /\bgecoördineerd plaats vinden\b/g,
+    replacement: "gecoördineerd plaatsvinden",
+  },
+  { pattern: /\bveiliig\b/g, replacement: "veilig" },
+  { pattern: /\blekkege\b/g, replacement: "lekkage" },
+  { pattern: /\bongeer\b/g, replacement: "ongeveer" },
+  { pattern: /\bzwanehals\b/g, replacement: "zwanenhals" },
+  { pattern: /\bstiI Ieggen\b/g, replacement: "stilleggen" },
+  { pattern: /\bcontrole lampjes\b/g, replacement: "controlelampjes" },
+  { pattern: /\bgashandel\b/g, replacement: "gashendel" },
+  {
+    pattern: /\beerst(e)?hulp handelingen\b/g,
+    replacement: "eerstehulphandelingen",
+  },
+  { pattern: /\bvoor en nadelen\b/g, replacement: "voor- en nadelen" },
+  { pattern: /\bten allen tijde\b/g, replacement: "te allen tijde" },
+  { pattern: /\boverige verkeer\b/g, replacement: "overig verkeer" },
+  { pattern: /\bzonodig\b/g, replacement: "zo nodig" },
+  {
+    pattern: /\bvoor of achterwaartse\b/g,
+    replacement: "voor- of achterwaartse",
+  },
+  {
+    pattern: /\bLet op op scheepvaart\b/g,
+    replacement: "Let op de scheepvaart",
+  },
+  { pattern: /\.{2,}/g, replacement: "." },
+  { pattern: /([.!?])(?=[A-ZÀ-Ý])/g, replacement: "$1 " },
+  { pattern: /\. filters\b/g, replacement: ". Filters" },
+  {
+    pattern:
+      /(Moet hygiënechecklist kennen en kunnen toepassen\. Vraagt naar allergieën en andere beperkingen\.)\s+Moet hygiënechecklist kennen en kunnen toepassen\. Vraagt naar allergieën en andere beperkingen\./g,
+    replacement: "$1",
+  },
+];
+
+function addCorrection(
+  corrections: Set<RequirementCorrection>,
+  correction: RequirementCorrection,
+) {
+  corrections.add(correction);
+}
+
+function ensureTerminalPunctuation(value: string): string {
+  if (/[.?!](?:["'’”)\]])*$/u.test(value)) return value;
+  if (/["'’”]$/u.test(value)) {
+    return value.replace(/(["'’”]+)$/u, ".$1");
+  }
+  return `${value}.`;
+}
+
+export function normalizeRequirement(value: unknown): {
+  original: string;
+  normalized: string;
+  corrections: RequirementCorrection[];
+} {
+  const original = String(value ?? "");
+  const corrections = new Set<RequirementCorrection>();
+  let normalized = original;
+
+  const lineEndingNormalized = normalized.replace(/\r\n?/g, "\n");
+  if (lineEndingNormalized !== normalized) {
+    addCorrection(corrections, "line-endings");
+    normalized = lineEndingNormalized;
+  }
+
+  const whitespaceTrimmed = normalized
+    .split("\n")
+    .map((line) => line.trim())
+    .join("\n")
+    .trim();
+  if (whitespaceTrimmed !== normalized) {
+    addCorrection(corrections, "trim-whitespace");
+    normalized = whitespaceTrimmed;
+  }
+
+  const inlineWhitespaceCollapsed = normalized
+    .split("\n")
+    .map((line) => line.replace(/[ \t]+/g, " "))
+    .join("\n");
+  if (inlineWhitespaceCollapsed !== normalized) {
+    addCorrection(corrections, "collapse-inline-whitespace");
+    normalized = inlineWhitespaceCollapsed;
+  }
+
+  const blankLinesCollapsed = normalized.replace(/\n{3,}/g, "\n\n");
+  if (blankLinesCollapsed !== normalized) {
+    addCorrection(corrections, "collapse-blank-lines");
+    normalized = blankLinesCollapsed;
+  }
+
+  for (const { pattern, replacement } of APPROVED_REQUIREMENT_REPLACEMENTS) {
+    const corrected = normalized.replace(pattern, replacement);
+    if (corrected !== normalized) {
+      addCorrection(corrections, "approved-spelling-or-grammar");
+      normalized = corrected;
     }
-
-    const allModuleWeights = [
-      ...existingModuleWeights,
-      ...assignedModuleWeights,
-    ];
-    const weight = allocateNextModuleWeight(allModuleWeights, taken);
-    taken.add(weight);
-    assignedModuleWeights.push(weight);
-    weights.set(handle, weight);
   }
 
-  return weights;
-}
+  if (/^[a-zà-ÿ]/u.test(normalized)) {
+    addCorrection(corrections, "sentence-start-capitalization");
+    normalized = `${normalized[0]?.toLocaleUpperCase("nl-NL")}${normalized.slice(
+      1,
+    )}`;
+  }
 
-async function buildCompetencyWeights(
-  competencies: Map<string, CompetencyEntityRecord>,
-  moduleWeights: Map<string, number>,
-  rows: ImportRow[],
-): Promise<Map<string, number>> {
-  const weights = new Map<string, number>();
-  const taken = await loadTakenWeights();
-
-  for (const row of rows) {
-    if (weights.has(row.competencyHandle)) continue;
-
-    const competency = competencies.get(row.competencyHandle);
-    if (!competency) continue;
-
-    if (competency.exists && competency.entity) {
-      weights.set(row.competencyHandle, competency.entity.weight);
-      taken.add(competency.entity.weight);
-      continue;
+  if (normalized) {
+    const punctuated = ensureTerminalPunctuation(normalized);
+    if (punctuated !== normalized) {
+      addCorrection(corrections, "terminal-punctuation");
+      normalized = punctuated;
     }
-
-    const moduleWeight = moduleWeights.get(row.moduleHandle);
-    if (moduleWeight === undefined) continue;
-
-    const weight = allocateNextCompetencyWeight(moduleWeight, taken);
-    taken.add(weight);
-    weights.set(row.competencyHandle, weight);
   }
 
-  return weights;
+  return {
+    original,
+    normalized,
+    corrections: [...corrections],
+  };
 }
 
-export type CreationDecisions = Map<string, boolean>;
-
-function normalizeVaarwater(name: string): string {
-  const trimmed = name.trim();
-  return VAARWATER_ALIASES[trimmed] ?? trimmed;
+function normalizeVaarwater(value: unknown): Vaarwater | null {
+  const title = normalizeText(value);
+  const normalized = VAARWATER_ALIASES[title] ?? title;
+  return normalized in COURSE_HANDLE_BY_VAARWATER
+    ? (normalized as Vaarwater)
+    : null;
 }
 
-function parseNiveau(cell: unknown): Niveau | null {
-  const match = String(cell ?? "")
-    .trim()
-    .match(/^Niveau\s+(4|[AB])$/i);
+function parseNiveau(value: unknown): Niveau | null {
+  const match = normalizeText(value).match(/^Niveau\s+(4|[AB])$/i);
   if (!match?.[1]) return null;
-  const value = match[1].toUpperCase();
-  if (value === "4") return "4";
-  if (value === "A") return "a";
-  if (value === "B") return "b";
-  return null;
+  return match[1].toLowerCase() as Niveau;
 }
 
-function resolveModuleHandle(moduleTitle: string): string {
-  const slug = slugify(moduleTitle);
-  return MODULE_HANDLE_OVERRIDES[slug] ?? slug;
+function parseVo(value: unknown, sourceRow: number): VoValue {
+  const normalized = normalizeText(value).toUpperCase();
+  invariant(
+    normalized === "" ||
+      normalized === "V" ||
+      normalized === "O" ||
+      normalized === "O/V",
+    `CSV row ${sourceRow}: unsupported V/O value "${normalized}"`,
+  );
+  return normalized;
 }
 
-function resolveProgramHandle(vaarwater: string, niveau: Niveau): string {
-  return `jacht-kajuitzeilen-${slugify(vaarwater)}-volwassenen-${niveau}`;
-}
-
-function deriveProgramTitle(vaarwater: string, niveau: Niveau): string {
-  const niveauLabel = niveau === "4" ? "4" : niveau.toUpperCase();
-  return `Jacht/kajuitzeilen ${vaarwater} Volwassenen ${niveauLabel}`;
-}
-
-function parseIsRequired(voCell: unknown): boolean {
-  return String(voCell ?? "")
-    .trim()
-    .toUpperCase() === "V";
-}
-
-function truncate(text: string, maxLength: number): string {
-  const normalized = text.replace(/\s+/g, " ").trim();
-  if (normalized.length <= maxLength) return normalized;
-  return `${normalized.slice(0, maxLength - 1)}…`;
+function assertNoMojibake(value: string, context: string) {
+  invariant(
+    !/[ÃÂ�]/u.test(value),
+    `${context}: text contains an invalid UTF-8 decoding marker`,
+  );
 }
 
 function detectDataColumns(rows: unknown[][]): DataColumn[] {
-  if (rows.length < 2) return [];
-
   const vaarwaterRow = rows[0] ?? [];
-  const headerRow = rows[1] ?? [];
+  const niveauRow = rows[1] ?? [];
   const columns: DataColumn[] = [];
-  let currentVaarwater = "";
+  let currentVaarwater: Vaarwater | null = null;
 
-  for (let columnIndex = 0; columnIndex < headerRow.length; columnIndex++) {
-    const vaarwaterCell = String(vaarwaterRow[columnIndex] ?? "").trim();
-    if (vaarwaterCell) {
-      currentVaarwater = normalizeVaarwater(vaarwaterCell);
-    }
+  for (
+    let columnIndex = 0;
+    columnIndex < Math.max(vaarwaterRow.length, niveauRow.length);
+    columnIndex++
+  ) {
+    const parsedVaarwater = normalizeVaarwater(vaarwaterRow[columnIndex]);
+    if (parsedVaarwater) currentVaarwater = parsedVaarwater;
 
-    const niveau = parseNiveau(headerRow[columnIndex]);
-    if (!niveau || !currentVaarwater) continue;
+    const niveau = parseNiveau(niveauRow[columnIndex]);
+    if (!currentVaarwater || !niveau) continue;
+    invariant(
+      niveau !== "4" || currentVaarwater === "Binnenwater",
+      "Niveau 4 is only approved for Binnenwater",
+    );
 
-    columns.push({
-      columnIndex,
-      vaarwater: currentVaarwater,
-      niveau,
-    });
+    columns.push({ columnIndex, vaarwater: currentVaarwater, niveau });
   }
 
   return columns;
 }
 
-export function parseWideJachtzeilenSheet(rows: unknown[][]): {
-  rows: ImportRow[];
-  defaultedKeuzeCount: number;
-  skippedEmptyEis: number;
-} {
+export function parseWideJachtzeilenSheet(
+  rows: unknown[][],
+  expected: {
+    targetCount: number;
+    sourceLinkCount: number;
+  } = {
+    targetCount: EXPECTED_TARGET_COUNT,
+    sourceLinkCount: EXPECTED_SOURCE_LINK_COUNT,
+  },
+): ParsedSourceRow[] {
+  invariant(rows.length >= 3, "CSV must contain two header rows and data");
   const dataColumns = detectDataColumns(rows);
-  const importRows: ImportRow[] = [];
-  let defaultedKeuzeCount = 0;
-  let skippedEmptyEis = 0;
-  const moduleOrder: string[] = [];
+  invariant(
+    dataColumns.length === expected.targetCount,
+    `Expected ${expected.targetCount} target columns, found ${dataColumns.length}`,
+  );
+  invariant(
+    dataColumns.filter((column) => column.niveau === "4").length === 1,
+    "Expected exactly one Niveau 4 target column",
+  );
+
+  const parsedRows: ParsedSourceRow[] = [];
 
   for (let rowIndex = 2; rowIndex < rows.length; rowIndex++) {
     const row = rows[rowIndex] ?? [];
-    const moduleTitle = String(row[0] ?? "").trim();
-    const voCell = row[1];
-    const competencyTitle = String(row[2] ?? "").trim();
+    const sourceRow = rowIndex + 1;
+    const moduleTitle = normalizeText(row[0]);
+    const competencyTitle = normalizeText(row[2]);
 
-    if (!moduleTitle || !competencyTitle) continue;
+    if (!moduleTitle && !competencyTitle) continue;
+    invariant(
+      moduleTitle && competencyTitle,
+      `CSV row ${sourceRow}: module and competency must both be populated`,
+    );
+    assertNoMojibake(moduleTitle, `CSV row ${sourceRow} module`);
+    assertNoMojibake(competencyTitle, `CSV row ${sourceRow} competency`);
 
-    if (!moduleOrder.includes(moduleTitle)) {
-      moduleOrder.push(moduleTitle);
-    }
-
-    const voValue = String(voCell ?? "").trim();
-    if (!voValue) defaultedKeuzeCount++;
-
-    const moduleHandle = resolveModuleHandle(moduleTitle);
-    const competencyHandle = slugify(competencyTitle);
-    const isRequired = parseIsRequired(voCell);
+    const vo = parseVo(row[1], sourceRow);
 
     for (const column of dataColumns) {
-      const eis = String(row[column.columnIndex] ?? "").trim();
-      if (!eis) {
-        skippedEmptyEis++;
-        continue;
-      }
+      const normalizedRequirement = normalizeRequirement(
+        row[column.columnIndex],
+      );
+      if (!normalizedRequirement.normalized) continue;
+      assertNoMojibake(
+        normalizedRequirement.normalized,
+        `CSV row ${sourceRow} requirement`,
+      );
 
-      importRows.push({
+      parsedRows.push({
+        sourceRow,
         vaarwater: column.vaarwater,
         niveau: column.niveau,
         moduleTitle,
-        moduleHandle,
         competencyTitle,
-        competencyHandle,
-        isRequired,
-        eis,
-        programHandle: resolveProgramHandle(column.vaarwater, column.niveau),
+        vo,
+        originalRequirement: normalizedRequirement.original,
+        requirement: normalizedRequirement.normalized,
+        corrections: normalizedRequirement.corrections,
       });
     }
   }
 
-  return { rows: importRows, defaultedKeuzeCount, skippedEmptyEis };
-}
-
-function addAffectedRow<T extends { affectedRows: ImportRow[] }>(
-  map: Map<string, T>,
-  key: string,
-  factory: () => T,
-  row: ImportRow,
-) {
-  const existing = map.get(key) ?? factory();
-  if (!existing.affectedRows.includes(row)) {
-    existing.affectedRows.push(row);
-  }
-  map.set(key, existing);
-}
-
-export async function resolveImportPlan(
-  parsedRows: ImportRow[],
-  parseStats: { defaultedKeuzeCount: number; skippedEmptyEis: number },
-): Promise<ImportPlan> {
-  const programs = new Map<string, ProgramEntityRecord>();
-  const modules = new Map<string, ModuleEntityRecord>();
-  const competencies = new Map<string, CompetencyEntityRecord>();
-
-  for (const row of parsedRows) {
-    addAffectedRow(
-      programs,
-      row.programHandle,
-      () => ({
-        handle: row.programHandle,
-        title: deriveProgramTitle(row.vaarwater, row.niveau),
-        vaarwater: row.vaarwater,
-        niveau: row.niveau,
-        exists: false,
-        entity: null,
-        affectedRows: [],
-      }),
-      row,
-    );
-
-    addAffectedRow(
-      modules,
-      row.moduleHandle,
-      () => ({
-        handle: row.moduleHandle,
-        title: row.moduleTitle,
-        exists: false,
-        entity: null,
-        affectedRows: [],
-      }),
-      row,
-    );
-
-    addAffectedRow(
-      competencies,
-      row.competencyHandle,
-      () => ({
-        handle: row.competencyHandle,
-        title: row.competencyTitle,
-        moduleTitle: row.moduleTitle,
-        exists: false,
-        entity: null,
-        affectedRows: [],
-      }),
-      row,
-    );
-  }
-
-  await Promise.all([
-    ...[...programs.values()].map(async (program) => {
-      program.entity = await Course.Program.fromHandle(program.handle);
-      program.exists = program.entity !== null;
-    }),
-    ...[...modules.values()].map(async (module) => {
-      module.entity = await Course.Module.fromHandle(module.handle);
-      module.exists = module.entity !== null;
-    }),
-    ...[...competencies.values()].map(async (competency) => {
-      competency.entity = await Course.Competency.fromHandle(competency.handle);
-      competency.exists = competency.entity !== null;
-    }),
-  ]);
-
-  const moduleWeights = await buildModuleWeights(modules, parsedRows);
-  const competencyWeights = await buildCompetencyWeights(
-    competencies,
-    moduleWeights,
-    parsedRows,
+  invariant(
+    parsedRows.length === expected.sourceLinkCount,
+    `Expected ${expected.sourceLinkCount} source links, found ${parsedRows.length}`,
   );
+
+  return parsedRows;
+}
+
+export function assertResolvedContentDecisions(
+  decisions: JachtzeilenAbContentDecisions,
+): ResolvedContentDecisions {
+  const unresolved: string[] = [];
+  if (decisions.ambiguousOvRequired === null) {
+    unresolved.push("ambiguousOvRequired");
+  }
+  if (decisions.blankVoRequired === null) unresolved.push("blankVoRequired");
+  if (decisions.combinedLagerwal === null) {
+    unresolved.push("combinedLagerwal");
+  }
+  if (decisions.rrp === null) unresolved.push("rrp");
+
+  invariant(
+    unresolved.length === 0,
+    `Unresolved content decisions: ${unresolved.join(", ")}`,
+  );
+
+  return decisions as ResolvedContentDecisions;
+}
+
+function resolveRequiredness(
+  row: ParsedSourceRow,
+  decisions: ResolvedContentDecisions,
+): boolean {
+  if (row.competencyTitle === SOURCE_WINDORIENTATION) return true;
+  if (row.vo === "V") return true;
+  if (row.vo === "O") return false;
+  if (row.vo === "O/V") {
+    return (
+      row.vaarwater === "Binnenwater" || row.vaarwater === "Ruim Binnenwater"
+    );
+  }
+  return decisions.blankVoRequired;
+}
+
+function resolveCompetencies(
+  row: ParsedSourceRow,
+  decisions: ResolvedContentDecisions,
+): CompetencyReference[] {
+  const type = row.moduleTitle === "Theorie" ? "knowledge" : "skill";
+
+  if (row.competencyTitle === SOURCE_COMBINED_LAGERWAL) {
+    if (decisions.combinedLagerwal === "split-existing-competencies") {
+      return [
+        {
+          handle: "aankomen-aan-een-lagerwal-zonder-motor-op-zeil",
+          title: "Aankomen aan een lagerwal zonder motor (op zeil)",
+          type: "skill",
+          createIfMissing: false,
+        },
+        {
+          handle: "afvaren-van-een-lagerwal-zonder-motor-op-zeil",
+          title: "Afvaren van een lagerwal zonder motor (op zeil)",
+          type: "skill",
+          createIfMissing: false,
+        },
+      ];
+    }
+
+    return [
+      {
+        handle: slugify(row.competencyTitle),
+        title: row.competencyTitle,
+        type: "skill",
+        createIfMissing: true,
+      },
+    ];
+  }
+
+  if (row.competencyTitle === SOURCE_RRP) {
+    if (decisions.rrp === "reuse-reglementen") {
+      return [
+        {
+          handle: "reglementen",
+          title: "Reglementen",
+          type: "knowledge",
+          createIfMissing: false,
+        },
+      ];
+    }
+
+    return [
+      {
+        handle: RRP_HANDLE,
+        title: RRP_TITLE,
+        type: "knowledge",
+        createIfMissing: true,
+      },
+    ];
+  }
+
+  return [
+    {
+      handle:
+        COMPETENCY_HANDLE_ALIASES[row.competencyTitle] ??
+        slugify(row.competencyTitle),
+      title: row.competencyTitle,
+      type,
+      createIfMissing: false,
+    },
+  ];
+}
+
+function resolveModuleHandle(title: string): string {
+  return MODULE_HANDLE_ALIASES[title] ?? slugify(title);
+}
+
+export function resolveProgramHandle(
+  vaarwater: Vaarwater,
+  niveau: Niveau,
+): string {
+  return `${COURSE_HANDLE_BY_VAARWATER[vaarwater]}-${niveau}`;
+}
+
+export function buildSourceImportPlan(input: {
+  sourceRows: ParsedSourceRow[];
+  sourceHash: string;
+  decisions: JachtzeilenAbContentDecisions;
+  expected?: {
+    targetCount: number;
+    materializedLinkCount: number;
+    targetLinkCounts?: Record<string, number>;
+  };
+}): SourceImportPlan {
+  const decisions = assertResolvedContentDecisions(input.decisions);
+  const expected = input.expected ?? {
+    targetCount: EXPECTED_TARGET_COUNT,
+    materializedLinkCount: EXPECTED_MATERIALIZED_LINK_COUNT,
+    targetLinkCounts: EXPECTED_LINK_COUNTS_BY_PROGRAM,
+  };
+  const rows: ImportRow[] = [];
+
+  for (const sourceRow of input.sourceRows) {
+    const courseHandle = COURSE_HANDLE_BY_VAARWATER[sourceRow.vaarwater];
+    const programHandle = resolveProgramHandle(
+      sourceRow.vaarwater,
+      sourceRow.niveau,
+    );
+
+    for (const competency of resolveCompetencies(sourceRow, decisions)) {
+      rows.push({
+        ...sourceRow,
+        moduleHandle: resolveModuleHandle(sourceRow.moduleTitle),
+        competency,
+        isRequired: resolveRequiredness(sourceRow, decisions),
+        courseHandle,
+        programHandle,
+      });
+    }
+  }
+
+  const deduplicatedRows = new Map<string, ImportRow>();
+  for (const row of rows) {
+    const key = [
+      row.programHandle,
+      row.moduleHandle,
+      row.competency.handle,
+    ].join("|");
+    const existing = deduplicatedRows.get(key);
+    if (existing) {
+      invariant(
+        existing.requirement === row.requirement &&
+          existing.isRequired === row.isRequired,
+        `Conflicting duplicate target row: ${key}`,
+      );
+      continue;
+    }
+    deduplicatedRows.set(key, row);
+  }
+
+  const targets = new Map<string, ImportRow[]>();
+  for (const row of deduplicatedRows.values()) {
+    const targetRows = targets.get(row.programHandle) ?? [];
+    targetRows.push(row);
+    targets.set(row.programHandle, targetRows);
+  }
+
+  invariant(
+    targets.size === expected.targetCount,
+    `Expected ${expected.targetCount} program targets, found ${targets.size}`,
+  );
+  invariant(
+    deduplicatedRows.size === expected.materializedLinkCount,
+    `Expected ${expected.materializedLinkCount} materialized links, found ${deduplicatedRows.size}`,
+  );
+
+  for (const [programHandle, expectedCount] of Object.entries(
+    expected.targetLinkCounts ?? {},
+  )) {
+    const actualCount = targets.get(programHandle)?.length ?? 0;
+    invariant(
+      actualCount === expectedCount,
+      `Expected ${expectedCount} links for ${programHandle}, found ${actualCount}`,
+    );
+  }
+
+  const changed = input.sourceRows
+    .filter((row) => row.corrections.length > 0)
+    .map((row) => ({
+      sourceRow: row.sourceRow,
+      programHandle: resolveProgramHandle(row.vaarwater, row.niveau),
+      moduleTitle: row.moduleTitle,
+      competencyTitle: row.competencyTitle,
+      original: row.originalRequirement,
+      normalized: row.requirement,
+      corrections: row.corrections,
+    }));
+  const unchangedRows = input.sourceRows
+    .filter((row) => row.corrections.length === 0)
+    .map((row) => ({
+      sourceRow: row.sourceRow,
+      programHandle: resolveProgramHandle(row.vaarwater, row.niveau),
+      moduleTitle: row.moduleTitle,
+      competencyTitle: row.competencyTitle,
+      requirement: row.requirement,
+    }));
 
   return {
-    rows: parsedRows,
-    parseStats,
-    programs,
-    modules,
-    competencies,
-    moduleWeights,
-    competencyWeights,
+    revision: decisions.revision,
+    sourceHash: input.sourceHash,
+    sourceRows: input.sourceRows,
+    rows: [...deduplicatedRows.values()],
+    targets,
+    normalization: {
+      changed,
+      unchanged: {
+        count: unchangedRows.length,
+        sha256: sha256(Buffer.from(JSON.stringify(unchangedRows))),
+      },
+    },
   };
 }
 
-function formatSampleList(items: string[], maxItems: number): string {
-  const shown = items.slice(0, maxItems);
-  const lines = shown.map((item) => `  • ${item}`);
-  if (items.length > maxItems) {
-    lines.push(`  … and ${items.length - maxItems} more`);
-  }
-  return lines.join("\n");
+function sha256(buffer: Buffer): string {
+  return createHash("sha256").update(buffer).digest("hex");
 }
 
-function buildProgramPromptMessage(program: ProgramEntityRecord): string {
-  const sampleCompetencies = [
-    ...new Set(
-      program.affectedRows.map(
-        (row) => `${row.competencyTitle} (module: ${row.moduleTitle})`,
-      ),
-    ),
-  ];
-
-  return [
-    "MISSING PROGRAM (level)",
-    "",
-    `Handle:    ${program.handle}`,
-    `Title:     ${program.title} (derived)`,
-    `Vaarwater: ${program.vaarwater}`,
-    `Niveau:    ${program.niveau.toUpperCase()}`,
-    "",
-    "Problem:   This opleidingsprogramma does not exist in the database.",
-    "           Without it, no curriculum revision 2601 can be created for this level.",
-    "",
-    `Affected:  ${program.affectedRows.length} import rows from the Excel file will be skipped if you decline.`,
-    "",
-    "Sample competencies that would be linked:",
-    formatSampleList(sampleCompetencies, 3),
-    "",
-    "Create this program now?",
-  ].join("\n");
-}
-
-function buildModulePromptMessage(module: ModuleEntityRecord): string {
-  const niveaus = [...new Set(module.affectedRows.map((row) => row.niveau))];
-  const vaarwaters = [
-    ...new Set(module.affectedRows.map((row) => row.vaarwater)),
-  ];
-  const sampleCompetencies = [
-    ...new Set(module.affectedRows.map((row) => row.competencyTitle)),
-  ];
-
-  return [
-    "MISSING MODULE",
-    "",
-    `Handle:  ${module.handle}`,
-    `Title:   ${module.title} (from Excel)`,
-    "",
-    "Problem: This module is referenced in the Excel but was not found by handle.",
-    "         All competencies under this module for revision 2601 depend on it.",
-    "",
-    `Affected: ${module.affectedRows.length} import rows across niveaus: ${niveaus.join(", ")}`,
-    `          vaarwateren: ${vaarwaters.join(", ")}`,
-    "",
-    "Used with competencies:",
-    formatSampleList(sampleCompetencies, 3),
-    "",
-    "Create this module now?",
-  ].join("\n");
-}
-
-function buildCompetencyPromptMessage(
-  competency: CompetencyEntityRecord,
-): string {
-  const sampleRow = competency.affectedRows[0];
-  const competencyType =
-    competency.moduleTitle === "Theorie" ? "knowledge" : "skill";
-
-  return [
-    "MISSING COMPETENCY",
-    "",
-    `Handle:  ${competency.handle}`,
-    `Title:   ${competency.title} (from Excel)`,
-    `Module:  ${competency.moduleTitle}`,
-    `Type:    ${competencyType} (derived: ${competency.moduleTitle === "Theorie" ? "Theorie module" : "not Theorie module"})`,
-    "",
-    "Problem: This competency entity does not exist. The eisen text from Excel",
-    "         cannot be linked to curriculum 2601 without it.",
-    "",
-    `Affected: ${competency.affectedRows.length} import rows (vaarwater/niveau combinations with an eis)`,
-    "",
-    sampleRow
-      ? `Sample eis (${sampleRow.vaarwater}, niveau ${sampleRow.niveau.toUpperCase()}):\n  "${truncate(sampleRow.eis, 120)}"`
-      : "",
-    "",
-    "Create this competency now?",
-  ]
-    .filter(Boolean)
-    .join("\n");
-}
-
-export async function promptForMissingEntities(
-  plan: ImportPlan,
-): Promise<CreationDecisions> {
-  const decisions: CreationDecisions = new Map();
-
-  const missingPrograms = [...plan.programs.values()].filter((p) => !p.exists);
-  const missingModules = [...plan.modules.values()].filter((m) => !m.exists);
-  const missingCompetencies = [...plan.competencies.values()].filter(
-    (c) => !c.exists,
+export function loadSourceFile(filePath: string): {
+  sourceHash: string;
+  rows: unknown[][];
+} {
+  const normalizedPath = filePath.trim().replace(/^["']|["']$/g, "");
+  invariant(fs.existsSync(normalizedPath), `File not found: ${normalizedPath}`);
+  invariant(
+    path.extname(normalizedPath).toLowerCase() === ".csv",
+    "The source file must be the reviewed CSV",
   );
 
-  const promptCount =
-    missingPrograms.length + missingModules.length + missingCompetencies.length;
+  const buffer = fs.readFileSync(normalizedPath);
+  const sourceHash = sha256(buffer);
+  invariant(
+    sourceHash === EXPECTED_SOURCE_SHA256,
+    `Source hash mismatch. Expected ${EXPECTED_SOURCE_SHA256}, got ${sourceHash}`,
+  );
 
-  if (promptCount === 0) {
-    console.log("\nAll programs, modules, and competencies already exist.");
-    return decisions;
-  }
+  const workbook = read(buffer.toString("utf8"), { type: "string" });
+  const sheetName = workbook.SheetNames[0];
+  invariant(sheetName, "CSV workbook has no sheet");
+  const worksheet = workbook.Sheets[sheetName];
+  invariant(worksheet, "CSV worksheet is missing");
 
-  console.log(`\n→ ${promptCount} prompts required before import can proceed\n`);
-
-  for (const program of missingPrograms) {
-    const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([
-      {
-        type: "confirm",
-        name: "confirmed",
-        message: buildProgramPromptMessage(program),
-        default: false,
-      },
-    ]);
-    decisions.set(program.handle, confirmed);
-  }
-
-  for (const module of missingModules) {
-    const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([
-      {
-        type: "confirm",
-        name: "confirmed",
-        message: buildModulePromptMessage(module),
-        default: false,
-      },
-    ]);
-    decisions.set(module.handle, confirmed);
-  }
-
-  for (const competency of missingCompetencies) {
-    const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([
-      {
-        type: "confirm",
-        name: "confirmed",
-        message: buildCompetencyPromptMessage(competency),
-        default: false,
-      },
-    ]);
-    decisions.set(competency.handle, confirmed);
-  }
-
-  return decisions;
+  return {
+    sourceHash,
+    rows: utils.sheet_to_json<unknown[]>(worksheet, {
+      header: 1,
+      defval: "",
+      raw: false,
+    }),
+  };
 }
 
-function isApprovedForCreation(
-  handle: string,
-  exists: boolean,
-  decisions: CreationDecisions,
-): boolean {
-  if (exists) return true;
-  return decisions.get(handle) === true;
-}
-
-async function findCourseIdForProgram(
-  vaarwater: string,
-): Promise<string | null> {
-  const niveaus: Niveau[] = ["4", "a", "b"];
-  for (const niveau of niveaus) {
-    const siblingHandle = resolveProgramHandle(vaarwater, niveau);
-    const sibling = await Course.Program.fromHandle(siblingHandle);
-    if (sibling?.course?.id) {
-      return sibling.course.id;
-    }
-  }
-
-  const discipline = await Course.Discipline.fromHandle("jachtzeilen");
-  if (!discipline) return null;
-
-  const volwassenenCategory = await Course.Category.fromHandle("volwassenen");
-  const course = await Course.findOne({
-    disciplineId: discipline.id,
-    ...(volwassenenCategory
-      ? { categoryId: volwassenenCategory.id }
-      : {}),
-  });
-
-  return course?.id ?? null;
-}
-
-async function createApprovedProgram(
-  program: ProgramEntityRecord,
-): Promise<{ id: string } | null> {
-  const degreeHandle = `niveau-${program.niveau}`;
-  const degree = await Course.Degree.fromHandle(degreeHandle);
-  if (!degree) {
-    console.error(
-      `Failed to create program ${program.handle}: degree "${degreeHandle}" not found`,
+async function loadUniformGearTypeIds(courseId: string): Promise<string[]> {
+  const query = useQuery();
+  const rows = await query
+    .select({
+      curriculumId: schema.curriculum.id,
+      gearTypeId: schema.curriculumGearLink.gearTypeId,
+    })
+    .from(schema.curriculum)
+    .innerJoin(
+      schema.program,
+      eq(schema.program.id, schema.curriculum.programId),
+    )
+    .innerJoin(
+      schema.curriculumGearLink,
+      eq(schema.curriculumGearLink.curriculumId, schema.curriculum.id),
+    )
+    .where(
+      and(
+        eq(schema.program.courseId, courseId),
+        eq(schema.curriculum.revision, "2501"),
+      ),
     );
-    return null;
+
+  invariant(rows.length > 0, `No 2501 gear links found for course ${courseId}`);
+  const byCurriculum = new Map<string, Set<string>>();
+  for (const row of rows) {
+    const ids = byCurriculum.get(row.curriculumId) ?? new Set<string>();
+    ids.add(row.gearTypeId);
+    byCurriculum.set(row.curriculumId, ids);
   }
 
-  const courseId = await findCourseIdForProgram(program.vaarwater);
-  if (!courseId) {
-    console.error(
-      `Failed to create program ${program.handle}: could not resolve courseId (create manually or ensure a sibling program exists)`,
-    );
-    return null;
-  }
+  const signatures = unique(
+    [...byCurriculum.values()].map((ids) => [...ids].sort().join(",")),
+  );
+  invariant(
+    signatures.length === 1,
+    `2501 curricula do not have a uniform gear-type set for course ${courseId}`,
+  );
 
-  try {
-    return await Course.Program.create({
-      handle: program.handle,
-      title: program.title,
-      degreeId: degree.id,
-      courseId,
-    });
-  } catch (error) {
-    console.error(`Failed to create program ${program.handle}:`, error);
-    return null;
-  }
+  const gearTypeIds = [...(byCurriculum.values().next().value ?? [])].sort();
+  invariant(
+    gearTypeIds.length === EXPECTED_GEAR_TYPE_COUNT,
+    `Expected ${EXPECTED_GEAR_TYPE_COUNT} gear types for course ${courseId}, found ${gearTypeIds.length}`,
+  );
+  return gearTypeIds;
 }
 
-async function ensureCurriculumStarted(
-  curriculumId: string,
-  startedAt: string | null | undefined,
-) {
-  if (startedAt) return;
-  await Curriculum.start({
-    curriculumId,
-    startedAt: REVISION_STARTED_AT,
-  });
-}
-
-async function getOrCreateCurriculum2601(
-  programId: string,
-  cache: Map<string, Promise<{ id: string }>>,
-): Promise<{ id: string }> {
-  const cacheKey = `${programId}-${REVISION}`;
-  let curriculumPromise = cache.get(cacheKey);
-
-  if (!curriculumPromise) {
-    curriculumPromise = (async () => {
-      const existing = await Curriculum.list({ filter: { programId } });
-      const match = existing.find((c) => c.revision === REVISION);
-
-      if (match) {
-        await ensureCurriculumStarted(match.id, match.startedAt);
-        return { id: match.id };
-      }
-
-      const created = await Curriculum.create({ programId, revision: REVISION });
-      await ensureCurriculumStarted(created.id, null);
-      return created;
-    })();
-    cache.set(cacheKey, curriculumPromise);
-  }
-
-  return curriculumPromise;
-}
-
-async function upsertCurriculumCompetency(input: {
+async function assertExistingDraftIsSubset(input: {
   curriculumId: string;
-  moduleId: string;
-  competencyId: string;
-  isRequired: boolean;
-  requirement: string;
+  targetRows: ImportRow[];
+  gearTypeIds: string[];
 }) {
   const query = useQuery();
-  const existing = await Curriculum.Competency.list({
-    filter: {
-      curriculumId: input.curriculumId,
-      moduleId: input.moduleId,
-      competencyId: input.competencyId,
-    },
-  });
-
-  const match = existing[0];
-  if (match) {
-    await query
-      .update(schema.curriculumCompetency)
-      .set({
-        isRequired: input.isRequired,
-        requirement: input.requirement,
+  const [moduleRows, competencyRows, gearRows] = await Promise.all([
+    query
+      .select({ moduleHandle: schema.module.handle })
+      .from(schema.curriculumModule)
+      .innerJoin(
+        schema.module,
+        eq(schema.module.id, schema.curriculumModule.moduleId),
+      )
+      .where(eq(schema.curriculumModule.curriculumId, input.curriculumId)),
+    query
+      .select({
+        moduleHandle: schema.module.handle,
+        competencyHandle: schema.competency.handle,
+        isRequired: schema.curriculumCompetency.isRequired,
+        requirement: schema.curriculumCompetency.requirement,
       })
-      .where(eq(schema.curriculumCompetency.id, match.id));
-    return { updated: true };
-  }
+      .from(schema.curriculumCompetency)
+      .innerJoin(
+        schema.module,
+        eq(schema.module.id, schema.curriculumCompetency.moduleId),
+      )
+      .innerJoin(
+        schema.competency,
+        eq(schema.competency.id, schema.curriculumCompetency.competencyId),
+      )
+      .where(eq(schema.curriculumCompetency.curriculumId, input.curriculumId)),
+    query
+      .select({ gearTypeId: schema.curriculumGearLink.gearTypeId })
+      .from(schema.curriculumGearLink)
+      .where(eq(schema.curriculumGearLink.curriculumId, input.curriculumId)),
+  ]);
 
-  await Curriculum.Competency.create(input);
-  return { updated: false };
+  const targetModules = new Set(
+    input.targetRows.map((row) => row.moduleHandle),
+  );
+  const targetCompetencies = new Set(
+    input.targetRows.map(
+      (row) => `${row.moduleHandle}|${row.competency.handle}`,
+    ),
+  );
+  const targetGearTypes = new Set(input.gearTypeIds);
+
+  const extraModules = moduleRows.filter(
+    (row) => !targetModules.has(row.moduleHandle),
+  );
+  const extraCompetencies = competencyRows.filter((row) => {
+    const key = `${row.moduleHandle}|${row.competencyHandle}`;
+    if (!targetCompetencies.has(key)) return true;
+    const expected = input.targetRows.find(
+      (targetRow) =>
+        targetRow.moduleHandle === row.moduleHandle &&
+        targetRow.competency.handle === row.competencyHandle,
+    );
+    return (
+      !expected ||
+      expected.isRequired !== row.isRequired ||
+      expected.requirement !== row.requirement
+    );
+  });
+  const extraGearTypes = gearRows.filter(
+    (row) => !targetGearTypes.has(row.gearTypeId),
+  );
+
+  invariant(
+    extraModules.length === 0 &&
+      extraCompetencies.length === 0 &&
+      extraGearTypes.length === 0,
+    `Existing curriculum ${input.curriculumId} contains data outside this import`,
+  );
 }
 
-export async function applyImportPlan(
-  plan: ImportPlan,
-  decisions: CreationDecisions,
-): Promise<{
-  rowsProcessed: number;
-  rowsSkipped: number;
-  programsCreated: number;
-  modulesCreated: number;
-  competenciesCreated: number;
-  curriculumLinksUpserted: number;
-}> {
-  const stats = {
-    rowsProcessed: 0,
-    rowsSkipped: 0,
-    programsCreated: 0,
-    modulesCreated: 0,
-    competenciesCreated: 0,
-    curriculumLinksUpserted: 0,
-  };
-
-  const programIds = new Map<string, string>();
-  const moduleIds = new Map<string, string>();
-  const competencyIds = new Map<string, string>();
-  const curriculumCache = new Map<string, Promise<{ id: string }>>();
-  const failedCreations = new Set<string>();
-
-  for (const program of plan.programs.values()) {
-    if (program.exists && program.entity) {
-      programIds.set(program.handle, program.entity.id);
-      continue;
-    }
-    if (!isApprovedForCreation(program.handle, program.exists, decisions)) {
-      failedCreations.add(program.handle);
-      continue;
-    }
-    const created = await createApprovedProgram(program);
-    if (created) {
-      programIds.set(program.handle, created.id);
-      stats.programsCreated++;
-    } else {
-      failedCreations.add(program.handle);
-    }
+async function resolveDatabaseImportPlan(
+  source: SourceImportPlan,
+  catalogHash: string,
+): Promise<DatabaseImportPlan> {
+  const query = useQuery();
+  const courseHandles = unique(source.rows.map((row) => row.courseHandle));
+  const programHandles = unique(source.rows.map((row) => row.programHandle));
+  const moduleHandles = unique(source.rows.map((row) => row.moduleHandle));
+  const competencyReferences = new Map<string, CompetencyReference>();
+  for (const row of source.rows) {
+    competencyReferences.set(row.competency.handle, row.competency);
   }
+  const competencyHandles = [...competencyReferences.keys()];
 
-  for (const module of plan.modules.values()) {
-    if (module.exists && module.entity) {
-      moduleIds.set(module.handle, module.entity.id);
-      continue;
-    }
-    if (!isApprovedForCreation(module.handle, module.exists, decisions)) {
-      failedCreations.add(module.handle);
-      continue;
-    }
-    const weight = plan.moduleWeights.get(module.handle);
-    if (weight === undefined) {
-      console.error(
-        `Failed to create module ${module.handle}: no weight allocated`,
+  const [courses, degrees, modules, competencies, programs] = await Promise.all(
+    [
+      query
+        .select({ id: schema.course.id, handle: schema.course.handle })
+        .from(schema.course)
+        .where(inArray(schema.course.handle, courseHandles)),
+      query
+        .select({ id: schema.degree.id, handle: schema.degree.handle })
+        .from(schema.degree)
+        .where(
+          inArray(schema.degree.handle, ["niveau-4", "niveau-a", "niveau-b"]),
+        ),
+      query
+        .select({ id: schema.module.id, handle: schema.module.handle })
+        .from(schema.module)
+        .where(inArray(schema.module.handle, moduleHandles)),
+      query
+        .select({
+          id: schema.competency.id,
+          handle: schema.competency.handle,
+          title: schema.competency.title,
+          type: schema.competency.type,
+          weight: schema.competency.weight,
+        })
+        .from(schema.competency)
+        .where(inArray(schema.competency.handle, competencyHandles)),
+      query
+        .select({
+          id: schema.program.id,
+          handle: schema.program.handle,
+          title: schema.program.title,
+          courseId: schema.program.courseId,
+          degreeId: schema.program.degreeId,
+        })
+        .from(schema.program)
+        .where(inArray(schema.program.handle, programHandles)),
+    ],
+  );
+
+  invariant(
+    courses.length === courseHandles.length,
+    "Not all four target Jachtzeilen courses exist",
+  );
+  invariant(
+    degrees.length === 3,
+    "Degrees niveau-4, niveau-a and niveau-b must exist",
+  );
+  invariant(
+    modules.length === moduleHandles.length,
+    `Missing modules: ${moduleHandles
+      .filter((handle) => !modules.some((module) => module.handle === handle))
+      .join(", ")}`,
+  );
+
+  const competencyIds = new Map(
+    competencies.map((competency) => [competency.handle, competency.id]),
+  );
+  for (const competency of competencies) {
+    const reference = competencyReferences.get(competency.handle);
+    invariant(reference, `Unexpected competency ${competency.handle}`);
+    if (competency.handle === RRP_HANDLE) {
+      invariant(
+        competency.title === RRP_TITLE &&
+          competency.type === "knowledge" &&
+          competency.weight === RRP_WEIGHT,
+        "Existing RR&P competency does not match the approved title and ordering",
       );
-      failedCreations.add(module.handle);
-      continue;
-    }
-    try {
-      const created = await Course.Module.create({
-        handle: module.handle,
-        title: module.title,
-        weight,
-      });
-      moduleIds.set(module.handle, created.id);
-      stats.modulesCreated++;
-    } catch (error) {
-      console.error(`Failed to create module ${module.handle}:`, error);
-      failedCreations.add(module.handle);
     }
   }
+  const competenciesToCreate = competencyHandles
+    .filter((handle) => !competencyIds.has(handle))
+    .map((handle) => competencyReferences.get(handle))
+    .filter((value): value is CompetencyReference => value !== undefined);
+  const forbiddenMissing = competenciesToCreate.filter(
+    (competency) => !competency.createIfMissing,
+  );
+  invariant(
+    forbiddenMissing.length === 0,
+    `Missing competencies without an approved create decision: ${forbiddenMissing
+      .map((competency) => competency.handle)
+      .join(", ")}`,
+  );
 
-  for (const competency of plan.competencies.values()) {
-    if (competency.exists && competency.entity) {
-      competencyIds.set(competency.handle, competency.entity.id);
-      continue;
-    }
-    if (
-      !isApprovedForCreation(competency.handle, competency.exists, decisions)
-    ) {
-      failedCreations.add(competency.handle);
-      continue;
-    }
-    const type = competency.moduleTitle === "Theorie" ? "knowledge" : "skill";
-    const weight = plan.competencyWeights.get(competency.handle);
-    if (weight === undefined) {
-      console.error(
-        `Failed to create competency ${competency.handle}: no weight allocated`,
+  const courseByHandle = new Map(
+    courses.map((course) => [course.handle, course.id]),
+  );
+  const degreeByHandle = new Map(
+    degrees.map((degree) => [degree.handle, degree.id]),
+  );
+  const moduleByHandle = new Map(
+    modules.map((module) => [module.handle, module.id]),
+  );
+  const programByHandle = new Map(
+    programs.map((program) => [program.handle, program]),
+  );
+
+  const existingProgramIds = programs.map((program) => program.id);
+  const curricula =
+    existingProgramIds.length === 0
+      ? []
+      : await query
+          .select({
+            id: schema.curriculum.id,
+            programId: schema.curriculum.programId,
+            startedAt: schema.curriculum.startedAt,
+          })
+          .from(schema.curriculum)
+          .where(
+            and(
+              inArray(schema.curriculum.programId, existingProgramIds),
+              eq(schema.curriculum.revision, source.revision),
+            ),
+          );
+  const curriculumByProgramId = new Map(
+    curricula.map((curriculum) => [curriculum.programId, curriculum]),
+  );
+
+  const targets: DatabaseTargetPlan[] = [];
+  for (const [programHandle, rows] of source.targets) {
+    const firstRow = rows[0];
+    invariant(firstRow, `No rows for target ${programHandle}`);
+    const courseId = courseByHandle.get(firstRow.courseHandle);
+    const degreeId = degreeByHandle.get(`niveau-${firstRow.niveau}`);
+    invariant(courseId, `Course not found: ${firstRow.courseHandle}`);
+    invariant(degreeId, `Degree not found: niveau-${firstRow.niveau}`);
+
+    const existingProgram = programByHandle.get(programHandle) ?? null;
+    if (existingProgram) {
+      invariant(
+        existingProgram.courseId === courseId &&
+          existingProgram.degreeId === degreeId,
+        `Existing program ${programHandle} points to the wrong course or degree`,
       );
-      failedCreations.add(competency.handle);
-      continue;
-    }
-    try {
-      const created = await Course.Competency.create({
-        handle: competency.handle,
-        title: competency.title,
-        type,
-        weight,
-      });
-      competencyIds.set(competency.handle, created.id);
-      stats.competenciesCreated++;
-    } catch (error) {
-      console.error(`Failed to create competency ${competency.handle}:`, error);
-      failedCreations.add(competency.handle);
-    }
-  }
-
-  for (const row of plan.rows) {
-    if (
-      failedCreations.has(row.programHandle) ||
-      failedCreations.has(row.moduleHandle) ||
-      failedCreations.has(row.competencyHandle) ||
-      !isApprovedForCreation(row.programHandle, plan.programs.get(row.programHandle)?.exists ?? false, decisions) ||
-      !isApprovedForCreation(row.moduleHandle, plan.modules.get(row.moduleHandle)?.exists ?? false, decisions) ||
-      !isApprovedForCreation(row.competencyHandle, plan.competencies.get(row.competencyHandle)?.exists ?? false, decisions)
-    ) {
-      stats.rowsSkipped++;
-      continue;
+      invariant(
+        existingProgram.title === null || existingProgram.title === "",
+        `Existing program ${programHandle} must not have a custom title`,
+      );
     }
 
-    const programId = programIds.get(row.programHandle);
-    const moduleId = moduleIds.get(row.moduleHandle);
-    const competencyId = competencyIds.get(row.competencyHandle);
-
-    if (!programId || !moduleId || !competencyId) {
-      stats.rowsSkipped++;
-      continue;
-    }
-
-    const { id: curriculumId } = await getOrCreateCurriculum2601(
-      programId,
-      curriculumCache,
+    const existingCurriculum = existingProgram
+      ? (curriculumByProgramId.get(existingProgram.id) ?? null)
+      : null;
+    invariant(
+      !existingCurriculum?.startedAt ||
+        new Date(existingCurriculum.startedAt).valueOf() ===
+          new Date(IMPORT_STARTED_AT).valueOf(),
+      `Curriculum ${existingCurriculum?.id} has an unexpected activation date`,
     );
 
-    await Curriculum.linkModule({ curriculumId, moduleId });
+    const gearTypeIds = await loadUniformGearTypeIds(courseId);
+    if (existingCurriculum) {
+      await assertExistingDraftIsSubset({
+        curriculumId: existingCurriculum.id,
+        targetRows: rows,
+        gearTypeIds,
+      });
+    }
 
-    await upsertCurriculumCompetency({
-      curriculumId,
-      moduleId,
-      competencyId,
-      isRequired: row.isRequired,
-      requirement: row.eis,
+    targets.push({
+      programHandle,
+      courseHandle: firstRow.courseHandle,
+      courseId,
+      degreeId,
+      rows,
+      moduleIds: new Map(
+        unique(rows.map((row) => row.moduleHandle)).map((handle) => {
+          const id = moduleByHandle.get(handle);
+          invariant(id, `Module not found: ${handle}`);
+          return [handle, id];
+        }),
+      ),
+      gearTypeIds,
+      existingProgramId: existingProgram?.id ?? null,
+      existingCurriculumId: existingCurriculum?.id ?? null,
+      existingCurriculumStartedAt: existingCurriculum?.startedAt ?? null,
     });
-
-    stats.rowsProcessed++;
-    stats.curriculumLinksUpserted++;
   }
 
-  return stats;
+  return {
+    source,
+    targets,
+    competencyIds,
+    competenciesToCreate,
+    catalogHash,
+  };
 }
 
-function printLookupSummary(plan: ImportPlan) {
-  const programTargets = new Set(plan.rows.map((row) => row.programHandle));
-  const missingPrograms = [...plan.programs.values()].filter((p) => !p.exists);
-  const missingModules = [...plan.modules.values()].filter((m) => !m.exists);
-  const missingCompetencies = [...plan.competencies.values()].filter(
-    (c) => !c.exists,
+function printPlan(plan: DatabaseImportPlan) {
+  console.log("Jachtzeilen 4/A/B import plan");
+  console.log("=============================");
+  console.log(`Revision: ${plan.source.revision}`);
+  console.log(`Started at: ${IMPORT_STARTED_AT}`);
+  console.log(`Source hash: ${plan.source.sourceHash}`);
+  console.log(`Catalog hash: ${plan.catalogHash}`);
+  console.log(`Source links: ${plan.source.sourceRows.length}`);
+  console.log(`Materialized links: ${plan.source.rows.length}`);
+  console.log(`Targets: ${plan.targets.length}`);
+  console.log(
+    `Normalized source links: ${plan.source.normalization.changed.length}`,
+  );
+  console.log(
+    `New programs: ${plan.targets.filter((t) => !t.existingProgramId).length}`,
+  );
+  console.log(
+    `New active curricula: ${plan.targets.filter((t) => !t.existingCurriculumId).length}`,
+  );
+  console.log(
+    `New competencies: ${
+      plan.competenciesToCreate
+        .map((competency) => competency.handle)
+        .join(", ") || "none"
+    }`,
+  );
+  console.log("");
+
+  for (const target of plan.targets) {
+    console.log(
+      `- ${target.programHandle}: ${target.rows.length} competencies, ${target.moduleIds.size} modules, ${target.gearTypeIds.length} gear types`,
+    );
+  }
+}
+
+async function applySharedTitleCorrections(): Promise<
+  ImportManifest["correctedCompetencyTitles"]
+> {
+  const query = useQuery();
+  const rows = await query
+    .select({
+      id: schema.competency.id,
+      handle: schema.competency.handle,
+      title: schema.competency.title,
+    })
+    .from(schema.competency)
+    .where(
+      inArray(
+        schema.competency.handle,
+        SHARED_COMPETENCY_TITLE_CORRECTIONS.map(
+          (correction) => correction.handle,
+        ),
+      ),
+    );
+  invariant(
+    rows.length === SHARED_COMPETENCY_TITLE_CORRECTIONS.length,
+    "Not all shared competencies requiring title correction exist",
   );
 
-  console.log(`\nParsed ${plan.rows.length} rows across ${programTargets.size} program targets (revision ${REVISION})`);
-  console.log(
-    `Programs:     ${plan.programs.size - missingPrograms.length} found, ${missingPrograms.length} missing`,
+  const changed: ImportManifest["correctedCompetencyTitles"] = [];
+  for (const correction of SHARED_COMPETENCY_TITLE_CORRECTIONS) {
+    const row = rows.find(
+      (candidate) => candidate.handle === correction.handle,
+    );
+    invariant(row, `Shared competency not found: ${correction.handle}`);
+    invariant(
+      row.title === correction.oldTitle || row.title === correction.newTitle,
+      `Unexpected title for shared competency ${correction.handle}`,
+    );
+    if (row.title === correction.newTitle) continue;
+
+    const updated = await query
+      .update(schema.competency)
+      .set({ title: correction.newTitle })
+      .where(
+        and(
+          eq(schema.competency.id, row.id),
+          eq(schema.competency.title, correction.oldTitle),
+        ),
+      )
+      .returning({ id: schema.competency.id });
+    invariant(
+      updated.length === 1,
+      `Concurrent title change detected for ${correction.handle}`,
+    );
+    changed.push({
+      competencyId: row.id,
+      handle: correction.handle,
+      from: correction.oldTitle,
+      to: correction.newTitle,
+    });
+  }
+  return changed;
+}
+
+async function createMissingCompetencies(plan: DatabaseImportPlan): Promise<{
+  createdIds: string[];
+  shiftedWeights: ImportManifest["shiftedCompetencyWeights"];
+}> {
+  const query = useQuery();
+  if (plan.competenciesToCreate.length === 0) {
+    return { createdIds: [], shiftedWeights: [] };
+  }
+  invariant(
+    plan.competenciesToCreate.length === 1 &&
+      plan.competenciesToCreate[0]?.handle === RRP_HANDLE,
+    "Only the approved RR&P competency may be created",
   );
-  console.log(
-    `Modules:      ${plan.modules.size - missingModules.length} found, ${missingModules.length} missing`,
+
+  const reglementen = await query
+    .select({
+      id: schema.competency.id,
+      weight: schema.competency.weight,
+    })
+    .from(schema.competency)
+    .where(eq(schema.competency.handle, "reglementen"));
+  invariant(
+    reglementen.length === 1 && reglementen[0]?.weight === REGLEMENTEN_WEIGHT,
+    "Reglementen does not have the expected ordering weight",
   );
-  console.log(
-    `Competencies: ${plan.competencies.size - missingCompetencies.length} found, ${missingCompetencies.length} missing`,
+
+  const shifted = await query
+    .update(schema.competency)
+    .set({ weight: sql`${schema.competency.weight} + 1` })
+    .where(sql`${schema.competency.weight} > ${REGLEMENTEN_WEIGHT}`)
+    .returning({
+      competencyId: schema.competency.id,
+      handle: schema.competency.handle,
+      weight: schema.competency.weight,
+    });
+  const shiftedWeights = shifted.map((row) => ({
+    competencyId: row.competencyId,
+    handle: row.handle,
+    from: row.weight - 1,
+    to: row.weight,
+  }));
+
+  const competency = plan.competenciesToCreate[0];
+  invariant(competency, "RR&P competency plan is missing");
+  const inserted = await query
+    .insert(schema.competency)
+    .values({
+      handle: competency.handle,
+      title: competency.title,
+      type: competency.type,
+      weight: RRP_WEIGHT,
+    })
+    .returning({ id: schema.competency.id });
+  const id = inserted[0]?.id;
+  invariant(id, `Failed to create competency ${competency.handle}`);
+  plan.competencyIds.set(competency.handle, id);
+
+  return { createdIds: [id], shiftedWeights };
+}
+
+async function verifyImportedTarget(input: {
+  curriculumId: string;
+  target: DatabaseTargetPlan;
+  competencyIds: Map<string, string>;
+}) {
+  const query = useQuery();
+  const [curriculumRows, moduleRows, competencyRows, gearRows] =
+    await Promise.all([
+      query
+        .select({
+          revision: schema.curriculum.revision,
+          startedAt: schema.curriculum.startedAt,
+        })
+        .from(schema.curriculum)
+        .where(eq(schema.curriculum.id, input.curriculumId)),
+      query
+        .select({ moduleId: schema.curriculumModule.moduleId })
+        .from(schema.curriculumModule)
+        .where(eq(schema.curriculumModule.curriculumId, input.curriculumId)),
+      query
+        .select({
+          id: schema.curriculumCompetency.id,
+          moduleId: schema.curriculumCompetency.moduleId,
+          competencyId: schema.curriculumCompetency.competencyId,
+          isRequired: schema.curriculumCompetency.isRequired,
+          requirement: schema.curriculumCompetency.requirement,
+        })
+        .from(schema.curriculumCompetency)
+        .where(
+          eq(schema.curriculumCompetency.curriculumId, input.curriculumId),
+        ),
+      query
+        .select({ gearTypeId: schema.curriculumGearLink.gearTypeId })
+        .from(schema.curriculumGearLink)
+        .where(eq(schema.curriculumGearLink.curriculumId, input.curriculumId)),
+    ]);
+
+  invariant(
+    curriculumRows.length === 1 &&
+      curriculumRows[0]?.revision ===
+        JACHTZEILEN_AB_CONTENT_DECISIONS.revision &&
+      new Date(curriculumRows[0].startedAt ?? "").valueOf() ===
+        new Date(IMPORT_STARTED_AT).valueOf(),
+    `Curriculum metadata mismatch for ${input.target.programHandle}`,
   );
-  console.log(
-    `Parse notes:  ${plan.parseStats.defaultedKeuzeCount} rows defaulted to Keuze (empty V/O); ${plan.parseStats.skippedEmptyEis} empty eis cells skipped during parse`,
+
+  invariant(
+    JSON.stringify(moduleRows.map((row) => row.moduleId).sort()) ===
+      JSON.stringify([...input.target.moduleIds.values()].sort()),
+    `Module count mismatch for ${input.target.programHandle}`,
   );
+  const expectedCompetencies = input.target.rows
+    .map((row) => {
+      const moduleId = input.target.moduleIds.get(row.moduleHandle);
+      const competencyId = input.competencyIds.get(row.competency.handle);
+      invariant(moduleId, `Module ID missing: ${row.moduleHandle}`);
+      invariant(
+        competencyId,
+        `Competency ID missing: ${row.competency.handle}`,
+      );
+      return JSON.stringify({
+        moduleId,
+        competencyId,
+        isRequired: row.isRequired,
+        requirement: row.requirement,
+      });
+    })
+    .sort();
+  const actualCompetencies = competencyRows
+    .map((row) =>
+      JSON.stringify({
+        moduleId: row.moduleId,
+        competencyId: row.competencyId,
+        isRequired: row.isRequired,
+        requirement: row.requirement,
+      }),
+    )
+    .sort();
+  invariant(
+    JSON.stringify(actualCompetencies) === JSON.stringify(expectedCompetencies),
+    `Competency count mismatch for ${input.target.programHandle}`,
+  );
+  invariant(
+    JSON.stringify(gearRows.map((row) => row.gearTypeId).sort()) ===
+      JSON.stringify([...input.target.gearTypeIds].sort()),
+    `Gear-type count mismatch for ${input.target.programHandle}`,
+  );
+}
+
+async function loadTargetLinkState(curriculumId: string): Promise<{
+  moduleIds: Set<string>;
+  competencyLinkIds: Set<string>;
+  gearTypeIds: Set<string>;
+}> {
+  const query = useQuery();
+  const [moduleRows, competencyRows, gearRows] = await Promise.all([
+    query
+      .select({ moduleId: schema.curriculumModule.moduleId })
+      .from(schema.curriculumModule)
+      .where(eq(schema.curriculumModule.curriculumId, curriculumId)),
+    query
+      .select({ id: schema.curriculumCompetency.id })
+      .from(schema.curriculumCompetency)
+      .where(eq(schema.curriculumCompetency.curriculumId, curriculumId)),
+    query
+      .select({ gearTypeId: schema.curriculumGearLink.gearTypeId })
+      .from(schema.curriculumGearLink)
+      .where(eq(schema.curriculumGearLink.curriculumId, curriculumId)),
+  ]);
+  return {
+    moduleIds: new Set(moduleRows.map((row) => row.moduleId)),
+    competencyLinkIds: new Set(competencyRows.map((row) => row.id)),
+    gearTypeIds: new Set(gearRows.map((row) => row.gearTypeId)),
+  };
+}
+
+async function applyImport(plan: DatabaseImportPlan): Promise<ImportManifest> {
+  return withTransaction(async () => {
+    const transactionCatalog = await readJachtzeilenCatalogFingerprint();
+    invariant(
+      transactionCatalog.hash === plan.catalogHash,
+      `Catalog changed after planning. Expected ${plan.catalogHash}, got ${transactionCatalog.hash}`,
+    );
+
+    const query = useQuery();
+    const createdProgramIds: string[] = [];
+    const createdCurriculumIds: string[] = [];
+    for (const target of plan.targets) {
+      if (target.existingCurriculumId) {
+        await assertExistingDraftIsSubset({
+          curriculumId: target.existingCurriculumId,
+          targetRows: target.rows,
+          gearTypeIds: target.gearTypeIds,
+        });
+      }
+    }
+    const correctedCompetencyTitles = await applySharedTitleCorrections();
+    const { createdIds: createdCompetencyIds, shiftedWeights } =
+      await createMissingCompetencies(plan);
+    const manifestTargets: ImportManifest["targets"] = [];
+
+    for (const target of plan.targets) {
+      let programId = target.existingProgramId;
+      if (!programId) {
+        const inserted = await query
+          .insert(schema.program)
+          .values({
+            handle: target.programHandle,
+            courseId: target.courseId,
+            degreeId: target.degreeId,
+          })
+          .returning({ id: schema.program.id });
+        programId = inserted[0]?.id ?? null;
+        invariant(
+          programId,
+          `Failed to create program ${target.programHandle}`,
+        );
+        createdProgramIds.push(programId);
+      }
+
+      let curriculumId = target.existingCurriculumId;
+      const curriculumWasCreated = !curriculumId;
+      let previousStartedAt = target.existingCurriculumStartedAt;
+      if (!curriculumId) {
+        const inserted = await query
+          .insert(schema.curriculum)
+          .values({
+            programId,
+            revision: plan.source.revision,
+            startedAt: IMPORT_STARTED_AT,
+          })
+          .returning({ id: schema.curriculum.id });
+        curriculumId = inserted[0]?.id ?? null;
+        invariant(
+          curriculumId,
+          `Failed to create curriculum for ${target.programHandle}`,
+        );
+        createdCurriculumIds.push(curriculumId);
+      } else {
+        const existingRows = await query
+          .select({ startedAt: schema.curriculum.startedAt })
+          .from(schema.curriculum)
+          .where(eq(schema.curriculum.id, curriculumId));
+        const currentStartedAt = existingRows[0]?.startedAt ?? null;
+        previousStartedAt = currentStartedAt;
+        invariant(
+          existingRows.length === 1 &&
+            (!currentStartedAt ||
+              new Date(currentStartedAt).valueOf() ===
+                new Date(IMPORT_STARTED_AT).valueOf()),
+          `Curriculum ${curriculumId} changed after planning`,
+        );
+        if (!currentStartedAt) {
+          const updated = await query
+            .update(schema.curriculum)
+            .set({ startedAt: IMPORT_STARTED_AT })
+            .where(
+              and(
+                eq(schema.curriculum.id, curriculumId),
+                sql`${schema.curriculum.startedAt} IS NULL`,
+              ),
+            )
+            .returning({ id: schema.curriculum.id });
+          invariant(
+            updated.length === 1,
+            `Could not activate curriculum ${curriculumId}`,
+          );
+        }
+      }
+
+      const before = curriculumWasCreated
+        ? {
+            moduleIds: new Set<string>(),
+            competencyLinkIds: new Set<string>(),
+            gearTypeIds: new Set<string>(),
+          }
+        : await loadTargetLinkState(curriculumId);
+
+      await query
+        .insert(schema.curriculumModule)
+        .values(
+          [...target.moduleIds.values()].map((moduleId) => ({
+            curriculumId,
+            moduleId,
+          })),
+        )
+        .onConflictDoNothing();
+
+      await query
+        .insert(schema.curriculumCompetency)
+        .values(
+          target.rows.map((row) => {
+            const moduleId = target.moduleIds.get(row.moduleHandle);
+            const competencyId = plan.competencyIds.get(row.competency.handle);
+            invariant(moduleId, `Module ID missing: ${row.moduleHandle}`);
+            invariant(
+              competencyId,
+              `Competency ID missing: ${row.competency.handle}`,
+            );
+            return {
+              curriculumId,
+              moduleId,
+              competencyId,
+              isRequired: row.isRequired,
+              requirement: row.requirement,
+            };
+          }),
+        )
+        .onConflictDoNothing();
+
+      await query
+        .insert(schema.curriculumGearLink)
+        .values(
+          target.gearTypeIds.map((gearTypeId) => ({
+            curriculumId,
+            gearTypeId,
+          })),
+        )
+        .onConflictDoNothing();
+
+      await verifyImportedTarget({
+        curriculumId,
+        target,
+        competencyIds: plan.competencyIds,
+      });
+      const after = await loadTargetLinkState(curriculumId);
+      manifestTargets.push({
+        programHandle: target.programHandle,
+        programId,
+        curriculumId,
+        courseHandle: target.courseHandle,
+        competencyCount: target.rows.length,
+        moduleCount: target.moduleIds.size,
+        gearTypeCount: target.gearTypeIds.length,
+        curriculumWasCreated,
+        previousStartedAt,
+        createdModuleIds: [...after.moduleIds].filter(
+          (id) => !before.moduleIds.has(id),
+        ),
+        createdCompetencyLinkIds: [...after.competencyLinkIds].filter(
+          (id) => !before.competencyLinkIds.has(id),
+        ),
+        createdGearTypeIds: [...after.gearTypeIds].filter(
+          (id) => !before.gearTypeIds.has(id),
+        ),
+      });
+    }
+
+    const postImportCatalog = await readJachtzeilenCatalogFingerprint();
+    invariant(
+      postImportCatalog.hash === plan.catalogHash,
+      `Catalog fingerprint changed unexpectedly during import: ${postImportCatalog.hash}`,
+    );
+
+    return {
+      kind: "jachtzeilen-ab-import",
+      version: 2,
+      createdAt: new Date().toISOString(),
+      sourceHash: plan.source.sourceHash,
+      catalogHash: plan.catalogHash,
+      revision: plan.source.revision,
+      startedAt: IMPORT_STARTED_AT,
+      createdProgramIds,
+      createdCurriculumIds,
+      createdCompetencyIds,
+      shiftedCompetencyWeights: shiftedWeights,
+      correctedCompetencyTitles,
+      normalization: plan.source.normalization,
+      targets: manifestTargets,
+    };
+  });
+}
+
+function readManifest(manifestPath: string): ImportManifest {
+  const parsed = JSON.parse(
+    fs.readFileSync(manifestPath, "utf8"),
+  ) as ImportManifest;
+  invariant(
+    parsed.kind === "jachtzeilen-ab-import" && parsed.version === 2,
+    "Unsupported manifest",
+  );
+  invariant(
+    parsed.sourceHash === EXPECTED_SOURCE_SHA256,
+    "Manifest source hash does not match the reviewed CSV",
+  );
+  invariant(
+    /^[a-f0-9]{64}$/.test(parsed.catalogHash),
+    "Manifest catalog hash is invalid",
+  );
+  invariant(
+    sameInstant(parsed.startedAt, IMPORT_STARTED_AT),
+    "Manifest activation date is invalid",
+  );
+  invariant(
+    parsed.revision === JACHTZEILEN_AB_CONTENT_DECISIONS.revision,
+    "Manifest revision is invalid",
+  );
+  invariant(
+    parsed.targets.length === EXPECTED_TARGET_COUNT &&
+      JSON.stringify(
+        parsed.targets.map((target) => target.programHandle).sort(),
+      ) === JSON.stringify(Object.keys(EXPECTED_LINK_COUNTS_BY_PROGRAM).sort()),
+    "Manifest target set is invalid",
+  );
+  invariant(
+    parsed.targets.every(
+      (target) =>
+        target.competencyCount ===
+          EXPECTED_LINK_COUNTS_BY_PROGRAM[
+            target.programHandle as keyof typeof EXPECTED_LINK_COUNTS_BY_PROGRAM
+          ] && target.gearTypeCount === EXPECTED_GEAR_TYPE_COUNT,
+    ),
+    "Manifest target counts are invalid",
+  );
+  return parsed;
+}
+
+function writeManifest(
+  manifest: ImportManifest,
+  requestedPath?: string,
+): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const manifestPath =
+    requestedPath ??
+    path.join(
+      process.cwd(),
+      `.jachtzeilen-ab-import-manifest-${timestamp}.json`,
+    );
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  return manifestPath;
+}
+
+async function inspectRollback(manifest: ImportManifest) {
+  const query = useQuery();
+  const curriculumIds = unique(
+    manifest.targets.map((target) => target.curriculumId),
+  );
+  const [catalog, curricula, studentRows, certificateRows] = await Promise.all([
+    readJachtzeilenCatalogFingerprint(),
+    query
+      .select({
+        id: schema.curriculum.id,
+        revision: schema.curriculum.revision,
+        startedAt: schema.curriculum.startedAt,
+      })
+      .from(schema.curriculum)
+      .where(inArray(schema.curriculum.id, curriculumIds)),
+    query
+      .select({ id: schema.studentCurriculum.id })
+      .from(schema.studentCurriculum)
+      .where(inArray(schema.studentCurriculum.curriculumId, curriculumIds))
+      .limit(1),
+    query
+      .select({ id: schema.certificate.id })
+      .from(schema.certificate)
+      .innerJoin(
+        schema.studentCurriculum,
+        eq(schema.studentCurriculum.id, schema.certificate.studentCurriculumId),
+      )
+      .where(inArray(schema.studentCurriculum.curriculumId, curriculumIds))
+      .limit(1),
+  ]);
+
+  invariant(
+    catalog.hash === manifest.catalogHash,
+    `Rollback refused: catalog hash mismatch (${catalog.hash})`,
+  );
+  invariant(
+    curricula.length === curriculumIds.length &&
+      curricula.every(
+        (curriculum) =>
+          curriculum.revision === manifest.revision &&
+          new Date(curriculum.startedAt ?? "").valueOf() ===
+            new Date(manifest.startedAt).valueOf(),
+      ),
+    "Rollback refused: imported curriculum metadata changed",
+  );
+  invariant(
+    studentRows.length === 0,
+    "Rollback refused: at least one student is linked to an imported curriculum",
+  );
+  invariant(
+    certificateRows.length === 0,
+    "Rollback refused: at least one certificate is linked to an imported curriculum",
+  );
+
+  if (manifest.shiftedCompetencyWeights.length > 0) {
+    const shiftedRows = await query
+      .select({
+        id: schema.competency.id,
+        weight: schema.competency.weight,
+      })
+      .from(schema.competency)
+      .where(
+        inArray(
+          schema.competency.id,
+          manifest.shiftedCompetencyWeights.map((entry) => entry.competencyId),
+        ),
+      );
+    invariant(
+      shiftedRows.length === manifest.shiftedCompetencyWeights.length &&
+        shiftedRows.every((row) => {
+          const expected = manifest.shiftedCompetencyWeights.find(
+            (entry) => entry.competencyId === row.id,
+          );
+          return expected?.to === row.weight;
+        }),
+      "Rollback refused: shifted competency weights changed",
+    );
+  }
+
+  if (manifest.correctedCompetencyTitles.length > 0) {
+    const titleRows = await query
+      .select({
+        id: schema.competency.id,
+        title: schema.competency.title,
+      })
+      .from(schema.competency)
+      .where(
+        inArray(
+          schema.competency.id,
+          manifest.correctedCompetencyTitles.map((entry) => entry.competencyId),
+        ),
+      );
+    invariant(
+      titleRows.length === manifest.correctedCompetencyTitles.length &&
+        titleRows.every((row) => {
+          const expected = manifest.correctedCompetencyTitles.find(
+            (entry) => entry.competencyId === row.id,
+          );
+          return expected?.to === row.title;
+        }),
+      "Rollback refused: corrected competency titles changed",
+    );
+  }
+
+  for (const target of manifest.targets.filter(
+    (candidate) => !candidate.curriculumWasCreated,
+  )) {
+    const state = await loadTargetLinkState(target.curriculumId);
+    invariant(
+      target.createdModuleIds.every((id) => state.moduleIds.has(id)) &&
+        target.createdCompetencyLinkIds.every((id) =>
+          state.competencyLinkIds.has(id),
+        ) &&
+        target.createdGearTypeIds.every((id) => state.gearTypeIds.has(id)),
+      `Rollback refused: imported links changed for ${target.programHandle}`,
+    );
+  }
+}
+
+async function rollbackImport(manifest: ImportManifest) {
+  await withTransaction(async () => {
+    await inspectRollback(manifest);
+    const query = useQuery();
+    const curriculumIds = manifest.createdCurriculumIds;
+
+    for (const target of manifest.targets.filter(
+      (candidate) => !candidate.curriculumWasCreated,
+    )) {
+      if (target.createdCompetencyLinkIds.length > 0) {
+        await query
+          .delete(schema.curriculumCompetency)
+          .where(
+            inArray(
+              schema.curriculumCompetency.id,
+              target.createdCompetencyLinkIds,
+            ),
+          );
+      }
+      if (target.createdGearTypeIds.length > 0) {
+        await query
+          .delete(schema.curriculumGearLink)
+          .where(
+            and(
+              eq(schema.curriculumGearLink.curriculumId, target.curriculumId),
+              inArray(
+                schema.curriculumGearLink.gearTypeId,
+                target.createdGearTypeIds,
+              ),
+            ),
+          );
+      }
+      if (target.createdModuleIds.length > 0) {
+        await query
+          .delete(schema.curriculumModule)
+          .where(
+            and(
+              eq(schema.curriculumModule.curriculumId, target.curriculumId),
+              inArray(
+                schema.curriculumModule.moduleId,
+                target.createdModuleIds,
+              ),
+            ),
+          );
+      }
+      if (!sameInstant(target.previousStartedAt, manifest.startedAt)) {
+        const updated = await query
+          .update(schema.curriculum)
+          .set({ startedAt: target.previousStartedAt })
+          .where(
+            and(
+              eq(schema.curriculum.id, target.curriculumId),
+              eq(schema.curriculum.startedAt, manifest.startedAt),
+            ),
+          )
+          .returning({ id: schema.curriculum.id });
+        invariant(
+          updated.length === 1,
+          `Rollback refused: activation changed for ${target.programHandle}`,
+        );
+      }
+    }
+
+    if (curriculumIds.length > 0) {
+      await query
+        .delete(schema.curriculumCompetency)
+        .where(
+          inArray(schema.curriculumCompetency.curriculumId, curriculumIds),
+        );
+      await query
+        .delete(schema.curriculumModule)
+        .where(inArray(schema.curriculumModule.curriculumId, curriculumIds));
+      await query
+        .delete(schema.curriculumGearLink)
+        .where(inArray(schema.curriculumGearLink.curriculumId, curriculumIds));
+      await query
+        .delete(schema.curriculum)
+        .where(inArray(schema.curriculum.id, curriculumIds));
+    }
+
+    if (manifest.createdProgramIds.length > 0) {
+      const remainingCurricula = await query
+        .select({ id: schema.curriculum.id })
+        .from(schema.curriculum)
+        .where(inArray(schema.curriculum.programId, manifest.createdProgramIds))
+        .limit(1);
+      invariant(
+        remainingCurricula.length === 0,
+        "Rollback refused: a created program has another curriculum",
+      );
+      await query
+        .delete(schema.program)
+        .where(inArray(schema.program.id, manifest.createdProgramIds));
+    }
+
+    if (manifest.createdCompetencyIds.length > 0) {
+      const remainingLinks = await query
+        .select({ id: schema.curriculumCompetency.id })
+        .from(schema.curriculumCompetency)
+        .where(
+          inArray(
+            schema.curriculumCompetency.competencyId,
+            manifest.createdCompetencyIds,
+          ),
+        )
+        .limit(1);
+      invariant(
+        remainingLinks.length === 0,
+        "Rollback refused: a created competency is linked elsewhere",
+      );
+      await query
+        .delete(schema.competency)
+        .where(inArray(schema.competency.id, manifest.createdCompetencyIds));
+    }
+
+    for (const entry of manifest.shiftedCompetencyWeights) {
+      const updated = await query
+        .update(schema.competency)
+        .set({ weight: entry.from })
+        .where(
+          and(
+            eq(schema.competency.id, entry.competencyId),
+            eq(schema.competency.weight, entry.to),
+          ),
+        )
+        .returning({ id: schema.competency.id });
+      invariant(
+        updated.length === 1,
+        `Rollback refused: competency weight changed for ${entry.handle}`,
+      );
+    }
+
+    for (const entry of manifest.correctedCompetencyTitles) {
+      const updated = await query
+        .update(schema.competency)
+        .set({ title: entry.from })
+        .where(
+          and(
+            eq(schema.competency.id, entry.competencyId),
+            eq(schema.competency.title, entry.to),
+          ),
+        )
+        .returning({ id: schema.competency.id });
+      invariant(
+        updated.length === 1,
+        `Rollback refused: competency title changed for ${entry.handle}`,
+      );
+    }
+
+    const catalog = await readJachtzeilenCatalogFingerprint();
+    invariant(
+      catalog.hash === manifest.catalogHash,
+      `Rollback produced catalog hash ${catalog.hash}, expected ${manifest.catalogHash}`,
+    );
+  });
+}
+
+export function parseCliOptions(args: string[]): CliOptions {
+  const options: CliOptions = {
+    command: "plan",
+    execute: false,
+  };
+  let commandSeen = false;
+
+  for (const arg of args) {
+    if (arg === "--") continue;
+    if (!arg.startsWith("-") && !commandSeen) {
+      invariant(
+        arg === "plan" ||
+          arg === "import" ||
+          arg === "rollback" ||
+          arg === "verify-local",
+        `Unknown command: ${arg}`,
+      );
+      options.command = arg;
+      commandSeen = true;
+      continue;
+    }
+    if (arg === "--execute") {
+      options.execute = true;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+
+    const [name, value] = arg.split("=", 2);
+    invariant(value, `Option ${name} requires =VALUE`);
+    if (name === "--file") options.filePath = value;
+    else if (name === "--manifest") options.manifestPath = value;
+    else if (name === "--pg-uri") options.pgUri = value;
+    else if (name === "--expected-catalog-hash") {
+      options.expectedCatalogHash = value;
+    } else if (name === "--attestation") options.attestationPath = value;
+    else throw new Error(`Unknown option: ${name}`);
+  }
+
+  return options;
+}
+
+function printHelp() {
+  console.log(`
+Usage:
+  pnpm --filter @nawadi/scripts import:jachtzeilen-ab -- plan --file=/path/source.csv
+  pnpm --filter @nawadi/scripts import:jachtzeilen-ab -- import --file=/path/source.csv --expected-catalog-hash=SHA256 --execute
+  pnpm --filter @nawadi/scripts import:jachtzeilen-ab -- verify-local --file=/path/source.csv --pg-uri=postgresql://postgres:postgres@127.0.0.1:54322/postgres --execute
+  pnpm --filter @nawadi/scripts import:jachtzeilen-ab -- rollback --manifest=/path/manifest.json --execute
+
+Safety:
+  - plan is read-only.
+  - import requires --execute and the catalog hash tested locally.
+  - all nine revision 2601 curricula are active from ${IMPORT_STARTED_AT}.
+  - import and rollback are atomic and fail closed on unexpected data.
+  - the reviewed CSV SHA-256 is enforced.
+`);
+}
+
+async function buildDatabasePlan(
+  options: CliOptions,
+): Promise<DatabaseImportPlan> {
+  invariant(options.filePath, "--file is required");
+  const { sourceHash, rows } = loadSourceFile(options.filePath);
+  const sourceRows = parseWideJachtzeilenSheet(rows);
+  const sourcePlan = buildSourceImportPlan({
+    sourceRows,
+    sourceHash,
+    decisions: JACHTZEILEN_AB_CONTENT_DECISIONS,
+  });
+  const catalog = await readJachtzeilenCatalogFingerprint();
+  if (options.expectedCatalogHash) {
+    invariant(
+      options.expectedCatalogHash === catalog.hash,
+      `Catalog hash mismatch. Expected ${options.expectedCatalogHash}, got ${catalog.hash}`,
+    );
+  }
+  return resolveDatabaseImportPlan(sourcePlan, catalog.hash);
+}
+
+async function runPlanOrImport(options: CliOptions) {
+  const databasePlan = await buildDatabasePlan(options);
+  printPlan(databasePlan);
+
+  if (options.command !== "import" || !options.execute) {
+    console.log("");
+    console.log(
+      "Dry run only. Use the import command with --execute to write.",
+    );
+    return;
+  }
+
+  invariant(
+    options.expectedCatalogHash,
+    "--expected-catalog-hash is required for an executing import",
+  );
+  invariant(
+    options.expectedCatalogHash === databasePlan.catalogHash,
+    "The expected catalog hash does not match the planned catalog",
+  );
+  const manifest = await applyImport(databasePlan);
+  const manifestPath = writeManifest(manifest, options.manifestPath);
+  console.log("");
+  console.log(`Import committed. All nine curricula are active.`);
+  console.log(`Manifest: ${manifestPath}`);
+}
+
+function assertLocalPgUri(pgUri: string) {
+  let url: URL;
+  try {
+    url = new URL(pgUri);
+  } catch {
+    throw new Error("verify-local requires a PostgreSQL URL");
+  }
+  invariant(
+    url.hostname === "localhost" ||
+      url.hostname === "127.0.0.1" ||
+      url.hostname === "::1",
+    "verify-local is restricted to localhost",
+  );
+}
+
+function writeAttestation(
+  value: Record<string, unknown>,
+  requestedPath?: string,
+): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filePath = path.resolve(
+    requestedPath ??
+      path.join(
+        process.cwd(),
+        `.jachtzeilen-ab-local-attestation-${timestamp}.json`,
+      ),
+  );
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  return filePath;
+}
+
+async function runLocalVerification(options: CliOptions) {
+  invariant(options.pgUri, "verify-local requires --pg-uri");
+  assertLocalPgUri(options.pgUri);
+  const initialPlan = await buildDatabasePlan(options);
+  printPlan(initialPlan);
+  if (!options.execute) {
+    console.log("Dry run only. Add --execute to run the local lifecycle test.");
+    return;
+  }
+
+  const firstManifest = await applyImport(initialPlan);
+  const rerunPlan = await buildDatabasePlan({
+    ...options,
+    expectedCatalogHash: initialPlan.catalogHash,
+  });
+  invariant(
+    rerunPlan.targets.every(
+      (target) =>
+        target.existingProgramId !== null &&
+        target.existingCurriculumId !== null,
+    ) && rerunPlan.competenciesToCreate.length === 0,
+    "Idempotency check failed while planning the rerun",
+  );
+  const rerunManifest = await applyImport(rerunPlan);
+  invariant(
+    rerunManifest.createdProgramIds.length === 0 &&
+      rerunManifest.createdCurriculumIds.length === 0 &&
+      rerunManifest.createdCompetencyIds.length === 0 &&
+      rerunManifest.shiftedCompetencyWeights.length === 0 &&
+      rerunManifest.correctedCompetencyTitles.length === 0 &&
+      rerunManifest.targets.every(
+        (target) =>
+          target.createdModuleIds.length === 0 &&
+          target.createdCompetencyLinkIds.length === 0 &&
+          target.createdGearTypeIds.length === 0,
+      ),
+    "Idempotency check created or changed data",
+  );
+
+  const tamperedSourceRows = initialPlan.source.sourceRows.map((row, index) =>
+    index === 0
+      ? {
+          ...row,
+          requirement: `${row.requirement} Onverwachte wijziging.`,
+        }
+      : row,
+  );
+  const tamperedSource = buildSourceImportPlan({
+    sourceRows: tamperedSourceRows,
+    sourceHash: initialPlan.source.sourceHash,
+    decisions: JACHTZEILEN_AB_CONTENT_DECISIONS,
+  });
+  let failClosedPassed = false;
+  try {
+    await resolveDatabaseImportPlan(tamperedSource, initialPlan.catalogHash);
+  } catch (error) {
+    failClosedPassed =
+      error instanceof Error &&
+      error.message.includes("contains data outside this import");
+  }
+  invariant(failClosedPassed, "Fail-closed lifecycle check did not fail");
+
+  await rollbackImport(firstManifest);
+  const afterRollback = await readJachtzeilenCatalogFingerprint();
+  invariant(
+    afterRollback.hash === initialPlan.catalogHash,
+    "Catalog hash did not return to baseline after rollback",
+  );
+
+  const reimportPlan = await buildDatabasePlan({
+    ...options,
+    expectedCatalogHash: initialPlan.catalogHash,
+  });
+  const finalManifest = await applyImport(reimportPlan);
+  const finalManifestPath = writeManifest(finalManifest, options.manifestPath);
+  const attestationPath = writeAttestation(
+    {
+      kind: "jachtzeilen-ab-local-verification",
+      version: 1,
+      verifiedAt: new Date().toISOString(),
+      sourceHash: initialPlan.source.sourceHash,
+      catalogHash: initialPlan.catalogHash,
+      revision: initialPlan.source.revision,
+      startedAt: IMPORT_STARTED_AT,
+      targetCount: initialPlan.targets.length,
+      sourceLinkCount: initialPlan.source.sourceRows.length,
+      materializedLinkCount: initialPlan.source.rows.length,
+      checks: {
+        initialImport: true,
+        exactCountsAndActivation: true,
+        idempotentRerun: true,
+        failClosedOnChangedRequirement: true,
+        manifestGenerated: true,
+        rollback: true,
+        reimport: true,
+      },
+      finalManifestPath,
+    },
+    options.attestationPath,
+  );
+  console.log(`Local lifecycle verification passed: ${attestationPath}`);
+  console.log(`Final local import manifest: ${finalManifestPath}`);
+}
+
+async function runRollback(options: CliOptions) {
+  invariant(options.manifestPath, "--manifest is required");
+  const manifest = readManifest(options.manifestPath);
+  await inspectRollback(manifest);
+  console.log(
+    `Rollback plan: ${manifest.createdCurriculumIds.length} curricula, ${manifest.createdProgramIds.length} programs, ${manifest.createdCompetencyIds.length} competencies`,
+  );
+  if (!options.execute) {
+    console.log("Dry run only. Add --execute to roll back.");
+    return;
+  }
+  await rollbackImport(manifest);
+  console.log("Rollback committed.");
 }
 
 async function main() {
-  const { filePath } = await inquirer.prompt<{ filePath: string }>([
+  const options = parseCliOptions(process.argv.slice(2));
+  const pgUri = options.pgUri ?? process.env.PGURI;
+  invariant(pgUri, "PGURI or --pg-uri is required");
+
+  await withDatabase(
     {
-      type: "input",
-      name: "filePath",
-      message: "Enter the path to the Jachtzeilen A/B XLSX file:",
-      validate: (input: string) => {
-        if (!input) return "Please enter a file path";
-        if (!input.endsWith(".xlsx")) return "File must be an XLSX file";
-        return true;
-      },
+      connectionString: pgUri,
+      max: 1,
     },
-  ]);
-
-  const workbook = loadWorkbookFromPath(filePath);
-  if (!workbook.SheetNames.length) {
-    throw new Error("No sheets found in the XLSX file");
-  }
-
-  const sheetName = workbook.SheetNames[0];
-  assert(sheetName, "Sheet name is required");
-
-  const worksheet = workbook.Sheets[sheetName];
-  assert(worksheet, "Worksheet is required");
-
-  const rawRows = utils.sheet_to_json<unknown[]>(worksheet, {
-    header: 1,
-    defval: "",
-  });
-
-  const { rows, defaultedKeuzeCount, skippedEmptyEis } =
-    parseWideJachtzeilenSheet(rawRows);
-
-  if (rows.length === 0) {
-    throw new Error("No import rows parsed from the Excel file");
-  }
-
-  console.log("Successfully read XLSX file");
-
-  const plan = await resolveImportPlan(rows, {
-    defaultedKeuzeCount,
-    skippedEmptyEis,
-  });
-
-  printLookupSummary(plan);
-
-  const decisions = await promptForMissingEntities(plan);
-
-  await withTransaction(async () => {
-    const stats = await applyImportPlan(plan, decisions);
-
-    console.log(`\nImport complete (revision ${REVISION})`);
-    console.log(`  Rows processed:            ${stats.rowsProcessed}`);
-    console.log(`  Rows skipped:              ${stats.rowsSkipped}`);
-    console.log(`  Programs created:          ${stats.programsCreated}`);
-    console.log(`  Modules created:           ${stats.modulesCreated}`);
-    console.log(`  Competencies created:      ${stats.competenciesCreated}`);
-    console.log(
-      `  Curriculum links upserted: ${stats.curriculumLinksUpserted}`,
-    );
-  });
+    async () => {
+      if (options.command === "rollback") {
+        await runRollback(options);
+      } else if (options.command === "verify-local") {
+        await runLocalVerification(options);
+      } else {
+        await runPlanOrImport(options);
+      }
+    },
+  );
 }
-
-const pgUri = process.env.PGURI;
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 function isDirectExecution(): boolean {
   const entry = process.argv[1];
-  if (!entry) return false;
-  return import.meta.url === pathToFileURL(entry).href;
+  return Boolean(entry && import.meta.url === pathToFileURL(entry).href);
 }
 
 if (isDirectExecution()) {
-  assert(pgUri, "PGURI environment variable is required");
-  assert(
-    supabaseUrl,
-    "NEXT_PUBLIC_SUPABASE_URL environment variable is required",
-  );
-  assert(
-    supabaseKey,
-    "SUPABASE_SERVICE_ROLE_KEY environment variable is required",
-  );
-
-  withSupabaseClient(
-    {
-      url: supabaseUrl,
-      serviceRoleKey: supabaseKey,
-    },
-    () =>
-      withDatabase(
-        {
-          connectionString: pgUri,
-        },
-        async () => {
-          await main();
-        },
-      )
-        .then(() => {
-          console.log("Done!");
-          process.exit(0);
-        })
-        .catch((error) => {
-          console.error("Error:", error);
-          process.exit(1);
-        }),
-  );
+  main().catch((error) => {
+    console.error("Fatal error:", error);
+    process.exit(1);
+  });
 }

--- a/packages/scripts/src/import-jachtzeilen-ab-programs.ts
+++ b/packages/scripts/src/import-jachtzeilen-ab-programs.ts
@@ -1,0 +1,887 @@
+import {
+  Course,
+  Curriculum,
+  useQuery,
+  withDatabase,
+  withSupabaseClient,
+  withTransaction,
+} from "@nawadi/core";
+import "dotenv/config";
+import assert from "node:assert";
+import fs from "node:fs";
+import { pathToFileURL } from "node:url";
+import { schema } from "@nawadi/db";
+import slugify from "@sindresorhus/slugify";
+import { eq } from "drizzle-orm";
+import inquirer from "inquirer";
+import pkg from "xlsx";
+
+const { read, utils } = pkg;
+
+function loadWorkbookFromPath(filePath: string) {
+  const normalizedPath = filePath.trim().replace(/^["']|["']$/g, "");
+
+  if (!fs.existsSync(normalizedPath)) {
+    throw new Error(`File not found: ${normalizedPath}`);
+  }
+
+  // xlsx ESM build does not wire up Node fs for readFile(); read via buffer instead.
+  const buffer = fs.readFileSync(normalizedPath);
+  return read(buffer, { type: "buffer" });
+}
+
+const REVISION = "2601";
+const REVISION_STARTED_AT = "2026-01-01T00:00:00.000Z";
+
+const MODULE_HANDLE_OVERRIDES: Record<string, string> = {
+  basis: "basis-jz",
+  theorie: "theorie-jz",
+  "basis-jz": "basis-jz",
+  "theorie-jz": "theorie-jz",
+};
+
+const VAARWATER_ALIASES: Record<string, string> = {
+  "Wad en Zeegaten": "Waddenzee en Zeeuwse Stromen",
+};
+
+type Niveau = "4" | "a" | "b";
+
+export interface ImportRow {
+  vaarwater: string;
+  niveau: Niveau;
+  moduleTitle: string;
+  moduleHandle: string;
+  competencyTitle: string;
+  competencyHandle: string;
+  isRequired: boolean;
+  eis: string;
+  programHandle: string;
+}
+
+interface DataColumn {
+  columnIndex: number;
+  vaarwater: string;
+  niveau: Niveau;
+}
+
+interface EntityRecord<T = { id: string }> {
+  handle: string;
+  exists: boolean;
+  entity: T | null;
+  affectedRows: ImportRow[];
+}
+
+interface ProgramEntityRecord extends EntityRecord {
+  handle: string;
+  title: string;
+  vaarwater: string;
+  niveau: Niveau;
+}
+
+interface ModuleEntityRecord extends EntityRecord {
+  title: string;
+}
+
+interface CompetencyEntityRecord extends EntityRecord {
+  title: string;
+  moduleTitle: string;
+}
+
+export interface ImportPlan {
+  rows: ImportRow[];
+  parseStats: {
+    defaultedKeuzeCount: number;
+    skippedEmptyEis: number;
+  };
+  programs: Map<string, ProgramEntityRecord>;
+  modules: Map<string, ModuleEntityRecord>;
+  competencies: Map<string, CompetencyEntityRecord>;
+  moduleWeights: Map<string, number>;
+}
+
+export type CreationDecisions = Map<string, boolean>;
+
+function normalizeVaarwater(name: string): string {
+  const trimmed = name.trim();
+  return VAARWATER_ALIASES[trimmed] ?? trimmed;
+}
+
+function parseNiveau(cell: unknown): Niveau | null {
+  const match = String(cell ?? "")
+    .trim()
+    .match(/^Niveau\s+(4|[AB])$/i);
+  if (!match?.[1]) return null;
+  const value = match[1].toUpperCase();
+  if (value === "4") return "4";
+  if (value === "A") return "a";
+  if (value === "B") return "b";
+  return null;
+}
+
+function resolveModuleHandle(moduleTitle: string): string {
+  const slug = slugify(moduleTitle);
+  return MODULE_HANDLE_OVERRIDES[slug] ?? slug;
+}
+
+function resolveProgramHandle(vaarwater: string, niveau: Niveau): string {
+  return `jacht-kajuitzeilen-${slugify(vaarwater)}-volwassenen-${niveau}`;
+}
+
+function deriveProgramTitle(vaarwater: string, niveau: Niveau): string {
+  const niveauLabel = niveau === "4" ? "4" : niveau.toUpperCase();
+  return `Jacht/kajuitzeilen ${vaarwater} Volwassenen ${niveauLabel}`;
+}
+
+function parseIsRequired(voCell: unknown): boolean {
+  return String(voCell ?? "")
+    .trim()
+    .toUpperCase() === "V";
+}
+
+function truncate(text: string, maxLength: number): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength - 1)}…`;
+}
+
+function detectDataColumns(rows: unknown[][]): DataColumn[] {
+  if (rows.length < 2) return [];
+
+  const vaarwaterRow = rows[0] ?? [];
+  const headerRow = rows[1] ?? [];
+  const columns: DataColumn[] = [];
+  let currentVaarwater = "";
+
+  for (let columnIndex = 0; columnIndex < headerRow.length; columnIndex++) {
+    const vaarwaterCell = String(vaarwaterRow[columnIndex] ?? "").trim();
+    if (vaarwaterCell) {
+      currentVaarwater = normalizeVaarwater(vaarwaterCell);
+    }
+
+    const niveau = parseNiveau(headerRow[columnIndex]);
+    if (!niveau || !currentVaarwater) continue;
+
+    columns.push({
+      columnIndex,
+      vaarwater: currentVaarwater,
+      niveau,
+    });
+  }
+
+  return columns;
+}
+
+export function parseWideJachtzeilenSheet(rows: unknown[][]): {
+  rows: ImportRow[];
+  defaultedKeuzeCount: number;
+  skippedEmptyEis: number;
+} {
+  const dataColumns = detectDataColumns(rows);
+  const importRows: ImportRow[] = [];
+  let defaultedKeuzeCount = 0;
+  let skippedEmptyEis = 0;
+  const moduleOrder: string[] = [];
+
+  for (let rowIndex = 2; rowIndex < rows.length; rowIndex++) {
+    const row = rows[rowIndex] ?? [];
+    const moduleTitle = String(row[0] ?? "").trim();
+    const voCell = row[1];
+    const competencyTitle = String(row[2] ?? "").trim();
+
+    if (!moduleTitle || !competencyTitle) continue;
+
+    if (!moduleOrder.includes(moduleTitle)) {
+      moduleOrder.push(moduleTitle);
+    }
+
+    const voValue = String(voCell ?? "").trim();
+    if (!voValue) defaultedKeuzeCount++;
+
+    const moduleHandle = resolveModuleHandle(moduleTitle);
+    const competencyHandle = slugify(competencyTitle);
+    const isRequired = parseIsRequired(voCell);
+
+    for (const column of dataColumns) {
+      const eis = String(row[column.columnIndex] ?? "").trim();
+      if (!eis) {
+        skippedEmptyEis++;
+        continue;
+      }
+
+      importRows.push({
+        vaarwater: column.vaarwater,
+        niveau: column.niveau,
+        moduleTitle,
+        moduleHandle,
+        competencyTitle,
+        competencyHandle,
+        isRequired,
+        eis,
+        programHandle: resolveProgramHandle(column.vaarwater, column.niveau),
+      });
+    }
+  }
+
+  return { rows: importRows, defaultedKeuzeCount, skippedEmptyEis };
+}
+
+function addAffectedRow<T extends { affectedRows: ImportRow[] }>(
+  map: Map<string, T>,
+  key: string,
+  factory: () => T,
+  row: ImportRow,
+) {
+  const existing = map.get(key) ?? factory();
+  if (!existing.affectedRows.includes(row)) {
+    existing.affectedRows.push(row);
+  }
+  map.set(key, existing);
+}
+
+export async function resolveImportPlan(
+  parsedRows: ImportRow[],
+  parseStats: { defaultedKeuzeCount: number; skippedEmptyEis: number },
+): Promise<ImportPlan> {
+  const programs = new Map<string, ProgramEntityRecord>();
+  const modules = new Map<string, ModuleEntityRecord>();
+  const competencies = new Map<string, CompetencyEntityRecord>();
+  const moduleWeights = new Map<string, number>();
+  let moduleWeightCounter = 0;
+
+  for (const row of parsedRows) {
+    if (!moduleWeights.has(row.moduleHandle)) {
+      moduleWeightCounter++;
+      moduleWeights.set(row.moduleHandle, moduleWeightCounter);
+    }
+
+    addAffectedRow(
+      programs,
+      row.programHandle,
+      () => ({
+        handle: row.programHandle,
+        title: deriveProgramTitle(row.vaarwater, row.niveau),
+        vaarwater: row.vaarwater,
+        niveau: row.niveau,
+        exists: false,
+        entity: null,
+        affectedRows: [],
+      }),
+      row,
+    );
+
+    addAffectedRow(
+      modules,
+      row.moduleHandle,
+      () => ({
+        handle: row.moduleHandle,
+        title: row.moduleTitle,
+        exists: false,
+        entity: null,
+        affectedRows: [],
+      }),
+      row,
+    );
+
+    addAffectedRow(
+      competencies,
+      row.competencyHandle,
+      () => ({
+        handle: row.competencyHandle,
+        title: row.competencyTitle,
+        moduleTitle: row.moduleTitle,
+        exists: false,
+        entity: null,
+        affectedRows: [],
+      }),
+      row,
+    );
+  }
+
+  await Promise.all([
+    ...[...programs.values()].map(async (program) => {
+      program.entity = await Course.Program.fromHandle(program.handle);
+      program.exists = program.entity !== null;
+    }),
+    ...[...modules.values()].map(async (module) => {
+      module.entity = await Course.Module.fromHandle(module.handle);
+      module.exists = module.entity !== null;
+    }),
+    ...[...competencies.values()].map(async (competency) => {
+      competency.entity = await Course.Competency.fromHandle(competency.handle);
+      competency.exists = competency.entity !== null;
+    }),
+  ]);
+
+  return {
+    rows: parsedRows,
+    parseStats,
+    programs,
+    modules,
+    competencies,
+    moduleWeights,
+  };
+}
+
+function formatSampleList(items: string[], maxItems: number): string {
+  const shown = items.slice(0, maxItems);
+  const lines = shown.map((item) => `  • ${item}`);
+  if (items.length > maxItems) {
+    lines.push(`  … and ${items.length - maxItems} more`);
+  }
+  return lines.join("\n");
+}
+
+function buildProgramPromptMessage(program: ProgramEntityRecord): string {
+  const sampleCompetencies = [
+    ...new Set(
+      program.affectedRows.map(
+        (row) => `${row.competencyTitle} (module: ${row.moduleTitle})`,
+      ),
+    ),
+  ];
+
+  return [
+    "MISSING PROGRAM (level)",
+    "",
+    `Handle:    ${program.handle}`,
+    `Title:     ${program.title} (derived)`,
+    `Vaarwater: ${program.vaarwater}`,
+    `Niveau:    ${program.niveau.toUpperCase()}`,
+    "",
+    "Problem:   This opleidingsprogramma does not exist in the database.",
+    "           Without it, no curriculum revision 2601 can be created for this level.",
+    "",
+    `Affected:  ${program.affectedRows.length} import rows from the Excel file will be skipped if you decline.`,
+    "",
+    "Sample competencies that would be linked:",
+    formatSampleList(sampleCompetencies, 3),
+    "",
+    "Create this program now?",
+  ].join("\n");
+}
+
+function buildModulePromptMessage(module: ModuleEntityRecord): string {
+  const niveaus = [...new Set(module.affectedRows.map((row) => row.niveau))];
+  const vaarwaters = [
+    ...new Set(module.affectedRows.map((row) => row.vaarwater)),
+  ];
+  const sampleCompetencies = [
+    ...new Set(module.affectedRows.map((row) => row.competencyTitle)),
+  ];
+
+  return [
+    "MISSING MODULE",
+    "",
+    `Handle:  ${module.handle}`,
+    `Title:   ${module.title} (from Excel)`,
+    "",
+    "Problem: This module is referenced in the Excel but was not found by handle.",
+    "         All competencies under this module for revision 2601 depend on it.",
+    "",
+    `Affected: ${module.affectedRows.length} import rows across niveaus: ${niveaus.join(", ")}`,
+    `          vaarwateren: ${vaarwaters.join(", ")}`,
+    "",
+    "Used with competencies:",
+    formatSampleList(sampleCompetencies, 3),
+    "",
+    "Create this module now?",
+  ].join("\n");
+}
+
+function buildCompetencyPromptMessage(
+  competency: CompetencyEntityRecord,
+): string {
+  const sampleRow = competency.affectedRows[0];
+  const competencyType =
+    competency.moduleTitle === "Theorie" ? "knowledge" : "skill";
+
+  return [
+    "MISSING COMPETENCY",
+    "",
+    `Handle:  ${competency.handle}`,
+    `Title:   ${competency.title} (from Excel)`,
+    `Module:  ${competency.moduleTitle}`,
+    `Type:    ${competencyType} (derived: ${competency.moduleTitle === "Theorie" ? "Theorie module" : "not Theorie module"})`,
+    "",
+    "Problem: This competency entity does not exist. The eisen text from Excel",
+    "         cannot be linked to curriculum 2601 without it.",
+    "",
+    `Affected: ${competency.affectedRows.length} import rows (vaarwater/niveau combinations with an eis)`,
+    "",
+    sampleRow
+      ? `Sample eis (${sampleRow.vaarwater}, niveau ${sampleRow.niveau.toUpperCase()}):\n  "${truncate(sampleRow.eis, 120)}"`
+      : "",
+    "",
+    "Create this competency now?",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export async function promptForMissingEntities(
+  plan: ImportPlan,
+): Promise<CreationDecisions> {
+  const decisions: CreationDecisions = new Map();
+
+  const missingPrograms = [...plan.programs.values()].filter((p) => !p.exists);
+  const missingModules = [...plan.modules.values()].filter((m) => !m.exists);
+  const missingCompetencies = [...plan.competencies.values()].filter(
+    (c) => !c.exists,
+  );
+
+  const promptCount =
+    missingPrograms.length + missingModules.length + missingCompetencies.length;
+
+  if (promptCount === 0) {
+    console.log("\nAll programs, modules, and competencies already exist.");
+    return decisions;
+  }
+
+  console.log(`\n→ ${promptCount} prompts required before import can proceed\n`);
+
+  for (const program of missingPrograms) {
+    const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([
+      {
+        type: "confirm",
+        name: "confirmed",
+        message: buildProgramPromptMessage(program),
+        default: false,
+      },
+    ]);
+    decisions.set(program.handle, confirmed);
+  }
+
+  for (const module of missingModules) {
+    const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([
+      {
+        type: "confirm",
+        name: "confirmed",
+        message: buildModulePromptMessage(module),
+        default: false,
+      },
+    ]);
+    decisions.set(module.handle, confirmed);
+  }
+
+  for (const competency of missingCompetencies) {
+    const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([
+      {
+        type: "confirm",
+        name: "confirmed",
+        message: buildCompetencyPromptMessage(competency),
+        default: false,
+      },
+    ]);
+    decisions.set(competency.handle, confirmed);
+  }
+
+  return decisions;
+}
+
+function isApprovedForCreation(
+  handle: string,
+  exists: boolean,
+  decisions: CreationDecisions,
+): boolean {
+  if (exists) return true;
+  return decisions.get(handle) === true;
+}
+
+async function findCourseIdForProgram(
+  vaarwater: string,
+): Promise<string | null> {
+  const niveaus: Niveau[] = ["4", "a", "b"];
+  for (const niveau of niveaus) {
+    const siblingHandle = resolveProgramHandle(vaarwater, niveau);
+    const sibling = await Course.Program.fromHandle(siblingHandle);
+    if (sibling?.course?.id) {
+      return sibling.course.id;
+    }
+  }
+
+  const discipline = await Course.Discipline.fromHandle("jachtzeilen");
+  if (!discipline) return null;
+
+  const volwassenenCategory = await Course.Category.fromHandle("volwassenen");
+  const course = await Course.findOne({
+    disciplineId: discipline.id,
+    ...(volwassenenCategory
+      ? { categoryId: volwassenenCategory.id }
+      : {}),
+  });
+
+  return course?.id ?? null;
+}
+
+async function createApprovedProgram(
+  program: ProgramEntityRecord,
+): Promise<{ id: string } | null> {
+  const degreeHandle = `niveau-${program.niveau}`;
+  const degree = await Course.Degree.fromHandle(degreeHandle);
+  if (!degree) {
+    console.error(
+      `Failed to create program ${program.handle}: degree "${degreeHandle}" not found`,
+    );
+    return null;
+  }
+
+  const courseId = await findCourseIdForProgram(program.vaarwater);
+  if (!courseId) {
+    console.error(
+      `Failed to create program ${program.handle}: could not resolve courseId (create manually or ensure a sibling program exists)`,
+    );
+    return null;
+  }
+
+  try {
+    return await Course.Program.create({
+      handle: program.handle,
+      title: program.title,
+      degreeId: degree.id,
+      courseId,
+    });
+  } catch (error) {
+    console.error(`Failed to create program ${program.handle}:`, error);
+    return null;
+  }
+}
+
+async function ensureCurriculumStarted(
+  curriculumId: string,
+  startedAt: string | null | undefined,
+) {
+  if (startedAt) return;
+  await Curriculum.start({
+    curriculumId,
+    startedAt: REVISION_STARTED_AT,
+  });
+}
+
+async function getOrCreateCurriculum2601(
+  programId: string,
+  cache: Map<string, Promise<{ id: string }>>,
+): Promise<{ id: string }> {
+  const cacheKey = `${programId}-${REVISION}`;
+  let curriculumPromise = cache.get(cacheKey);
+
+  if (!curriculumPromise) {
+    curriculumPromise = (async () => {
+      const existing = await Curriculum.list({ filter: { programId } });
+      const match = existing.find((c) => c.revision === REVISION);
+
+      if (match) {
+        await ensureCurriculumStarted(match.id, match.startedAt);
+        return { id: match.id };
+      }
+
+      const created = await Curriculum.create({ programId, revision: REVISION });
+      await ensureCurriculumStarted(created.id, null);
+      return created;
+    })();
+    cache.set(cacheKey, curriculumPromise);
+  }
+
+  return curriculumPromise;
+}
+
+async function upsertCurriculumCompetency(input: {
+  curriculumId: string;
+  moduleId: string;
+  competencyId: string;
+  isRequired: boolean;
+  requirement: string;
+}) {
+  const query = useQuery();
+  const existing = await Curriculum.Competency.list({
+    filter: {
+      curriculumId: input.curriculumId,
+      moduleId: input.moduleId,
+      competencyId: input.competencyId,
+    },
+  });
+
+  const match = existing[0];
+  if (match) {
+    await query
+      .update(schema.curriculumCompetency)
+      .set({
+        isRequired: input.isRequired,
+        requirement: input.requirement,
+      })
+      .where(eq(schema.curriculumCompetency.id, match.id));
+    return { updated: true };
+  }
+
+  await Curriculum.Competency.create(input);
+  return { updated: false };
+}
+
+export async function applyImportPlan(
+  plan: ImportPlan,
+  decisions: CreationDecisions,
+): Promise<{
+  rowsProcessed: number;
+  rowsSkipped: number;
+  programsCreated: number;
+  modulesCreated: number;
+  competenciesCreated: number;
+  curriculumLinksUpserted: number;
+}> {
+  const stats = {
+    rowsProcessed: 0,
+    rowsSkipped: 0,
+    programsCreated: 0,
+    modulesCreated: 0,
+    competenciesCreated: 0,
+    curriculumLinksUpserted: 0,
+  };
+
+  const programIds = new Map<string, string>();
+  const moduleIds = new Map<string, string>();
+  const competencyIds = new Map<string, string>();
+  const curriculumCache = new Map<string, Promise<{ id: string }>>();
+  const failedCreations = new Set<string>();
+
+  for (const program of plan.programs.values()) {
+    if (program.exists && program.entity) {
+      programIds.set(program.handle, program.entity.id);
+      continue;
+    }
+    if (!isApprovedForCreation(program.handle, program.exists, decisions)) {
+      failedCreations.add(program.handle);
+      continue;
+    }
+    const created = await createApprovedProgram(program);
+    if (created) {
+      programIds.set(program.handle, created.id);
+      stats.programsCreated++;
+    } else {
+      failedCreations.add(program.handle);
+    }
+  }
+
+  for (const module of plan.modules.values()) {
+    if (module.exists && module.entity) {
+      moduleIds.set(module.handle, module.entity.id);
+      continue;
+    }
+    if (!isApprovedForCreation(module.handle, module.exists, decisions)) {
+      failedCreations.add(module.handle);
+      continue;
+    }
+    const weight = plan.moduleWeights.get(module.handle) ?? 1;
+    try {
+      const created = await Course.Module.create({
+        handle: module.handle,
+        title: module.title,
+        weight,
+      });
+      moduleIds.set(module.handle, created.id);
+      stats.modulesCreated++;
+    } catch (error) {
+      console.error(`Failed to create module ${module.handle}:`, error);
+      failedCreations.add(module.handle);
+    }
+  }
+
+  for (const competency of plan.competencies.values()) {
+    if (competency.exists && competency.entity) {
+      competencyIds.set(competency.handle, competency.entity.id);
+      continue;
+    }
+    if (
+      !isApprovedForCreation(competency.handle, competency.exists, decisions)
+    ) {
+      failedCreations.add(competency.handle);
+      continue;
+    }
+    const type = competency.moduleTitle === "Theorie" ? "knowledge" : "skill";
+    try {
+      const created = await Course.Competency.create({
+        handle: competency.handle,
+        title: competency.title,
+        type,
+      });
+      competencyIds.set(competency.handle, created.id);
+      stats.competenciesCreated++;
+    } catch (error) {
+      console.error(`Failed to create competency ${competency.handle}:`, error);
+      failedCreations.add(competency.handle);
+    }
+  }
+
+  for (const row of plan.rows) {
+    if (
+      failedCreations.has(row.programHandle) ||
+      failedCreations.has(row.moduleHandle) ||
+      failedCreations.has(row.competencyHandle) ||
+      !isApprovedForCreation(row.programHandle, plan.programs.get(row.programHandle)?.exists ?? false, decisions) ||
+      !isApprovedForCreation(row.moduleHandle, plan.modules.get(row.moduleHandle)?.exists ?? false, decisions) ||
+      !isApprovedForCreation(row.competencyHandle, plan.competencies.get(row.competencyHandle)?.exists ?? false, decisions)
+    ) {
+      stats.rowsSkipped++;
+      continue;
+    }
+
+    const programId = programIds.get(row.programHandle);
+    const moduleId = moduleIds.get(row.moduleHandle);
+    const competencyId = competencyIds.get(row.competencyHandle);
+
+    if (!programId || !moduleId || !competencyId) {
+      stats.rowsSkipped++;
+      continue;
+    }
+
+    const { id: curriculumId } = await getOrCreateCurriculum2601(
+      programId,
+      curriculumCache,
+    );
+
+    await Curriculum.linkModule({ curriculumId, moduleId });
+
+    await upsertCurriculumCompetency({
+      curriculumId,
+      moduleId,
+      competencyId,
+      isRequired: row.isRequired,
+      requirement: row.eis,
+    });
+
+    stats.rowsProcessed++;
+    stats.curriculumLinksUpserted++;
+  }
+
+  return stats;
+}
+
+function printLookupSummary(plan: ImportPlan) {
+  const programTargets = new Set(plan.rows.map((row) => row.programHandle));
+  const missingPrograms = [...plan.programs.values()].filter((p) => !p.exists);
+  const missingModules = [...plan.modules.values()].filter((m) => !m.exists);
+  const missingCompetencies = [...plan.competencies.values()].filter(
+    (c) => !c.exists,
+  );
+
+  console.log(`\nParsed ${plan.rows.length} rows across ${programTargets.size} program targets (revision ${REVISION})`);
+  console.log(
+    `Programs:     ${plan.programs.size - missingPrograms.length} found, ${missingPrograms.length} missing`,
+  );
+  console.log(
+    `Modules:      ${plan.modules.size - missingModules.length} found, ${missingModules.length} missing`,
+  );
+  console.log(
+    `Competencies: ${plan.competencies.size - missingCompetencies.length} found, ${missingCompetencies.length} missing`,
+  );
+  console.log(
+    `Parse notes:  ${plan.parseStats.defaultedKeuzeCount} rows defaulted to Keuze (empty V/O); ${plan.parseStats.skippedEmptyEis} empty eis cells skipped during parse`,
+  );
+}
+
+async function main() {
+  const { filePath } = await inquirer.prompt<{ filePath: string }>([
+    {
+      type: "input",
+      name: "filePath",
+      message: "Enter the path to the Jachtzeilen A/B XLSX file:",
+      validate: (input: string) => {
+        if (!input) return "Please enter a file path";
+        if (!input.endsWith(".xlsx")) return "File must be an XLSX file";
+        return true;
+      },
+    },
+  ]);
+
+  const workbook = loadWorkbookFromPath(filePath);
+  if (!workbook.SheetNames.length) {
+    throw new Error("No sheets found in the XLSX file");
+  }
+
+  const sheetName = workbook.SheetNames[0];
+  assert(sheetName, "Sheet name is required");
+
+  const worksheet = workbook.Sheets[sheetName];
+  assert(worksheet, "Worksheet is required");
+
+  const rawRows = utils.sheet_to_json<unknown[]>(worksheet, {
+    header: 1,
+    defval: "",
+  });
+
+  const { rows, defaultedKeuzeCount, skippedEmptyEis } =
+    parseWideJachtzeilenSheet(rawRows);
+
+  if (rows.length === 0) {
+    throw new Error("No import rows parsed from the Excel file");
+  }
+
+  console.log("Successfully read XLSX file");
+
+  const plan = await resolveImportPlan(rows, {
+    defaultedKeuzeCount,
+    skippedEmptyEis,
+  });
+
+  printLookupSummary(plan);
+
+  const decisions = await promptForMissingEntities(plan);
+
+  await withTransaction(async () => {
+    const stats = await applyImportPlan(plan, decisions);
+
+    console.log(`\nImport complete (revision ${REVISION})`);
+    console.log(`  Rows processed:            ${stats.rowsProcessed}`);
+    console.log(`  Rows skipped:              ${stats.rowsSkipped}`);
+    console.log(`  Programs created:          ${stats.programsCreated}`);
+    console.log(`  Modules created:           ${stats.modulesCreated}`);
+    console.log(`  Competencies created:      ${stats.competenciesCreated}`);
+    console.log(
+      `  Curriculum links upserted: ${stats.curriculumLinksUpserted}`,
+    );
+  });
+}
+
+const pgUri = process.env.PGURI;
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+function isDirectExecution(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  return import.meta.url === pathToFileURL(entry).href;
+}
+
+if (isDirectExecution()) {
+  assert(pgUri, "PGURI environment variable is required");
+  assert(
+    supabaseUrl,
+    "NEXT_PUBLIC_SUPABASE_URL environment variable is required",
+  );
+  assert(
+    supabaseKey,
+    "SUPABASE_SERVICE_ROLE_KEY environment variable is required",
+  );
+
+  withSupabaseClient(
+    {
+      url: supabaseUrl,
+      serviceRoleKey: supabaseKey,
+    },
+    () =>
+      withDatabase(
+        {
+          connectionString: pgUri,
+        },
+        async () => {
+          await main();
+        },
+      )
+        .then(() => {
+          console.log("Done!");
+          process.exit(0);
+        })
+        .catch((error) => {
+          console.error("Error:", error);
+          process.exit(1);
+        }),
+  );
+}

--- a/packages/scripts/src/import-jachtzeilen-ab-programs.ts
+++ b/packages/scripts/src/import-jachtzeilen-ab-programs.ts
@@ -78,11 +78,18 @@ interface ProgramEntityRecord extends EntityRecord {
   niveau: Niveau;
 }
 
-interface ModuleEntityRecord extends EntityRecord {
+type ModuleEntity = NonNullable<
+  Awaited<ReturnType<typeof Course.Module.fromHandle>>
+>;
+type CompetencyEntity = NonNullable<
+  Awaited<ReturnType<typeof Course.Competency.fromHandle>>
+>;
+
+interface ModuleEntityRecord extends EntityRecord<ModuleEntity> {
   title: string;
 }
 
-interface CompetencyEntityRecord extends EntityRecord {
+interface CompetencyEntityRecord extends EntityRecord<CompetencyEntity> {
   title: string;
   moduleTitle: string;
 }
@@ -97,6 +104,135 @@ export interface ImportPlan {
   modules: Map<string, ModuleEntityRecord>;
   competencies: Map<string, CompetencyEntityRecord>;
   moduleWeights: Map<string, number>;
+  competencyWeights: Map<string, number>;
+}
+
+/** Next module weight in a new hundred-block, skipping any taken value. */
+export function allocateNextModuleWeight(
+  existingModuleWeights: readonly number[],
+  taken: ReadonlySet<number>,
+): number {
+  const maxModule = existingModuleWeights.length
+    ? Math.max(...existingModuleWeights)
+    : 0;
+  let candidate = Math.ceil((maxModule + 1) / 100) * 100;
+  if (candidate <= maxModule) {
+    candidate = maxModule + 100;
+  }
+  while (taken.has(candidate)) {
+    candidate += 100;
+  }
+  return candidate;
+}
+
+/** Next competency weight directly after its module (e.g. 601–603 under module 600). */
+export function allocateNextCompetencyWeight(
+  moduleWeight: number,
+  taken: ReadonlySet<number>,
+): number {
+  const inBand = [...taken].filter(
+    (weight) => weight > moduleWeight && weight < moduleWeight + 100,
+  );
+  let candidate =
+    inBand.length > 0 ? Math.max(...inBand) + 1 : moduleWeight + 1;
+  while (taken.has(candidate)) {
+    candidate += 1;
+  }
+  if (candidate >= moduleWeight + 100) {
+    throw new Error(
+      `No free competency weight for module weight ${moduleWeight}`,
+    );
+  }
+  return candidate;
+}
+
+function uniqueInOrder<T>(values: T[]): T[] {
+  const seen = new Set<T>();
+  const result: T[] = [];
+  for (const value of values) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    result.push(value);
+  }
+  return result;
+}
+
+async function loadTakenWeights(): Promise<Set<number>> {
+  const query = useQuery();
+  const [moduleRows, competencyRows] = await Promise.all([
+    query.select({ weight: schema.module.weight }).from(schema.module),
+    query.select({ weight: schema.competency.weight }).from(schema.competency),
+  ]);
+  return new Set([
+    ...moduleRows.map((row) => row.weight),
+    ...competencyRows.map((row) => row.weight),
+  ]);
+}
+
+async function buildModuleWeights(
+  modules: Map<string, ModuleEntityRecord>,
+  rows: ImportRow[],
+): Promise<Map<string, number>> {
+  const weights = new Map<string, number>();
+  const query = useQuery();
+  const moduleRows = await query
+    .select({ weight: schema.module.weight })
+    .from(schema.module);
+  const existingModuleWeights = moduleRows.map((row) => row.weight);
+  const taken = await loadTakenWeights();
+  const assignedModuleWeights: number[] = [];
+
+  for (const handle of uniqueInOrder(rows.map((row) => row.moduleHandle))) {
+    const module = modules.get(handle);
+    if (!module) continue;
+
+    if (module.exists && module.entity) {
+      weights.set(handle, module.entity.weight);
+      continue;
+    }
+
+    const allModuleWeights = [
+      ...existingModuleWeights,
+      ...assignedModuleWeights,
+    ];
+    const weight = allocateNextModuleWeight(allModuleWeights, taken);
+    taken.add(weight);
+    assignedModuleWeights.push(weight);
+    weights.set(handle, weight);
+  }
+
+  return weights;
+}
+
+async function buildCompetencyWeights(
+  competencies: Map<string, CompetencyEntityRecord>,
+  moduleWeights: Map<string, number>,
+  rows: ImportRow[],
+): Promise<Map<string, number>> {
+  const weights = new Map<string, number>();
+  const taken = await loadTakenWeights();
+
+  for (const row of rows) {
+    if (weights.has(row.competencyHandle)) continue;
+
+    const competency = competencies.get(row.competencyHandle);
+    if (!competency) continue;
+
+    if (competency.exists && competency.entity) {
+      weights.set(row.competencyHandle, competency.entity.weight);
+      taken.add(competency.entity.weight);
+      continue;
+    }
+
+    const moduleWeight = moduleWeights.get(row.moduleHandle);
+    if (moduleWeight === undefined) continue;
+
+    const weight = allocateNextCompetencyWeight(moduleWeight, taken);
+    taken.add(weight);
+    weights.set(row.competencyHandle, weight);
+  }
+
+  return weights;
 }
 
 export type CreationDecisions = Map<string, boolean>;
@@ -245,15 +381,8 @@ export async function resolveImportPlan(
   const programs = new Map<string, ProgramEntityRecord>();
   const modules = new Map<string, ModuleEntityRecord>();
   const competencies = new Map<string, CompetencyEntityRecord>();
-  const moduleWeights = new Map<string, number>();
-  let moduleWeightCounter = 0;
 
   for (const row of parsedRows) {
-    if (!moduleWeights.has(row.moduleHandle)) {
-      moduleWeightCounter++;
-      moduleWeights.set(row.moduleHandle, moduleWeightCounter);
-    }
-
     addAffectedRow(
       programs,
       row.programHandle,
@@ -312,6 +441,13 @@ export async function resolveImportPlan(
     }),
   ]);
 
+  const moduleWeights = await buildModuleWeights(modules, parsedRows);
+  const competencyWeights = await buildCompetencyWeights(
+    competencies,
+    moduleWeights,
+    parsedRows,
+  );
+
   return {
     rows: parsedRows,
     parseStats,
@@ -319,6 +455,7 @@ export async function resolveImportPlan(
     modules,
     competencies,
     moduleWeights,
+    competencyWeights,
   };
 }
 
@@ -669,7 +806,14 @@ export async function applyImportPlan(
       failedCreations.add(module.handle);
       continue;
     }
-    const weight = plan.moduleWeights.get(module.handle) ?? 1;
+    const weight = plan.moduleWeights.get(module.handle);
+    if (weight === undefined) {
+      console.error(
+        `Failed to create module ${module.handle}: no weight allocated`,
+      );
+      failedCreations.add(module.handle);
+      continue;
+    }
     try {
       const created = await Course.Module.create({
         handle: module.handle,
@@ -696,11 +840,20 @@ export async function applyImportPlan(
       continue;
     }
     const type = competency.moduleTitle === "Theorie" ? "knowledge" : "skill";
+    const weight = plan.competencyWeights.get(competency.handle);
+    if (weight === undefined) {
+      console.error(
+        `Failed to create competency ${competency.handle}: no weight allocated`,
+      );
+      failedCreations.add(competency.handle);
+      continue;
+    }
     try {
       const created = await Course.Competency.create({
         handle: competency.handle,
         title: competency.title,
         type,
+        weight,
       });
       competencyIds.set(competency.handle, created.id);
       stats.competenciesCreated++;

--- a/packages/scripts/src/jachtzeilen-ab-content-decisions.ts
+++ b/packages/scripts/src/jachtzeilen-ab-content-decisions.ts
@@ -1,0 +1,26 @@
+export type CombinedLagerwalDecision =
+  | "split-existing-competencies"
+  | "create-combined-competency";
+
+export type RrpDecision = "reuse-reglementen" | "create-rrp-competency";
+
+export interface JachtzeilenAbContentDecisions {
+  revision: string;
+  ambiguousOvRequired: "required-inland-optional-waddenzee-and-sea" | null;
+  blankVoRequired: boolean | null;
+  combinedLagerwal: CombinedLagerwalDecision | null;
+  rrp: RrpDecision | null;
+}
+
+/**
+ * Content decisions are intentionally explicit. The import refuses to plan or
+ * execute while a value is null, so editorial ambiguity cannot silently become
+ * production data.
+ */
+export const JACHTZEILEN_AB_CONTENT_DECISIONS = {
+  revision: "2601",
+  ambiguousOvRequired: "required-inland-optional-waddenzee-and-sea",
+  blankVoRequired: false,
+  combinedLagerwal: "split-existing-competencies",
+  rrp: "create-rrp-competency",
+} satisfies JachtzeilenAbContentDecisions;

--- a/packages/scripts/src/jachtzeilen-catalog-snapshot.ts
+++ b/packages/scripts/src/jachtzeilen-catalog-snapshot.ts
@@ -1,0 +1,388 @@
+import { createHash } from "node:crypto";
+
+export const JACHTZEILEN_COURSE_HANDLES = [
+  "jacht-kajuitzeilen-binnenwater-volwassenen",
+  "jacht-kajuitzeilen-ruim-binnenwater-volwassenen",
+  "jacht-kajuitzeilen-waddenzee-en-zeeuwse-stromen-volwassenen",
+  "jacht-kajuitzeilen-zee-volwassenen",
+] as const;
+
+export const CATALOG_TABLE_NAMES = [
+  "discipline",
+  "category",
+  "degree",
+  "course",
+  "course_category",
+  "program",
+  "module",
+  "competency",
+  "gear_type",
+  "curriculum",
+  "curriculum_module",
+  "curriculum_competency",
+  "curriculum_gear_link",
+] as const;
+
+type CatalogTableName = (typeof CATALOG_TABLE_NAMES)[number];
+type CatalogRow = Record<string, unknown>;
+
+export type JachtzeilenCatalogData = Record<CatalogTableName, CatalogRow[]>;
+
+export interface JachtzeilenCatalogSnapshot {
+  kind: "jachtzeilen-catalog-snapshot";
+  version: 1;
+  generatedAt: string;
+  sourceService: string;
+  catalogHash: string;
+  data: JachtzeilenCatalogData;
+}
+
+const SHARED_TITLE_CORRECTIONS = new Map<
+  string,
+  { oldTitle: string; newTitle: string }
+>([
+  [
+    "aanlegen-en-afvaren-met-spiegel-naar-de-wal-met-mooring-lazylines",
+    {
+      oldTitle:
+        "Aanlegen en afvaren met spiegel naar de wal met mooring-/lazylines",
+      newTitle:
+        "Aanleggen en afvaren met spiegel naar de wal met mooring-/lazy lines",
+    },
+  ],
+  [
+    "windorientatie",
+    {
+      oldTitle: "Windorientatie",
+      newTitle: "Windoriëntatie",
+    },
+  ],
+]);
+
+const HASH_FIELDS = {
+  discipline: ["id", "handle", "title", "weight", "abbreviation"],
+  category: [
+    "id",
+    "parent_category_id",
+    "handle",
+    "title",
+    "description",
+    "weight",
+  ],
+  degree: ["id", "handle", "title", "rang"],
+  course: [
+    "id",
+    "handle",
+    "title",
+    "description",
+    "discipline_id",
+    "abbreviation",
+  ],
+  course_category: ["id", "course_id", "category_id"],
+  program: ["id", "handle", "title", "course_id", "degree_id"],
+  module: ["id", "handle", "title", "weight"],
+  competency: ["id", "handle", "title", "type", "weight"],
+  gear_type: ["id", "handle", "title"],
+  curriculum: ["id", "program_id", "revision", "started_at"],
+  curriculum_module: ["curriculum_id", "module_id"],
+  curriculum_competency: [
+    "id",
+    "curriculum_id",
+    "module_id",
+    "competency_id",
+    "is_required",
+    "requirement",
+  ],
+  curriculum_gear_link: ["curriculum_id", "gear_type_id"],
+} satisfies Record<CatalogTableName, string[]>;
+
+function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function sqlStringList(values: readonly string[]): string {
+  return values.map((value) => `'${value.replaceAll("'", "''")}'`).join(", ");
+}
+
+const courseHandleSql = sqlStringList(JACHTZEILEN_COURSE_HANDLES);
+
+/**
+ * This query deliberately exports catalog data only: no people, students,
+ * cohorts, locations, certificates, or other operational records.
+ *
+ * It selects the four Jachtzeilen courses, their 2401/2501 curricula and
+ * dependencies, plus the global competency ordering band touched by RR&P and
+ * the two approved shared-title corrections.
+ */
+export const JACHTZEILEN_CATALOG_EXPORT_SQL = `
+WITH RECURSIVE
+target_courses AS (
+  SELECT c.*
+  FROM course c
+  WHERE c.handle IN (${courseHandleSql})
+),
+target_course_categories AS (
+  SELECT cc.*
+  FROM course_category cc
+  JOIN target_courses c ON c.id = cc.course_id
+),
+category_paths AS (
+  SELECT cc.category_id AS id, 0 AS depth
+  FROM target_course_categories cc
+  UNION ALL
+  SELECT c.parent_category_id AS id, cp.depth + 1 AS depth
+  FROM category_paths cp
+  JOIN category c ON c.id = cp.id
+  WHERE c.parent_category_id IS NOT NULL
+),
+target_category_ids AS (
+  SELECT id, max(depth) AS depth
+  FROM category_paths
+  GROUP BY id
+),
+baseline_curricula AS (
+  SELECT cu.*
+  FROM curriculum cu
+  JOIN program p ON p.id = cu.program_id
+  JOIN target_courses c ON c.id = p.course_id
+  WHERE cu.revision IN ('2401', '2501')
+),
+baseline_programs AS (
+  SELECT DISTINCT p.*
+  FROM program p
+  JOIN baseline_curricula cu ON cu.program_id = p.id
+),
+target_curriculum_modules AS (
+  SELECT cm.*
+  FROM curriculum_module cm
+  JOIN baseline_curricula cu ON cu.id = cm.curriculum_id
+),
+target_curriculum_competencies AS (
+  SELECT cc.*
+  FROM curriculum_competency cc
+  JOIN baseline_curricula cu ON cu.id = cc.curriculum_id
+),
+target_curriculum_gear_links AS (
+  SELECT cg.*
+  FROM curriculum_gear_link cg
+  JOIN baseline_curricula cu ON cu.id = cg.curriculum_id
+),
+target_modules AS (
+  SELECT DISTINCT m.*
+  FROM module m
+  JOIN target_curriculum_modules cm ON cm.module_id = m.id
+),
+linked_competencies AS (
+  SELECT DISTINCT c.*
+  FROM competency c
+  JOIN target_curriculum_competencies cc ON cc.competency_id = c.id
+),
+target_competencies AS (
+  SELECT * FROM linked_competencies
+  UNION
+  SELECT c.*
+  FROM competency c
+  WHERE c.weight >= 906
+     OR c.handle IN (
+       'reisvoorbereiding-routering-en-planning',
+       'aanlegen-en-afvaren-met-spiegel-naar-de-wal-met-mooring-lazylines',
+       'windorientatie'
+     )
+),
+target_gear_types AS (
+  SELECT DISTINCT g.*
+  FROM gear_type g
+  JOIN target_curriculum_gear_links cg ON cg.gear_type_id = g.id
+)
+SELECT jsonb_build_object(
+  'discipline', COALESCE((
+    SELECT jsonb_agg(to_jsonb(d) ORDER BY d.id)
+    FROM discipline d
+    WHERE d.id IN (SELECT discipline_id FROM target_courses)
+  ), '[]'::jsonb),
+  'category', COALESCE((
+    SELECT jsonb_agg(to_jsonb(c) ORDER BY ids.depth DESC, c.id)
+    FROM category c
+    JOIN target_category_ids ids ON ids.id = c.id
+  ), '[]'::jsonb),
+  'degree', COALESCE((
+    SELECT jsonb_agg(to_jsonb(d) ORDER BY d.id)
+    FROM degree d
+    WHERE d.handle IN (
+      'niveau-1', 'niveau-2', 'niveau-3',
+      'niveau-4', 'niveau-a', 'niveau-b'
+    )
+  ), '[]'::jsonb),
+  'course', COALESCE((
+    SELECT jsonb_agg(to_jsonb(c) ORDER BY c.id)
+    FROM target_courses c
+  ), '[]'::jsonb),
+  'course_category', COALESCE((
+    SELECT jsonb_agg(to_jsonb(cc) ORDER BY cc.id)
+    FROM target_course_categories cc
+  ), '[]'::jsonb),
+  'program', COALESCE((
+    SELECT jsonb_agg(to_jsonb(p) ORDER BY p.id)
+    FROM baseline_programs p
+  ), '[]'::jsonb),
+  'module', COALESCE((
+    SELECT jsonb_agg(to_jsonb(m) ORDER BY m.id)
+    FROM target_modules m
+  ), '[]'::jsonb),
+  'competency', COALESCE((
+    SELECT jsonb_agg(to_jsonb(c) ORDER BY c.id)
+    FROM target_competencies c
+  ), '[]'::jsonb),
+  'gear_type', COALESCE((
+    SELECT jsonb_agg(to_jsonb(g) ORDER BY g.id)
+    FROM target_gear_types g
+  ), '[]'::jsonb),
+  'curriculum', COALESCE((
+    SELECT jsonb_agg(to_jsonb(cu) ORDER BY cu.id)
+    FROM baseline_curricula cu
+  ), '[]'::jsonb),
+  'curriculum_module', COALESCE((
+    SELECT jsonb_agg(to_jsonb(cm) ORDER BY cm.curriculum_id, cm.module_id)
+    FROM target_curriculum_modules cm
+  ), '[]'::jsonb),
+  'curriculum_competency', COALESCE((
+    SELECT jsonb_agg(to_jsonb(cc) ORDER BY cc.id)
+    FROM target_curriculum_competencies cc
+  ), '[]'::jsonb),
+  'curriculum_gear_link', COALESCE((
+    SELECT jsonb_agg(
+      to_jsonb(cg) ORDER BY cg.curriculum_id, cg.gear_type_id
+    )
+    FROM target_curriculum_gear_links cg
+  ), '[]'::jsonb)
+) AS catalog
+`;
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stableValue);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, stableValue(child)]),
+    );
+  }
+  return value;
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(stableValue(value));
+}
+
+function selectFields(row: CatalogRow, fields: readonly string[]): CatalogRow {
+  return Object.fromEntries(fields.map((field) => [field, row[field] ?? null]));
+}
+
+function normalizeCompetenciesForHash(rows: CatalogRow[]): CatalogRow[] {
+  const rrp = rows.find(
+    (row) => row.handle === "reisvoorbereiding-routering-en-planning",
+  );
+  const rrpExists = rrp !== undefined;
+  if (rrp) {
+    invariant(
+      rrp.title === "Reisvoorbereiding, Routering en Planning (RR&P)" &&
+        rrp.type === "knowledge" &&
+        rrp.weight === 907,
+      "Existing RR&P competency does not match the approved definition",
+    );
+  }
+
+  return rows
+    .filter((row) => row.handle !== "reisvoorbereiding-routering-en-planning")
+    .map((row) => {
+      const normalized = selectFields(row, HASH_FIELDS.competency);
+      const handle = String(normalized.handle);
+      const titleCorrection = SHARED_TITLE_CORRECTIONS.get(handle);
+      if (titleCorrection) {
+        invariant(
+          normalized.title === titleCorrection.oldTitle ||
+            normalized.title === titleCorrection.newTitle,
+          `Unexpected title for shared competency ${handle}`,
+        );
+        normalized.title = titleCorrection.newTitle;
+      }
+
+      if (
+        rrpExists &&
+        typeof normalized.weight === "number" &&
+        normalized.weight > 907
+      ) {
+        normalized.weight -= 1;
+      }
+      return normalized;
+    });
+}
+
+export function assertCatalogData(
+  value: unknown,
+): asserts value is JachtzeilenCatalogData {
+  invariant(
+    value !== null && typeof value === "object" && !Array.isArray(value),
+    "Catalog export is not an object",
+  );
+  const record = value as Record<string, unknown>;
+  for (const tableName of CATALOG_TABLE_NAMES) {
+    invariant(
+      Array.isArray(record[tableName]),
+      `Catalog export is missing ${tableName}`,
+    );
+  }
+}
+
+export function computeJachtzeilenCatalogHash(
+  data: JachtzeilenCatalogData,
+): string {
+  assertCatalogData(data);
+
+  const semantic = Object.fromEntries(
+    CATALOG_TABLE_NAMES.map((tableName) => {
+      const rows =
+        tableName === "competency"
+          ? normalizeCompetenciesForHash(data[tableName])
+          : data[tableName].map((row) =>
+              selectFields(row, HASH_FIELDS[tableName]),
+            );
+      return [
+        tableName,
+        rows
+          .map((row) => stableValue(row) as CatalogRow)
+          .sort((left, right) =>
+            stableJson(left).localeCompare(stableJson(right)),
+          ),
+      ];
+    }),
+  );
+
+  return createHash("sha256").update(stableJson(semantic)).digest("hex");
+}
+
+export async function readJachtzeilenCatalogDataFromDatabase(): Promise<JachtzeilenCatalogData> {
+  const [{ useQuery }, { sql }] = await Promise.all([
+    import("@nawadi/core"),
+    import("drizzle-orm"),
+  ]);
+  const result = await useQuery().execute(
+    sql.raw(JACHTZEILEN_CATALOG_EXPORT_SQL),
+  );
+  const row = result.rows[0] as { catalog?: unknown } | undefined;
+  assertCatalogData(row?.catalog);
+  return row.catalog;
+}
+
+export async function readJachtzeilenCatalogFingerprint(): Promise<{
+  data: JachtzeilenCatalogData;
+  hash: string;
+}> {
+  const data = await readJachtzeilenCatalogDataFromDatabase();
+  return {
+    data,
+    hash: computeJachtzeilenCatalogHash(data),
+  };
+}

--- a/packages/scripts/src/manage-jachtzeilen-catalog-snapshot.ts
+++ b/packages/scripts/src/manage-jachtzeilen-catalog-snapshot.ts
@@ -1,0 +1,217 @@
+#!/usr/bin/env tsx
+
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  assertCatalogData,
+  CATALOG_TABLE_NAMES,
+  computeJachtzeilenCatalogHash,
+  JACHTZEILEN_CATALOG_EXPORT_SQL,
+  type JachtzeilenCatalogData,
+  type JachtzeilenCatalogSnapshot,
+} from "./jachtzeilen-catalog-snapshot.ts";
+
+type Command = "export" | "load";
+
+interface Options {
+  command: Command;
+  execute: boolean;
+  service?: string;
+  filePath?: string;
+  pgUri?: string;
+}
+
+function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function parseOptions(args: string[]): Options {
+  const options: Options = { command: "export", execute: false };
+  let commandSeen = false;
+
+  for (const arg of args) {
+    if (arg === "--") continue;
+    if (!arg.startsWith("-") && !commandSeen) {
+      invariant(arg === "export" || arg === "load", `Unknown command: ${arg}`);
+      options.command = arg;
+      commandSeen = true;
+      continue;
+    }
+    if (arg === "--execute") {
+      options.execute = true;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+
+    const [name, value] = arg.split("=", 2);
+    invariant(value, `Option ${name} requires =VALUE`);
+    if (name === "--service") options.service = value;
+    else if (name === "--file") options.filePath = value;
+    else if (name === "--pg-uri") options.pgUri = value;
+    else throw new Error(`Unknown option: ${name}`);
+  }
+
+  return options;
+}
+
+function printHelp() {
+  console.log(`
+Usage:
+  pnpm --filter @nawadi/scripts jachtzeilen:catalog-snapshot -- export --service=nawadi_prod_ro --file=.jachtzeilen-catalog-snapshot.json
+  pnpm --filter @nawadi/scripts jachtzeilen:catalog-snapshot -- load --file=.jachtzeilen-catalog-snapshot.json --pg-uri=postgresql://postgres:postgres@127.0.0.1:54322/postgres --execute
+
+The export contains catalog data only. Loading is restricted to localhost and
+truncates local catalog tables (plus local dependent test data through CASCADE).
+`);
+}
+
+function queryCatalogWithPsql(connection: string): JachtzeilenCatalogData {
+  const output = execFileSync(
+    "psql",
+    [
+      connection,
+      "-X",
+      "-v",
+      "ON_ERROR_STOP=1",
+      "-At",
+      "-c",
+      JACHTZEILEN_CATALOG_EXPORT_SQL,
+    ],
+    { encoding: "utf8", maxBuffer: 128 * 1024 * 1024 },
+  ).trim();
+  invariant(output, "Catalog export returned no data");
+  const parsed = JSON.parse(output) as unknown;
+  assertCatalogData(parsed);
+  return parsed;
+}
+
+function defaultSnapshotPath(): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  return path.join(process.cwd(), `.jachtzeilen-catalog-${timestamp}.json`);
+}
+
+function exportSnapshot(options: Options) {
+  const service = options.service ?? "nawadi_prod_ro";
+  const data = queryCatalogWithPsql(`service=${service}`);
+  const catalogHash = computeJachtzeilenCatalogHash(data);
+  const snapshot: JachtzeilenCatalogSnapshot = {
+    kind: "jachtzeilen-catalog-snapshot",
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    sourceService: service,
+    catalogHash,
+    data,
+  };
+  const filePath = path.resolve(options.filePath ?? defaultSnapshotPath());
+  fs.writeFileSync(filePath, `${JSON.stringify(snapshot, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  console.log(`Catalog snapshot written: ${filePath}`);
+  console.log(`Catalog hash: ${catalogHash}`);
+}
+
+function readSnapshot(filePath: string): JachtzeilenCatalogSnapshot {
+  const parsed = JSON.parse(
+    fs.readFileSync(path.resolve(filePath), "utf8"),
+  ) as JachtzeilenCatalogSnapshot;
+  invariant(
+    parsed.kind === "jachtzeilen-catalog-snapshot" && parsed.version === 1,
+    "Unsupported catalog snapshot",
+  );
+  assertCatalogData(parsed.data);
+  invariant(
+    computeJachtzeilenCatalogHash(parsed.data) === parsed.catalogHash,
+    "Catalog snapshot hash is invalid",
+  );
+  return parsed;
+}
+
+function assertLocalPostgres(pgUri: string) {
+  let url: URL;
+  try {
+    url = new URL(pgUri);
+  } catch {
+    throw new Error("--pg-uri must be a PostgreSQL URL");
+  }
+  invariant(
+    url.protocol === "postgres:" || url.protocol === "postgresql:",
+    "--pg-uri must be a PostgreSQL URL",
+  );
+  invariant(
+    url.hostname === "localhost" ||
+      url.hostname === "127.0.0.1" ||
+      url.hostname === "::1",
+    "Snapshot loading is restricted to localhost",
+  );
+}
+
+function dollarQuoteJson(value: unknown, index: number): string {
+  const json = JSON.stringify(value);
+  let tag = `$catalog_${index}$`;
+  while (json.includes(tag)) tag = `$catalog_${index}_${tag.length}$`;
+  return `${tag}${json}${tag}`;
+}
+
+function buildLoadSql(data: JachtzeilenCatalogData): string {
+  const insertStatements = CATALOG_TABLE_NAMES.map((tableName, index) => {
+    const json = dollarQuoteJson(data[tableName], index);
+    return `INSERT INTO ${tableName} SELECT * FROM json_populate_recordset(NULL::${tableName}, ${json}::json);`;
+  });
+
+  return [
+    String.raw`\set ON_ERROR_STOP on`,
+    "BEGIN;",
+    "SET LOCAL session_replication_role = replica;",
+    `TRUNCATE TABLE ${[...CATALOG_TABLE_NAMES].reverse().join(", ")} CASCADE;`,
+    ...insertStatements,
+    "SET LOCAL session_replication_role = origin;",
+    "COMMIT;",
+    "",
+  ].join("\n");
+}
+
+function loadSnapshot(options: Options) {
+  invariant(options.filePath, "--file is required");
+  invariant(options.pgUri, "--pg-uri is required");
+  assertLocalPostgres(options.pgUri);
+  const snapshot = readSnapshot(options.filePath);
+
+  console.log(
+    `Load plan: ${CATALOG_TABLE_NAMES.length} catalog tables from ${snapshot.sourceService}`,
+  );
+  console.log(`Catalog hash: ${snapshot.catalogHash}`);
+  if (!options.execute) {
+    console.log("Dry run only. Add --execute to replace the local catalog.");
+    return;
+  }
+
+  const result = spawnSync(
+    "psql",
+    [options.pgUri, "-X", "-v", "ON_ERROR_STOP=1"],
+    {
+      input: buildLoadSql(snapshot.data),
+      encoding: "utf8",
+      maxBuffer: 128 * 1024 * 1024,
+    },
+  );
+  invariant(
+    result.status === 0,
+    `Local catalog load failed:\n${result.stderr || result.stdout}`,
+  );
+
+  const loadedData = queryCatalogWithPsql(options.pgUri);
+  const loadedHash = computeJachtzeilenCatalogHash(loadedData);
+  invariant(
+    loadedHash === snapshot.catalogHash,
+    `Loaded catalog hash mismatch: expected ${snapshot.catalogHash}, got ${loadedHash}`,
+  );
+  console.log("Local catalog snapshot loaded and verified.");
+}
+
+const options = parseOptions(process.argv.slice(2));
+if (options.command === "export") exportSnapshot(options);
+else loadSnapshot(options);


### PR DESCRIPTION
Import script for the Jachtzeilen instructor levels (NWD A & B) across all 4 waterways.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/buchungapp/codesmith/nationaal-watersportdiploma/pr/486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786102583&installation_id=137554715&pr_number=486&repository=buchungapp%2Fnationaal-watersportdiploma&return_to=https%3A%2F%2Fgithub.com%2Fbuchungapp%2Fnationaal-watersportdiploma%2Fpull%2F486&signature=af557b628282d93c0994e6a7e95d1d09c0a183bc06978be97ab863d511c5bedf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a controlled import process for Jachtzeilen 4/A/B curricula from a reviewed CSV.
  * Added catalog snapshot export, hashing, and validated local loading tools.
  * Added dry-run planning, transactional execution, idempotent reruns, manifests, verification, and safe rollback support.
  * Added rules for requirement normalization, requiredness, competency reuse, and approved competency creation.

* **Documentation**
  * Added design documentation covering local verification, production execution, attestations, and rollback requirements.

* **Tests**
  * Added coverage for parsing, mapping, normalization, decision validation, and CLI safety defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->