### PR TITLE
feat: add secretariaat account impersonation

### DIFF
--- a/apps/web/src/app/(dashboard)/(management)/secretariaat/gebruikers/_components/table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/secretariaat/gebruikers/_components/table.tsx
@@ -8,9 +8,11 @@ import {
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
+import { useRouter } from "next/navigation";
 import { useAction } from "next-safe-action/hooks";
 import { useState } from "react";
 import { toast } from "sonner";
+import { startPersonImpersonationAction } from "~/app/_actions/admin/impersonation-actions";
 import { updatePersonEmailForAdminAction } from "~/app/_actions/person/merge-persons-action";
 import { DEFAULT_SERVER_ERROR_MESSAGE } from "~/app/_actions/utils";
 import {
@@ -115,24 +117,46 @@ const columns = [
 ];
 
 function RowActions({ person }: { person: Person }) {
+  const router = useRouter();
   const [isEmailDialogOpen, setIsEmailDialogOpen] = useState(false);
+  const [isImpersonationDialogOpen, setIsImpersonationDialogOpen] =
+    useState(false);
 
-  const { execute, result, reset } = useAction(
-    updatePersonEmailForAdminAction,
-    {
-      onSuccess: () => {
-        toast.success("E-mailadres bijgewerkt.");
-        closeEmailDialog();
-      },
-      onError: ({ error }) => {
-        toast.error(error.serverError ?? DEFAULT_SERVER_ERROR_MESSAGE);
-      },
+  const emailAction = useAction(updatePersonEmailForAdminAction, {
+    onSuccess: () => {
+      toast.success("E-mailadres bijgewerkt.");
+      closeEmailDialog();
     },
-  );
+    onError: ({ error }) => {
+      toast.error(error.serverError ?? DEFAULT_SERVER_ERROR_MESSAGE);
+    },
+  });
+
+  const impersonationAction = useAction(startPersonImpersonationAction, {
+    onSuccess: () => {
+      toast.success("Impersonatie gestart.");
+      closeImpersonationDialog();
+      router.push("/");
+      router.refresh();
+    },
+    onError: ({ error }) => {
+      toast.error(error.serverError ?? DEFAULT_SERVER_ERROR_MESSAGE);
+    },
+  });
+
+  const displayName = [person.firstName, person.lastNamePrefix, person.lastName]
+    .filter(Boolean)
+    .join(" ");
+  const isStartingImpersonation = impersonationAction.status === "executing";
 
   const closeEmailDialog = () => {
     setIsEmailDialogOpen(false);
-    reset();
+    emailAction.reset();
+  };
+
+  const closeImpersonationDialog = () => {
+    setIsImpersonationDialogOpen(false);
+    impersonationAction.reset();
   };
 
   return (
@@ -145,6 +169,11 @@ function RowActions({ person }: { person: Person }) {
           <DropdownItem onClick={() => setIsEmailDialogOpen(true)}>
             E-mail wijzigen…
           </DropdownItem>
+          {person.userId ? (
+            <DropdownItem onClick={() => setIsImpersonationDialogOpen(true)}>
+              Impersoneren…
+            </DropdownItem>
+          ) : null}
           <DropdownItem href={`?merge=true&duplicateId=${person.id}`}>
             Samenvoegen…
           </DropdownItem>
@@ -155,7 +184,7 @@ function RowActions({ person }: { person: Person }) {
         <form
           action={(formData) => {
             const email = formData.get("email") as string;
-            execute({ personId: person.id, email });
+            emailAction.execute({ personId: person.id, email });
           }}
         >
           <AlertTitle>E-mailadres wijzigen</AlertTitle>
@@ -171,7 +200,7 @@ function RowActions({ person }: { person: Person }) {
               autoComplete="off"
               spellCheck={false}
               placeholder="nieuw@voorbeeld.nl"
-              invalid={!!result.validationErrors?.email}
+              invalid={!!emailAction.result.validationErrors?.email}
               defaultValue={person.email ?? ""}
             />
           </AlertBody>
@@ -184,6 +213,46 @@ function RowActions({ person }: { person: Person }) {
             </Button>
           </AlertActions>
         </form>
+      </Alert>
+
+      <Alert
+        open={isImpersonationDialogOpen}
+        onClose={closeImpersonationDialog}
+        size="md"
+      >
+        <AlertTitle>Account impersoneren?</AlertTitle>
+        <AlertDescription>
+          Je neemt tijdelijk het account van deze gebruiker over. Gebruik dit
+          alleen voor support en stop de impersonatie direct na controle.
+        </AlertDescription>
+        <AlertBody>
+          <div className="rounded-lg bg-zinc-50 p-3 text-sm dark:bg-zinc-800/50">
+            <div className="font-medium text-zinc-900 dark:text-white">
+              {displayName}
+            </div>
+            <div className="mt-1 text-zinc-600 dark:text-zinc-400">
+              <Code>{person.handle}</Code>
+              {person.email ? <span> - {person.email}</span> : null}
+            </div>
+          </div>
+        </AlertBody>
+        <AlertActions>
+          <Button
+            plain
+            onClick={closeImpersonationDialog}
+            disabled={isStartingImpersonation}
+          >
+            Annuleren
+          </Button>
+          <Button
+            type="button"
+            color="orange"
+            onClick={() => impersonationAction.execute({ personId: person.id })}
+            disabled={isStartingImpersonation || !person.userId}
+          >
+            {isStartingImpersonation ? "Starten..." : "Impersoneren"}
+          </Button>
+        </AlertActions>
       </Alert>
     </div>
   );

--- a/apps/web/src/app/_actions/admin/impersonation-actions.ts
+++ b/apps/web/src/app/_actions/admin/impersonation-actions.ts
@@ -1,12 +1,22 @@
 "use server";
 
+import { User } from "@nawadi/core";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
-import { startImpersonation, stopImpersonation } from "~/lib/nwd";
+import { assertCanUseImpersonation } from "~/lib/impersonation";
+import {
+  getUserOrThrow,
+  startImpersonation,
+  stopImpersonation,
+} from "~/lib/nwd";
 import { actionClientWithMeta } from "../safe-action";
 
 const impersonateSchema = z.object({
   targetUserId: z.string().uuid(),
+});
+
+const impersonatePersonSchema = z.object({
+  personId: z.string().uuid(),
 });
 
 export const startImpersonationAction = actionClientWithMeta
@@ -14,6 +24,31 @@ export const startImpersonationAction = actionClientWithMeta
   .inputSchema(impersonateSchema)
   .action(async ({ parsedInput: { targetUserId } }) => {
     await startImpersonation(targetUserId);
+    revalidatePath("/", "layout");
+  });
+
+export const startPersonImpersonationAction = actionClientWithMeta
+  .metadata({ name: "start-person-impersonation" })
+  .inputSchema(impersonatePersonSchema)
+  .action(async ({ parsedInput: { personId } }) => {
+    const user = await getUserOrThrow();
+    assertCanUseImpersonation(user.email);
+
+    const persons = await User.Person.list({
+      filter: { personId },
+      limit: 1,
+    });
+    const person = persons.items[0];
+
+    if (!person) {
+      throw new Error("Persoon niet gevonden.");
+    }
+
+    if (!person.userId) {
+      throw new Error("Deze persoon heeft geen gekoppeld account.");
+    }
+
+    await startImpersonation(person.userId);
     revalidatePath("/", "layout");
   });
 

--- a/apps/web/src/app/_actions/safe-action.ts
+++ b/apps/web/src/app/_actions/safe-action.ts
@@ -22,12 +22,16 @@ export const actionClientWithMeta = createSafeActionClient({
   after(async () => {
     try {
       const user = await getUserOrThrow();
+      const impersonation = user._impersonation;
 
       posthog.capture({
         distinctId: user.authUserId,
         event: "action-executed",
         properties: {
           action: metadata.name,
+          impersonating: impersonation?.isImpersonating ?? false,
+          originalUserId: impersonation?.originalUserId,
+          impersonatedUserId: impersonation?.impersonatedUserId,
         },
       });
 

--- a/apps/web/src/lib/impersonation.test.tsx
+++ b/apps/web/src/lib/impersonation.test.tsx
@@ -1,4 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./authorization", () => ({
+  isSystemAdmin: vi.fn(
+    (email: string | null | undefined) => email === "admin@example.nl",
+  ),
+}));
+
 import {
   assertCanImpersonateTarget,
   assertCanUseImpersonation,
@@ -6,7 +13,7 @@ import {
 
 describe("assertCanUseImpersonation", () => {
   it("allows system administrators", () => {
-    expect(() => assertCanUseImpersonation("maurits@buchung.nl")).not.toThrow();
+    expect(() => assertCanUseImpersonation("admin@example.nl")).not.toThrow();
   });
 
   it("rejects non-administrators", () => {
@@ -42,7 +49,7 @@ describe("assertCanImpersonateTarget", () => {
       assertCanImpersonateTarget({
         operatorUserId: "admin-user",
         targetUserId: "other-admin-user",
-        targetEmail: "jeroen@buchung.nl",
+        targetEmail: "admin@example.nl",
       }),
     ).toThrow("Je kunt geen systeembeheerder impersoneren.");
   });

--- a/apps/web/src/lib/impersonation.test.tsx
+++ b/apps/web/src/lib/impersonation.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertCanImpersonateTarget,
+  assertCanUseImpersonation,
+} from "./impersonation";
+
+describe("assertCanUseImpersonation", () => {
+  it("allows system administrators", () => {
+    expect(() => assertCanUseImpersonation("maurits@buchung.nl")).not.toThrow();
+  });
+
+  it("rejects non-administrators", () => {
+    expect(() => assertCanUseImpersonation("support@example.nl")).toThrow(
+      "Unauthorized",
+    );
+  });
+});
+
+describe("assertCanImpersonateTarget", () => {
+  it("allows a regular support target", () => {
+    expect(() =>
+      assertCanImpersonateTarget({
+        operatorUserId: "admin-user",
+        targetUserId: "target-user",
+        targetEmail: "target@example.nl",
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects self-impersonation", () => {
+    expect(() =>
+      assertCanImpersonateTarget({
+        operatorUserId: "same-user",
+        targetUserId: "same-user",
+        targetEmail: "target@example.nl",
+      }),
+    ).toThrow("Je kunt je eigen account niet impersoneren.");
+  });
+
+  it("rejects impersonating another system administrator", () => {
+    expect(() =>
+      assertCanImpersonateTarget({
+        operatorUserId: "admin-user",
+        targetUserId: "other-admin-user",
+        targetEmail: "jeroen@buchung.nl",
+      }),
+    ).toThrow("Je kunt geen systeembeheerder impersoneren.");
+  });
+});

--- a/apps/web/src/lib/impersonation.ts
+++ b/apps/web/src/lib/impersonation.ts
@@ -1,0 +1,27 @@
+import { isSystemAdmin } from "./authorization";
+
+export function assertCanUseImpersonation(
+  operatorEmail: string | null | undefined,
+) {
+  if (!isSystemAdmin(operatorEmail)) {
+    throw new Error("Unauthorized");
+  }
+}
+
+export function assertCanImpersonateTarget({
+  operatorUserId,
+  targetUserId,
+  targetEmail,
+}: {
+  operatorUserId: string;
+  targetUserId: string;
+  targetEmail: string | null | undefined;
+}) {
+  if (targetUserId === operatorUserId) {
+    throw new Error("Je kunt je eigen account niet impersoneren.");
+  }
+
+  if (isSystemAdmin(targetEmail)) {
+    throw new Error("Je kunt geen systeembeheerder impersoneren.");
+  }
+}

--- a/apps/web/src/lib/nwd.ts
+++ b/apps/web/src/lib/nwd.ts
@@ -25,6 +25,10 @@ import "server-only";
 import { cacheLife, cacheTag } from "next/cache";
 import packageInfo from "~/../package.json";
 import dayjs from "~/lib/dayjs";
+import {
+  assertCanImpersonateTarget,
+  assertCanUseImpersonation,
+} from "~/lib/impersonation";
 import { invariant } from "~/utils/invariant";
 import posthog from "./posthog";
 
@@ -285,17 +289,19 @@ export const startImpersonation = async (targetUserId: string) => {
   return makeRequest(async () => {
     const authUser = await getUserOrThrow();
 
-    // Verify system admin permissions
-    const { isSystemAdmin } = await import("~/lib/authorization");
-    if (!isSystemAdmin(authUser.email)) {
-      throw new Error("Unauthorized");
-    }
+    assertCanUseImpersonation(authUser.email);
 
     // Verify target user exists
     const targetUser = await User.fromId(targetUserId);
     if (!targetUser) {
       throw new Error("Target user not found");
     }
+
+    assertCanImpersonateTarget({
+      operatorUserId: authUser.authUserId,
+      targetUserId,
+      targetEmail: targetUser.email,
+    });
 
     // Set impersonation cookie
     const cookieStore = await cookies();


### PR DESCRIPTION
## Summary

Adds a safer secretariaat impersonation flow for support work:

- Adds an `Impersoneren...` row action on `/secretariaat/gebruikers` for people with linked accounts.
- Starts impersonation from `personId`, resolving the auth user id server-side instead of trusting a client-provided auth id.
- Adds a confirmation dialog with the person's name, NWD-id, and email before taking over the account.
- Blocks self-impersonation and impersonating another system admin.
- Adds impersonation metadata to generic server-action analytics so actions taken during impersonation are easier to trace.
- Adds focused unit coverage for the impersonation permission guards.

## Test Coverage

Branch-specific coverage added:

```text
apps/web/src/lib/impersonation.test.tsx
- allows system administrators to use impersonation
- rejects non-administrators
- allows regular support targets
- rejects self-impersonation
- rejects system-admin targets
```

## Verification Results

Passed:

```text
PATH="/tmp/corepack-shims:$PATH" pnpm --filter @nawadi/web exec vitest run src/lib/impersonation.test.tsx
Test Files  1 passed (1)
Tests       5 passed (5)
```

```text
corepack pnpm exec biome check <touched files>
Checked 6 files. No fixes applied.
```

```text
corepack pnpm --filter @nawadi/web exec eslint <touched files>
0 errors, existing warnings only.
```

Not fully green locally:

- `pnpm --filter @nawadi/web test:components` has 2 unrelated existing failures in `src/app/_components/ai-chat/use-sticky-scroll.test.tsx`.
- Root package tests require the local Supabase DB to be running/reset. `supabase start` could not bind port `54322` because another local project already owns it.
- `/ship` pre-landing review checklist was missing at `.agents/skills/gstack/review/checklist.md`, so the formal gstack review gate was explicitly skipped by request.

## Test plan

- [x] Focused impersonation guard tests pass.
- [x] Targeted formatter check passes.
- [x] Targeted lint has no new errors.
- [ ] Full local suites not completed due to unrelated/local environment blockers above.

🤖 Generated with OpenAI Codex

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/buchungapp/codesmith/nationaal-watersportdiploma/pr/487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786177599&installation_id=137554715&pr_number=487&repository=buchungapp%2Fnationaal-watersportdiploma&return_to=https%3A%2F%2Fgithub.com%2Fbuchungapp%2Fnationaal-watersportdiploma%2Fpull%2F487&signature=2b67af283c33460f7c4d74ec3e097267d5c090ca04f724cacd69ff6c5f94f071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an account impersonation option for eligible admin users directly from the user management table.
  * Expanded impersonation to work from a person profile, with a confirmation dialog showing key account details.

* **Bug Fixes**
  * Tightened impersonation safeguards to prevent self-impersonation and impersonating restricted admin accounts.
  * Improved form handling so email updates and impersonation flows reset and report errors more reliably.

* **Tests**
  * Added coverage for impersonation permission checks and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->