### PR TITLE
fix(auth): avoid competing OTP redirects

### DIFF
--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -4,7 +4,6 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import { Toaster } from "sonner";
 import coverImage from "./_assets/zeilen-4.jpg";
-import SessionCheck from "./login/_components/session-check";
 import "sonner/dist/styles.css";
 
 import { SpeedInsights } from "@vercel/speed-insights/next";
@@ -78,7 +77,6 @@ export default function Layout({ children }: { children: React.ReactNode }) {
                 />
               </div>
             </div>
-            <SessionCheck />
           </div>
 
           <Toaster richColors />

--- a/apps/web/src/app/(auth)/login/login-route-guard.test.tsx
+++ b/apps/web/src/app/(auth)/login/login-route-guard.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import CodePage from "./code/page";
+import LoginPage from "./page";
+
+vi.mock("~/app/_components/brand/logo", () => ({
+  default: () => <div data-testid="logo" />,
+}));
+
+vi.mock("./_components/login-form", () => ({
+  EmailForm: () => <form data-testid="email-form" />,
+  OtpForm: () => <form data-testid="otp-form" />,
+}));
+
+vi.mock("./_components/session-check", () => ({
+  default: () => <div data-testid="session-check" />,
+}));
+
+describe("login session guard", () => {
+  it("redirects existing sessions away from the login entry page", () => {
+    render(<LoginPage />);
+
+    expect(screen.getByTestId("session-check")).toBeInTheDocument();
+  });
+
+  it("does not compete with OTP verification on the code page", async () => {
+    const page = await CodePage({
+      searchParams: Promise.resolve({ email: "sailor@example.com" }),
+    });
+
+    render(page);
+
+    expect(screen.queryByTestId("session-check")).not.toBeInTheDocument();
+    expect(screen.getByTestId("otp-form")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -1,26 +1,30 @@
 import { constants } from "@nawadi/lib";
 import Logo from "~/app/_components/brand/logo";
 import { EmailForm } from "./_components/login-form";
+import SessionCheck from "./_components/session-check";
 
 export default function Page() {
   return (
-    <div className="mx-auto w-full lg:w-96 max-w-sm">
-      <div>
-        <Logo className="w-auto h-20 text-white" />
-        <h2 className="mt-8 font-bold text-slate-900 text-2xl leading-8 tracking-tight">
-          Welkom bij het {constants.APP_NAME}
-        </h2>
-        <p className="mt-2 text-slate-500 text-sm leading-6">
-          Voer je e-mailadres in om verder te gaan. Als je nog geen account
-          hebt, maken we er een voor je.
-        </p>
-      </div>
-
-      <div className="mt-8">
+    <>
+      <SessionCheck />
+      <div className="mx-auto w-full lg:w-96 max-w-sm">
         <div>
-          <EmailForm className="space-y-6" />
+          <Logo className="w-auto h-20 text-white" />
+          <h2 className="mt-8 font-bold text-slate-900 text-2xl leading-8 tracking-tight">
+            Welkom bij het {constants.APP_NAME}
+          </h2>
+          <p className="mt-2 text-slate-500 text-sm leading-6">
+            Voer je e-mailadres in om verder te gaan. Als je nog geen account
+            hebt, maken we er een voor je.
+          </p>
+        </div>
+
+        <div className="mt-8">
+          <div>
+            <EmailForm className="space-y-6" />
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/apps/web/src/app/(dashboard)/(account)/profiel/route.ts
+++ b/apps/web/src/app/(dashboard)/(account)/profiel/route.ts
@@ -1,15 +1,9 @@
 import { redirect } from "next/navigation";
-import type { NextRequest } from "next/server";
 import { getUserOrThrow } from "~/lib/nwd";
+import { getProfileRedirectPath } from "~/lib/profile-redirect";
 
-export async function GET(_request: NextRequest) {
+export async function GET() {
   const user = await getUserOrThrow();
 
-  const primaryPerson = user.persons.find((person) => person.isPrimary);
-
-  if (!primaryPerson) {
-    redirect("/account");
-  }
-
-  redirect(`/profiel/${primaryPerson.handle}`);
+  redirect(getProfileRedirectPath(user.persons));
 }

--- a/apps/web/src/app/_actions/auth/verify-action.ts
+++ b/apps/web/src/app/_actions/auth/verify-action.ts
@@ -1,8 +1,9 @@
 "use server";
-import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { z } from "zod";
 import { zfd } from "zod-form-data";
+import { getUserOrThrow } from "~/lib/nwd";
+import { getProfileRedirectPath } from "~/lib/profile-redirect";
 import { createClient } from "~/lib/supabase/server";
 import { actionClientWithMeta } from "../safe-action";
 
@@ -31,6 +32,7 @@ export const verifyAction = actionClientWithMeta
       throw error;
     }
 
-    revalidatePath("/", "layout");
-    redirect("/profiel?_cacheBust=1");
+    const user = await getUserOrThrow();
+
+    redirect(getProfileRedirectPath(user.persons));
   });

--- a/apps/web/src/lib/profile-redirect.test.tsx
+++ b/apps/web/src/lib/profile-redirect.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { getProfileRedirectPath } from "./profile-redirect";
+
+describe("getProfileRedirectPath", () => {
+  it("redirects to the primary person's profile", () => {
+    expect(
+      getProfileRedirectPath([
+        { handle: "secondary-person", isPrimary: false },
+        { handle: "primary-person", isPrimary: true },
+      ]),
+    ).toBe("/profiel/primary-person");
+  });
+
+  it("redirects to account setup when no primary person exists", () => {
+    expect(
+      getProfileRedirectPath([
+        { handle: "person-without-primary-status", isPrimary: false },
+      ]),
+    ).toBe("/account");
+  });
+});

--- a/apps/web/src/lib/profile-redirect.ts
+++ b/apps/web/src/lib/profile-redirect.ts
@@ -1,0 +1,12 @@
+type ProfilePerson = {
+  handle: string;
+  isPrimary: boolean;
+};
+
+export function getProfileRedirectPath(
+  persons: readonly ProfilePerson[],
+): `/profiel/${string}` | "/account" {
+  const primaryPerson = persons.find((person) => person.isPrimary);
+
+  return primaryPerson ? `/profiel/${primaryPerson.handle}` : "/account";
+}


### PR DESCRIPTION
## What changed

- Scope the existing-session guard to `/login` so it is not rendered while `/login/code` verifies an OTP.
- Remove the layout-wide `revalidatePath` from OTP verification.
- Resolve the user's final account/profile destination inside the action and perform one redirect.
- Reuse the same destination helper from the `/profiel` compatibility route.
- Add regression coverage for redirect ownership and profile destination selection.

## Root cause

OTP verification updates the Supabase auth cookies. Next.js then rerenders the active auth layout, where `SessionCheck` detected the new session and issued a redirect while `verifyAction` was simultaneously revalidating the layout and issuing its own redirect. The intermediate `/profiel` route added another redirect.

Those competing redirects could leave the Server Action fetch with a non-RSC response, producing `An unexpected response was received from the server.` even though navigation often completed successfully.

PostHog issue: https://eu.posthog.com/project/18411/error_tracking/019db683-b009-7bd3-a8ff-c35d57a71402

## Impact

OTP verification now has a single navigation owner and redirects directly to `/account` or the user's primary profile. Existing authenticated users are still redirected away from the `/login` entry page.

## Validation

- `pnpm exec biome check ...` — passed
- Focused ESLint on all changed files — passed
- Focused Vitest suites — 4/4 tests passed
- Full component suite — 70/72 tests passed; two unrelated existing sticky-scroll assertions failed
- Repository-wide type generation is blocked locally because the Next/PostHog config requires a PostHog `projectId`; direct `tsc` then lacks generated static-image declarations

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/buchungapp/codesmith/nationaal-watersportdiploma/pr/489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786805722&installation_id=137554715&pr_number=489&repository=buchungapp%2Fnationaal-watersportdiploma&return_to=https%3A%2F%2Fgithub.com%2Fbuchungapp%2Fnationaal-watersportdiploma%2Fpull%2F489&signature=635fde5a7b93ddbab59c4e3098c4d3f7c8cbc34849c9cc5ccbe533b520074c37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved login routing by checking existing sessions at the login entry point.
  * Redirected verified users to their primary profile, or to account setup when no profile exists.

* **Bug Fixes**
  * Prevented session-check behavior from affecting the OTP verification screen.

* **Tests**
  * Added coverage for login session handling and profile redirect scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->