### PR TITLE
Fix external certificate metadata rendering

### DIFF
--- a/apps/web/src/app/(dashboard)/_components/nwd/certificates.tsx
+++ b/apps/web/src/app/(dashboard)/_components/nwd/certificates.tsx
@@ -10,6 +10,7 @@ import {
   DescriptionTerm,
 } from "../description-list";
 import { GridList, GridListHeader, GridListItem } from "../grid-list";
+import { displayableExternalCertificateMetadata } from "./external-certificate-metadata";
 
 export async function NWDCertificates({
   personId,
@@ -85,9 +86,9 @@ export async function ExternalCertificates({
   return (
     <GridList>
       {certificates.map((certificate) => {
-        const metadataEntries = certificate.metadata
-          ? Object.entries(certificate.metadata)
-          : [];
+        const metadataEntries = displayableExternalCertificateMetadata(
+          certificate.metadata,
+        );
 
         return (
           <GridListItem key={certificate.id}>

--- a/apps/web/src/app/(dashboard)/_components/nwd/external-certificate-metadata.test.tsx
+++ b/apps/web/src/app/(dashboard)/_components/nwd/external-certificate-metadata.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { displayableExternalCertificateMetadata } from "./external-certificate-metadata";
+
+describe("displayableExternalCertificateMetadata", () => {
+  it("keeps public scalar values", () => {
+    expect(
+      displayableExternalCertificateMetadata({
+        discipline: "Kielboot",
+        level: 3,
+        current: true,
+      }),
+    ).toEqual([
+      ["discipline", "Kielboot"],
+      ["level", "3"],
+      ["current", "true"],
+    ]);
+  });
+
+  it("hides internal and structured provenance metadata", () => {
+    expect(
+      displayableExternalCertificateMetadata({
+        discipline: "Kielboot",
+        __verified: true,
+        legacyCwo: {
+          importKey: "private-import-key",
+          rowHashes: ["private-row-hash"],
+        },
+        tags: ["legacy"],
+        empty: null,
+      }),
+    ).toEqual([["discipline", "Kielboot"]]);
+  });
+
+  it("handles missing metadata", () => {
+    expect(displayableExternalCertificateMetadata(null)).toEqual([]);
+    expect(displayableExternalCertificateMetadata(undefined)).toEqual([]);
+  });
+});

--- a/apps/web/src/app/(dashboard)/_components/nwd/external-certificate-metadata.test.tsx
+++ b/apps/web/src/app/(dashboard)/_components/nwd/external-certificate-metadata.test.tsx
@@ -31,6 +31,12 @@ describe("displayableExternalCertificateMetadata", () => {
     ).toEqual([["discipline", "Kielboot"]]);
   });
 
+  it("hides the legacy CWO key even when its value is scalar", () => {
+    expect(
+      displayableExternalCertificateMetadata({ legacyCwo: "private" }),
+    ).toEqual([]);
+  });
+
   it("handles missing metadata", () => {
     expect(displayableExternalCertificateMetadata(null)).toEqual([]);
     expect(displayableExternalCertificateMetadata(undefined)).toEqual([]);

--- a/apps/web/src/app/(dashboard)/_components/nwd/external-certificate-metadata.ts
+++ b/apps/web/src/app/(dashboard)/_components/nwd/external-certificate-metadata.ts
@@ -1,0 +1,20 @@
+const INTERNAL_METADATA_KEYS = new Set(["legacyCwo"]);
+
+export function displayableExternalCertificateMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+): Array<[key: string, value: string]> {
+  if (!metadata) return [];
+
+  return Object.entries(metadata).flatMap(([key, value]) => {
+    if (key.startsWith("__") || INTERNAL_METADATA_KEYS.has(key)) return [];
+    if (
+      typeof value !== "string" &&
+      typeof value !== "number" &&
+      typeof value !== "boolean"
+    ) {
+      return [];
+    }
+
+    return [[key, String(value)]];
+  });
+}


### PR DESCRIPTION
## What changed

- Filter external-certificate metadata before rendering it.
- Keep public scalar metadata values visible.
- Hide internal keys such as `legacyCwo` and `__verified`.
- Ignore nested objects, arrays, and null values so they can never be passed directly to React.
- Add regression coverage for the structured legacy CWO provenance shape.

## Why

The location person page rendered every metadata value directly as a React child. Legacy CWO imports store structured provenance under `_metadata.legacyCwo`, so affected person pages crashed with minified React error #31.

The provenance remains intact in PostgreSQL; this is only a presentation-layer fix.

## Impact

Person pages containing newly imported legacy CWO external certificates render again without exposing internal import hashes or plan metadata.

## Validation

- Targeted Vitest regression suite: 3/3 passed.
- Biome check passed for all changed files.
- Targeted ESLint passed for all changed files.
- Repository-wide web typecheck remains blocked by pre-existing missing image assets unrelated to this diff.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/buchungapp/codesmith/nationaal-watersportdiploma/pr/491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786894627&installation_id=137554715&pr_number=491&repository=buchungapp%2Fnationaal-watersportdiploma&return_to=https%3A%2F%2Fgithub.com%2Fbuchungapp%2Fnationaal-watersportdiploma%2Fpull%2F491&signature=ee2a2123e847a3bb47f5ebb123dc9e3cdc1dc7b3539c7e1f85c178f1c78b0621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved external certificate metadata display by showing only relevant, readable values.
  * Removed internal, structured, empty, and unsupported metadata from the certificate details view.
  * Added safe handling when certificate metadata is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->