### PR TITLE
fix(diplomas): cohort-style partial issuance in Diploma toevoegen dialog

### DIFF
--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_actions/fetch.ts
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_actions/fetch.ts
@@ -1,8 +1,7 @@
 "use server";
 
 import {
-  listCompletedCompetenciesByStudentCurriculumId,
-  listCurriculaByPersonId,
+  getStudentCurriculumProgressForLocation,
   listCurriculaByProgram,
   listGearTypesByCurriculumForLocation,
 } from "~/lib/nwd";
@@ -19,30 +18,15 @@ export async function getGearTypesByCurriculumForLocation(
 }
 
 export async function getExistingStudentCurriculumProgress(
+  locationId: string,
   personId: string,
   curriculumId: string,
   gearTypeId: string,
-): Promise<{
-  studentCurriculumId: string;
-  completedCompetencyIds: string[];
-} | null> {
-  const curricula = await listCurriculaByPersonId(personId);
-
-  const match = curricula.find(
-    (row) =>
-      row.curriculum.id === curriculumId && row.gearType.id === gearTypeId,
+) {
+  return await getStudentCurriculumProgressForLocation(
+    locationId,
+    personId,
+    curriculumId,
+    gearTypeId,
   );
-
-  if (!match) {
-    return null;
-  }
-
-  const completed = await listCompletedCompetenciesByStudentCurriculumId(
-    match.id,
-  );
-
-  return {
-    studentCurriculumId: match.id,
-    completedCompetencyIds: completed.map((row) => row.competencyId),
-  };
 }

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_actions/fetch.ts
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_actions/fetch.ts
@@ -1,6 +1,8 @@
 "use server";
 
 import {
+  listCompletedCompetenciesByStudentCurriculumId,
+  listCurriculaByPersonId,
   listCurriculaByProgram,
   listGearTypesByCurriculumForLocation,
 } from "~/lib/nwd";
@@ -14,4 +16,33 @@ export async function getGearTypesByCurriculumForLocation(
   curriculumId: string,
 ) {
   return await listGearTypesByCurriculumForLocation(locationId, curriculumId);
+}
+
+export async function getExistingStudentCurriculumProgress(
+  personId: string,
+  curriculumId: string,
+  gearTypeId: string,
+): Promise<{
+  studentCurriculumId: string;
+  completedCompetencyIds: string[];
+} | null> {
+  const curricula = await listCurriculaByPersonId(personId);
+
+  const match = curricula.find(
+    (row) =>
+      row.curriculum.id === curriculumId && row.gearType.id === gearTypeId,
+  );
+
+  if (!match) {
+    return null;
+  }
+
+  const completed = await listCompletedCompetenciesByStudentCurriculumId(
+    match.id,
+  );
+
+  return {
+    studentCurriculumId: match.id,
+    completedCompetencyIds: completed.map((row) => row.competencyId),
+  };
 }

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_components/create-dialog-client.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_components/create-dialog-client.tsx
@@ -181,7 +181,12 @@ function CreateDialogClient({
     let cancelled = false;
     setIsProgressLoading(true);
 
-    getExistingStudentCurriculumProgress(personId, curriculumId, gearTypeId)
+    getExistingStudentCurriculumProgress(
+      locationId,
+      personId,
+      curriculumId,
+      gearTypeId,
+    )
       .then((progress) => {
         if (cancelled) return;
         setCompletedCompetencyIds(progress?.completedCompetencyIds ?? []);
@@ -198,7 +203,12 @@ function CreateDialogClient({
     return () => {
       cancelled = true;
     };
-  }, [selectedPerson?.id, selectedCurriculum?.id, selectedGearType]);
+  }, [
+    locationId,
+    selectedPerson?.id,
+    selectedCurriculum?.id,
+    selectedGearType,
+  ]);
 
   if (!searchedStudents)
     throw new Error("Person list data must be available through fallback");
@@ -372,88 +382,28 @@ function CreateDialogClient({
                         {selectedCurriculum.modules
                           .sort((a, b) => a.weight - b.weight)
                           .filter((module) => module.isRequired)
-                          .map((module) => {
-                            const competencyIds = module.competencies.map(
-                              (c) => c.id,
-                            );
-                            const provenCount = competencyIds.filter((id) =>
-                              provenSet.has(id),
-                            ).length;
-                            const isFullyProven =
-                              competencyIds.length > 0 &&
-                              provenCount === competencyIds.length;
-                            const isPartiallyProven =
-                              provenCount > 0 &&
-                              provenCount < competencyIds.length;
-
-                            return (
-                              <CheckboxField
-                                key={`${module.id}-${
-                                  isFullyProven ? "proven" : "open"
-                                }`}
-                              >
-                                <Checkbox
-                                  name="competencies"
-                                  value={competencyIds.join(",")}
-                                  defaultChecked={true}
-                                  disabled={isFullyProven}
-                                />
-                                <Label>{module.title}</Label>
-                                {isFullyProven ? (
-                                  <Description>Al behaald</Description>
-                                ) : isPartiallyProven ? (
-                                  <Description>
-                                    {provenCount} van {competencyIds.length}{" "}
-                                    competenties al behaald
-                                  </Description>
-                                ) : null}
-                              </CheckboxField>
-                            );
-                          })}
+                          .map((module) => (
+                            <ModuleCheckboxField
+                              key={module.id}
+                              module={module}
+                              provenSet={provenSet}
+                              defaultCheckedWhenOpen={true}
+                            />
+                          ))}
                       </CheckboxGroup>
                       <CheckboxGroup>
                         <Legend>Keuzemodules</Legend>
                         {selectedCurriculum.modules
                           .sort((a, b) => a.weight - b.weight)
                           .filter((module) => !module.isRequired)
-                          .map((module) => {
-                            const competencyIds = module.competencies.map(
-                              (c) => c.id,
-                            );
-                            const provenCount = competencyIds.filter((id) =>
-                              provenSet.has(id),
-                            ).length;
-                            const isFullyProven =
-                              competencyIds.length > 0 &&
-                              provenCount === competencyIds.length;
-                            const isPartiallyProven =
-                              provenCount > 0 &&
-                              provenCount < competencyIds.length;
-
-                            return (
-                              <CheckboxField
-                                key={`${module.id}-${
-                                  isFullyProven ? "proven" : "open"
-                                }`}
-                              >
-                                <Checkbox
-                                  name="competencies"
-                                  value={competencyIds.join(",")}
-                                  defaultChecked={isFullyProven}
-                                  disabled={isFullyProven}
-                                />
-                                <Label>{module.title}</Label>
-                                {isFullyProven ? (
-                                  <Description>Al behaald</Description>
-                                ) : isPartiallyProven ? (
-                                  <Description>
-                                    {provenCount} van {competencyIds.length}{" "}
-                                    competenties al behaald
-                                  </Description>
-                                ) : null}
-                              </CheckboxField>
-                            );
-                          })}
+                          .map((module) => (
+                            <ModuleCheckboxField
+                              key={module.id}
+                              module={module}
+                              provenSet={provenSet}
+                              defaultCheckedWhenOpen={false}
+                            />
+                          ))}
                       </CheckboxGroup>
                     </div>
                   ) : (
@@ -479,6 +429,46 @@ function CreateDialogClient({
         </form>
       </Dialog>
     </>
+  );
+}
+
+function ModuleCheckboxField({
+  module,
+  provenSet,
+  defaultCheckedWhenOpen,
+}: {
+  module: Awaited<
+    ReturnType<typeof listCurriculaByProgram>
+  >[number]["modules"][number];
+  provenSet: Set<string>;
+  defaultCheckedWhenOpen: boolean;
+}) {
+  const competencyIds = module.competencies.map((c) => c.id);
+  const provenCount = competencyIds.filter((id) => provenSet.has(id)).length;
+  const isFullyProven =
+    competencyIds.length > 0 && provenCount === competencyIds.length;
+  const isPartiallyProven =
+    provenCount > 0 && provenCount < competencyIds.length;
+
+  return (
+    // The proven-state key remounts the uncontrolled checkbox when the
+    // async progress fetch flips its defaultChecked/disabled state.
+    <CheckboxField key={`${module.id}-${isFullyProven ? "proven" : "open"}`}>
+      <Checkbox
+        name="competencies"
+        value={competencyIds.join(",")}
+        defaultChecked={isFullyProven || defaultCheckedWhenOpen}
+        disabled={isFullyProven}
+      />
+      <Label>{module.title}</Label>
+      {isFullyProven ? (
+        <Description>Al behaald</Description>
+      ) : isPartiallyProven ? (
+        <Description>
+          {provenCount} van {competencyIds.length} competenties al behaald
+        </Description>
+      ) : null}
+    </CheckboxField>
   );
 }
 

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_components/create-dialog-client.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_components/create-dialog-client.tsx
@@ -28,6 +28,7 @@ import {
   DialogTitle,
 } from "~/app/(dashboard)/_components/dialog";
 import {
+  Description,
   Field,
   FieldGroup,
   Fieldset,
@@ -49,6 +50,7 @@ import type {
 } from "~/lib/nwd";
 import {
   getCurriculaByProgram,
+  getExistingStudentCurriculumProgress,
   getGearTypesByCurriculumForLocation,
 } from "../_actions/fetch";
 
@@ -92,8 +94,8 @@ function CreateDialogClient({
         toast.success("Diploma toegevoegd");
         closeDialog();
       },
-      onError: () => {
-        toast.error(DEFAULT_SERVER_ERROR_MESSAGE);
+      onError: ({ error }) => {
+        toast.error(error.serverError ?? DEFAULT_SERVER_ERROR_MESSAGE);
       },
     },
   );
@@ -103,9 +105,8 @@ function CreateDialogClient({
   const [selectedProgram, setSelectedProgram] = useState<
     NonNullable<typeof programs>[number] | null
   >(
-    programs?.find(
-      (program) => program.id === getInputValue("curriculum")?.id,
-    ) ?? null,
+    programs?.find((program) => program.id === getInputValue("program")?.id) ??
+      null,
   );
   const [selectedGearType, setSelectedGearType] = useState<string | null>(
     getInputValue("gearType")?.id ?? null,
@@ -124,9 +125,18 @@ function CreateDialogClient({
       },
     });
 
+  const [selectedPerson, setSelectedPerson] = useState<
+    NonNullable<typeof searchedStudents>["items"][number] | null
+  >(null);
+
   const [gearTypes, setGearTypes] = useState<
     Awaited<ReturnType<typeof listGearTypesByCurriculumForLocation>>
   >([]);
+
+  const [completedCompetencyIds, setCompletedCompetencyIds] = useState<
+    string[]
+  >([]);
+  const [isProgressLoading, setIsProgressLoading] = useState(false);
 
   // @TODO why are we using an effect for this?
   useEffect(() => {
@@ -154,8 +164,57 @@ function CreateDialogClient({
     void fetchCurricula();
   }, [selectedProgram, locationId]);
 
+  // Fetch the cursist's already-proven competencies for the selected
+  // programma + vaartuig so the dialog can render proven modules as
+  // "Al behaald" and let the server issue a partial diploma over the delta.
+  useEffect(() => {
+    const personId = selectedPerson?.id;
+    const curriculumId = selectedCurriculum?.id;
+    const gearTypeId = selectedGearType;
+
+    if (!personId || !curriculumId || !gearTypeId) {
+      setCompletedCompetencyIds([]);
+      setIsProgressLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsProgressLoading(true);
+
+    getExistingStudentCurriculumProgress(personId, curriculumId, gearTypeId)
+      .then((progress) => {
+        if (cancelled) return;
+        setCompletedCompetencyIds(progress?.completedCompetencyIds ?? []);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setCompletedCompetencyIds([]);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setIsProgressLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedPerson?.id, selectedCurriculum?.id, selectedGearType]);
+
   if (!searchedStudents)
     throw new Error("Person list data must be available through fallback");
+
+  const provenSet = new Set(completedCompetencyIds);
+
+  const allModulesFullyProven =
+    !!selectedCurriculum &&
+    selectedCurriculum.modules.length > 0 &&
+    selectedCurriculum.modules.every((module) => {
+      const competencyIds = module.competencies.map((c) => c.id);
+      return (
+        competencyIds.length > 0 &&
+        competencyIds.every((id) => provenSet.has(id))
+      );
+    });
 
   return (
     <>
@@ -184,6 +243,7 @@ function CreateDialogClient({
                       name="person"
                       options={searchedStudents.items}
                       autoFocus={true}
+                      onChange={setSelectedPerson}
                       displayValue={(person) => {
                         if (!person) return "";
                         const fullName = [
@@ -258,7 +318,7 @@ function CreateDialogClient({
                       defaultValue={
                         programs?.find(
                           (program) =>
-                            program.id === getInputValue("curriculum")?.id,
+                            program.id === getInputValue("program")?.id,
                         ) ?? null
                       }
                       invalid={!!result?.validationErrors?.curriculum}
@@ -312,36 +372,88 @@ function CreateDialogClient({
                         {selectedCurriculum.modules
                           .sort((a, b) => a.weight - b.weight)
                           .filter((module) => module.isRequired)
-                          .map((module) => (
-                            <CheckboxField key={module.id}>
-                              <Checkbox
-                                name="competencies"
-                                value={module.competencies
-                                  .map((c) => c.id)
-                                  .join(",")}
-                                defaultChecked={true}
-                              />
-                              <Label>{module.title}</Label>
-                            </CheckboxField>
-                          ))}
+                          .map((module) => {
+                            const competencyIds = module.competencies.map(
+                              (c) => c.id,
+                            );
+                            const provenCount = competencyIds.filter((id) =>
+                              provenSet.has(id),
+                            ).length;
+                            const isFullyProven =
+                              competencyIds.length > 0 &&
+                              provenCount === competencyIds.length;
+                            const isPartiallyProven =
+                              provenCount > 0 &&
+                              provenCount < competencyIds.length;
+
+                            return (
+                              <CheckboxField
+                                key={`${module.id}-${
+                                  isFullyProven ? "proven" : "open"
+                                }`}
+                              >
+                                <Checkbox
+                                  name="competencies"
+                                  value={competencyIds.join(",")}
+                                  defaultChecked={true}
+                                  disabled={isFullyProven}
+                                />
+                                <Label>{module.title}</Label>
+                                {isFullyProven ? (
+                                  <Description>Al behaald</Description>
+                                ) : isPartiallyProven ? (
+                                  <Description>
+                                    {provenCount} van {competencyIds.length}{" "}
+                                    competenties al behaald
+                                  </Description>
+                                ) : null}
+                              </CheckboxField>
+                            );
+                          })}
                       </CheckboxGroup>
                       <CheckboxGroup>
                         <Legend>Keuzemodules</Legend>
                         {selectedCurriculum.modules
                           .sort((a, b) => a.weight - b.weight)
                           .filter((module) => !module.isRequired)
-                          .map((module) => (
-                            <CheckboxField key={module.id}>
-                              <Checkbox
-                                name="competencies"
-                                value={module.competencies
-                                  .map((c) => c.id)
-                                  .join(",")}
-                                defaultChecked={false}
-                              />
-                              <Label>{module.title}</Label>
-                            </CheckboxField>
-                          ))}
+                          .map((module) => {
+                            const competencyIds = module.competencies.map(
+                              (c) => c.id,
+                            );
+                            const provenCount = competencyIds.filter((id) =>
+                              provenSet.has(id),
+                            ).length;
+                            const isFullyProven =
+                              competencyIds.length > 0 &&
+                              provenCount === competencyIds.length;
+                            const isPartiallyProven =
+                              provenCount > 0 &&
+                              provenCount < competencyIds.length;
+
+                            return (
+                              <CheckboxField
+                                key={`${module.id}-${
+                                  isFullyProven ? "proven" : "open"
+                                }`}
+                              >
+                                <Checkbox
+                                  name="competencies"
+                                  value={competencyIds.join(",")}
+                                  defaultChecked={isFullyProven}
+                                  disabled={isFullyProven}
+                                />
+                                <Label>{module.title}</Label>
+                                {isFullyProven ? (
+                                  <Description>Al behaald</Description>
+                                ) : isPartiallyProven ? (
+                                  <Description>
+                                    {provenCount} van {competencyIds.length}{" "}
+                                    competenties al behaald
+                                  </Description>
+                                ) : null}
+                              </CheckboxField>
+                            );
+                          })}
                       </CheckboxGroup>
                     </div>
                   ) : (
@@ -352,10 +464,17 @@ function CreateDialogClient({
             </Fieldset>
           </DialogBody>
           <DialogActions>
+            {allModulesFullyProven ? (
+              <Text className="mr-auto text-left">
+                Deze cursist heeft dit diploma al volledig behaald.
+              </Text>
+            ) : null}
             <Button plain onClick={closeDialog}>
               Sluiten
             </Button>
-            <SubmitButton />
+            <SubmitButton
+              disabled={isProgressLoading || allModulesFullyProven}
+            />
           </DialogActions>
         </form>
       </Dialog>
@@ -363,10 +482,10 @@ function CreateDialogClient({
   );
 }
 
-function SubmitButton() {
+function SubmitButton({ disabled }: { disabled?: boolean }) {
   const { pending } = useFormStatus();
   return (
-    <Button color="branding-dark" disabled={pending} type="submit">
+    <Button color="branding-dark" disabled={pending || disabled} type="submit">
       {pending ? <Spinner className="text-white" /> : null}
       Opslaan
     </Button>

--- a/apps/web/src/lib/nwd.ts
+++ b/apps/web/src/lib/nwd.ts
@@ -1407,6 +1407,47 @@ export const createPersonForLocation = async (
   });
 };
 
+export const getStudentCurriculumProgressForLocation = async (
+  locationId: string,
+  personId: string,
+  curriculumId: string,
+  gearTypeId: string,
+): Promise<{
+  studentCurriculumId: string;
+  completedCompetencyIds: string[];
+} | null> => {
+  return makeRequest(async () => {
+    const authUser = await getUserOrThrow();
+    const primaryPerson = await getPrimaryPerson(authUser);
+
+    await isActiveActorTypeInLocation({
+      actorType: ["location_admin"],
+      locationId,
+      personId: primaryPerson.id,
+    });
+
+    const curricula = await Student.Curriculum.listByPersonId({ personId });
+
+    const match = curricula.find(
+      (row) =>
+        row.curriculum.id === curriculumId && row.gearType.id === gearTypeId,
+    );
+
+    if (!match) {
+      return null;
+    }
+
+    const completed = await Student.Curriculum.listCompletedCompetenciesById({
+      id: match.id,
+    });
+
+    return {
+      studentCurriculumId: match.id,
+      completedCompetencyIds: completed.map((row) => row.competencyId),
+    };
+  });
+};
+
 export const createCompletedCertificate = async (
   locationId: string,
   personId: string,
@@ -1458,9 +1499,9 @@ export const createCompletedCertificate = async (
       const alreadyProvenIds = new Set(
         alreadyProven.map((row) => row.competencyId),
       );
-      const newCompetencyIds = competencies
-        .flat()
-        .filter((id) => !alreadyProvenIds.has(id));
+      const newCompetencyIds = [...new Set(competencies.flat())].filter(
+        (id) => !alreadyProvenIds.has(id),
+      );
 
       if (newCompetencyIds.length === 0) {
         // The dialog's pre-flight fetch should keep operators from

--- a/apps/web/src/lib/nwd.ts
+++ b/apps/web/src/lib/nwd.ts
@@ -1431,12 +1431,47 @@ export const createCompletedCertificate = async (
         personId: primaryPerson.id,
       });
 
-      // Start student curriculum
-      const { id: studentCurriculumId } = await Student.Curriculum.start({
-        curriculumId,
-        personId,
-        gearTypeId,
-      });
+      // Find or enroll the student curriculum. A blind insert would
+      // violate the partial unique index
+      // student_curriculum_unq_identity_gear_curriculum when the cursist
+      // already has a live enrolment for this (person, curriculum, gear).
+      const { id: studentCurriculumId } = await Student.Curriculum.findOrEnroll(
+        {
+          curriculumId,
+          personId,
+          gearTypeId,
+        },
+      );
+
+      // Subtract competencies the student has already proven via an
+      // earlier issued certificate on this curriculum. Re-recording them
+      // would violate the partial unique index
+      // student_completed_competency_unq_active_non_merge — the database
+      // guarantees one canonical record per (studentCurriculum,
+      // competency). This lets us issue a *partial* diploma covering only
+      // what's new, matching the competentiegericht-opleiden model (same
+      // pattern as issueCertificatesInCohort).
+      const alreadyProven =
+        await Student.Curriculum.listCompletedCompetenciesById({
+          id: studentCurriculumId,
+        });
+      const alreadyProvenIds = new Set(
+        alreadyProven.map((row) => row.competencyId),
+      );
+      const newCompetencyIds = competencies
+        .flat()
+        .filter((id) => !alreadyProvenIds.has(id));
+
+      if (newCompetencyIds.length === 0) {
+        // The dialog's pre-flight fetch should keep operators from
+        // landing here, but if a race lets it through, fail with a
+        // recognizable name and message the UI can surface directly.
+        const err = new Error(
+          "Deze cursist heeft deze modules al behaald op een eerder diploma.",
+        );
+        err.name = "DiplomaIssuanceBlockedError";
+        throw err;
+      }
 
       // Start certificate
       const { id: certificateId } = await Student.Certificate.startCertificate({
@@ -1448,7 +1483,7 @@ export const createCompletedCertificate = async (
       await Student.Certificate.completeCompetency({
         certificateId,
         studentCurriculumId,
-        competencyId: competencies.flat(),
+        competencyId: newCompetencyIds,
       });
 
       // Complete certificate

--- a/apps/web/src/lib/nwd.ts
+++ b/apps/web/src/lib/nwd.ts
@@ -1426,6 +1426,14 @@ export const getStudentCurriculumProgressForLocation = async (
       personId: primaryPerson.id,
     });
 
+    // The caller check above scopes the admin; this scopes the target,
+    // so an admin can't probe progress of persons outside their location.
+    await isActiveActorTypeInLocation({
+      actorType: ["student"],
+      locationId,
+      personId,
+    });
+
     const curricula = await Student.Curriculum.listByPersonId({ personId });
 
     const match = curricula.find(


### PR DESCRIPTION
## Problem

On July 20 a location admin hit "Er is iets misgegaan. Probeer het later opnieuw." four times in a row in the **Diploma toevoegen** dialog. Root cause (via PostHog `action-executed` events + Vercel runtime logs): `createCompletedCertificate` did a blind `Student.Curriculum.start` insert, violating the partial unique index `student_curriculum_unq_identity_gear_curriculum` because the cursist already had a live enrolment for that programma + vaartuig. The real error was swallowed and the generic toast gave the operator nothing to act on.

## Solution

Align the dialog with the cohort issuance model, which already handles this correctly (`issueCertificatesInCohort` + `findOrEnroll` + the delta-subtraction pattern):

- **Server** (`createCompletedCertificate` in `nwd.ts`): `findOrEnroll` instead of `start`; subtract competencies already proven on earlier certificates (`listCompletedCompetenciesById`); throw a named `DiplomaIssuanceBlockedError` ("Deze cursist heeft deze modules al behaald op een eerder diploma.") when the delta is empty; issue the certificate over the delta only. A double-submit race is still caught by `student_completed_competency_unq_active_non_merge` and rolls back.
- **Dialog UI**: once cursist + programma + vaartuig are selected, fetch existing progress (new `getExistingStudentCurriculumProgress` fetch action, built from existing nwd exports). Fully-proven modules render checked + disabled with "Al behaald"; partially-proven modules show "x van y competenties al behaald"; submit is disabled while the fetch is in flight and when the diploma is already fully achieved ("Deze cursist heeft dit diploma al volledig behaald.").
- **Error surfacing**: the toast now shows the real `serverError` message instead of always the generic one, and the Programma field no longer blanks after a failed submit (the restore matched a program id against a curriculum id).

## Verification

- Biome clean on all three changed files.
- `tsc --noEmit` clean for the changed code.
- Traced the three module states (fully proven / partially proven / not started) and the blocked-submit state: disabled checkboxes are omitted from FormData by design; the server delta-filter compensates for partially-proven modules. Submitting with nothing new selected is now blocked server-side — previously that path could create an empty diploma.

Out of scope (deliberate): warnings about certificates on older curriculum revisions (matches current cohort semantics), and PostHog exception capture for server actions (separate observability gap: next-safe-action swallows errors before `onRequestError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/buchungapp/codesmith/nationaal-watersportdiploma/pr/492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787132061&installation_id=137554715&pr_number=492&repository=buchungapp%2Fnationaal-watersportdiploma&return_to=https%3A%2F%2Fgithub.com%2Fbuchungapp%2Fnationaal-watersportdiploma%2Fpull%2F492&signature=219ceb19ed641d4e0a64da96e7e399b299515faef5e656f4504ca4e4a6bd56d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diploma creation now uses a student’s existing curriculum progress to issue partial diplomas.
  * Modules show proven competency counts; fully proven modules are marked “Al behaald” and can’t be re-selected.
  * Submission includes a notice when all modules are already fully proven.

* **Bug Fixes**
  * Prevents duplicate enrollments/awards by reusing the student’s existing curriculum record.
  * Blocks diploma issuance when no new competencies are available.
  * Disables submission while progress is loading, and improves displayed errors when issuance is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->