### PR TITLE
feat(diplomas): withdraw certificates from the diplomas page

### DIFF
--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_components/table-actions.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_components/table-actions.tsx
@@ -5,11 +5,15 @@ import {
   DisclosurePanel as HeadlessDisclosurePanel,
 } from "@headlessui/react";
 import { ChevronRightIcon } from "@heroicons/react/16/solid";
-import { useAction } from "next-safe-action/hooks";
+import {
+  type InferUseActionHookReturn,
+  useAction,
+} from "next-safe-action/hooks";
 import { useState } from "react";
 import { useFormStatus } from "react-dom";
 import { toast } from "sonner";
 import { downloadCertificatesAction } from "~/app/_actions/certificate/download-certificates-action";
+import { withdrawCertificatesAtLocationAction } from "~/app/_actions/certificate/withdraw-certificates-at-location-action";
 import { useFormInput } from "~/app/_actions/hooks/useFormInput";
 import { DEFAULT_SERVER_ERROR_MESSAGE } from "~/app/_actions/utils";
 import Spinner from "~/app/_components/spinner";
@@ -31,6 +35,7 @@ import {
 } from "~/app/(dashboard)/_components/dropdown";
 import {
   Description,
+  ErrorMessage,
   Field,
   Fieldset,
   Label,
@@ -52,6 +57,7 @@ type Certificate = Awaited<ReturnType<typeof listCertificates>>[number];
 
 interface Props {
   rows: Certificate[];
+  locationId: string;
   resetSelection: () => void;
 }
 
@@ -211,6 +217,75 @@ function DownloadSubmitButton() {
   );
 }
 
+function withdrawCertificatesAtLocationErrorMessage(
+  error: InferUseActionHookReturn<
+    typeof withdrawCertificatesAtLocationAction
+  >["result"],
+) {
+  if (error.serverError) {
+    return "Er is een fout opgetreden, mogelijk is het diploma meer dan 72 uur geleden uitgegeven. Neem in dat geval contact op met het Secretariaat.";
+  }
+
+  if (error.validationErrors) {
+    return "Een van de velden is niet correct ingevuld.";
+  }
+
+  return null;
+}
+
+function RemoveCertificatesDialog({
+  rows,
+  isOpen,
+  locationId,
+  close,
+  resetSelection,
+}: Props & {
+  isOpen: boolean;
+  close: () => void;
+}) {
+  const { execute, isPending, result } = useAction(
+    withdrawCertificatesAtLocationAction.bind(
+      null,
+      locationId,
+      rows.map((row) => row.id),
+    ),
+    {
+      onSuccess: () => {
+        close();
+        resetSelection();
+        toast.success("Diploma's verwijderd");
+      },
+    },
+  );
+
+  const errorMessage = withdrawCertificatesAtLocationErrorMessage(result);
+
+  return (
+    <Alert open={isOpen} onClose={close} size="md">
+      <AlertTitle>Diploma's verwijderen</AlertTitle>
+      <AlertDescription>
+        Tot 72 uur na het uitgeven van een diploma kan deze nog verwijderd
+        worden.{" "}
+        <strong>
+          Het verwijderen maakt het reeds uitgegeven diploma onbruikbaar!
+        </strong>{" "}
+        <br />
+        Weet je zeker dat je de diploma's wilt verwijderen?
+      </AlertDescription>
+      {errorMessage ? <ErrorMessage>{errorMessage}</ErrorMessage> : null}
+
+      <AlertActions>
+        <Button plain onClick={close}>
+          Annuleren
+        </Button>
+        <Button color="red" disabled={isPending} onClick={() => execute()}>
+          {isPending ? <Spinner className="text-white" /> : null} Verwijderen
+        </Button>
+      </AlertActions>
+    </Alert>
+  );
+}
+
 export function ActionButtons(props: Props) {
   const [isDialogOpen, setIsDialogOpen] = useState<string | null>(null);
 
@@ -220,11 +295,20 @@ export function ActionButtons(props: Props) {
         <DropdownItem onClick={() => setIsDialogOpen("download")}>
           <DropdownLabel>Diploma's downloaden</DropdownLabel>
         </DropdownItem>
+        <DropdownItem onClick={() => setIsDialogOpen("remove")}>
+          <DropdownLabel>Diploma's verwijderen</DropdownLabel>
+        </DropdownItem>
       </TableSelectionButton>
 
       <DownloadCertificatesDialog
         {...props}
         isOpen={isDialogOpen === "download"}
+        close={() => setIsDialogOpen(null)}
+      />
+
+      <RemoveCertificatesDialog
+        {...props}
+        isOpen={isDialogOpen === "remove"}
         close={() => setIsDialogOpen(null)}
       />
     </>

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_components/table-actions.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_components/table-actions.tsx
@@ -243,7 +243,7 @@ function RemoveCertificatesDialog({
   isOpen: boolean;
   close: () => void;
 }) {
-  const { execute, isPending, result } = useAction(
+  const { execute, isPending, result, reset } = useAction(
     withdrawCertificatesAtLocationAction.bind(
       null,
       locationId,
@@ -258,10 +258,15 @@ function RemoveCertificatesDialog({
     },
   );
 
+  const closeDialog = () => {
+    close();
+    reset();
+  };
+
   const errorMessage = withdrawCertificatesAtLocationErrorMessage(result);
 
   return (
-    <Alert open={isOpen} onClose={close} size="md">
+    <Alert open={isOpen} onClose={closeDialog} size="md">
       <AlertTitle>Diploma's verwijderen</AlertTitle>
       <AlertDescription>
         Tot 72 uur na het uitgeven van een diploma kan deze nog verwijderd
@@ -275,7 +280,7 @@ function RemoveCertificatesDialog({
       {errorMessage ? <ErrorMessage>{errorMessage}</ErrorMessage> : null}
 
       <AlertActions>
-        <Button plain onClick={close}>
+        <Button plain onClick={closeDialog}>
           Annuleren
         </Button>
         <Button color="red" disabled={isPending} onClick={() => execute()}>

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_components/table.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/_components/table.tsx
@@ -118,10 +118,12 @@ const columns = [
 export default function CertificateTable({
   certificates,
   totalItems,
+  locationId,
   placeholderRows,
 }: {
   certificates: Certificate[];
   totalItems: number;
+  locationId: string;
   placeholderRows?: number;
 }) {
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
@@ -188,6 +190,7 @@ export default function CertificateTable({
       >
         <ActionButtons
           rows={actionRows}
+          locationId={locationId}
           resetSelection={() => setRowSelection({})}
         />
       </TableSelection>

--- a/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/page.tsx
+++ b/apps/web/src/app/(dashboard)/(management)/locatie/[location]/diplomas/page.tsx
@@ -33,7 +33,11 @@ async function CertificatesTable(props: {
   });
 
   return (
-    <Table certificates={certificates.items} totalItems={certificates.count} />
+    <Table
+      certificates={certificates.items}
+      totalItems={certificates.count}
+      locationId={location.id}
+    />
   );
 }
 
@@ -57,7 +61,12 @@ export default function Page(props: {
 
       <Suspense
         fallback={
-          <Table placeholderRows={10} certificates={[]} totalItems={0} />
+          <Table
+            placeholderRows={10}
+            certificates={[]}
+            totalItems={0}
+            locationId=""
+          />
         }
       >
         <CertificatesTable

--- a/apps/web/src/app/_actions/certificate/withdraw-certificates-at-location-action.ts
+++ b/apps/web/src/app/_actions/certificate/withdraw-certificates-at-location-action.ts
@@ -1,0 +1,25 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { actionClientWithMeta } from "~/app/_actions/safe-action";
+import { withdrawCertificatesAtLocation } from "~/lib/nwd";
+
+const withdrawCertificatesAtLocationArgsSchema: [
+  locationId: z.ZodString,
+  certificateIds: z.ZodArray<z.ZodString>,
+] = [z.string().uuid(), z.array(z.string().uuid())];
+
+export const withdrawCertificatesAtLocationAction = actionClientWithMeta
+  .metadata({
+    name: "withdraw-certificates-at-location",
+  })
+  .bindArgsSchemas(withdrawCertificatesAtLocationArgsSchema)
+  .action(async ({ bindArgsParsedInputs: [locationId, certificateIds] }) => {
+    await withdrawCertificatesAtLocation({
+      locationId,
+      certificateIds,
+    });
+
+    revalidatePath("/locatie/[location]/diplomas", "page");
+  });

--- a/apps/web/src/lib/nwd.ts
+++ b/apps/web/src/lib/nwd.ts
@@ -1769,6 +1769,40 @@ export const withdrawCertificatesInCohort = async ({
   });
 };
 
+export const withdrawCertificatesAtLocation = async ({
+  locationId,
+  certificateIds,
+}: {
+  locationId: string;
+  certificateIds: string[];
+}) => {
+  return makeRequest(async () => {
+    return withTransaction(async () => {
+      const authUser = await getUserOrThrow();
+      const primaryPerson = await getPrimaryPerson(authUser);
+
+      await isActiveActorTypeInLocation({
+        actorType: ["location_admin"],
+        locationId,
+        personId: primaryPerson.id,
+      });
+
+      // Only withdraw certificates that belong to this location.
+      const { items } = await Certificate.list({
+        filter: { id: certificateIds, locationId },
+      });
+
+      if (items.length !== certificateIds.length) {
+        throw new Error("Certificate not found");
+      }
+
+      await Promise.all(certificateIds.map(Certificate.withdraw));
+
+      return;
+    });
+  });
+};
+
 export const listActiveCohortsForPerson = cache(
   async ({ personId }: { personId?: string } = {}) => {
     return makeRequest(async () => {


### PR DESCRIPTION
## Problem

The cohort diplomas view lets location admins delete an issued certificate up to 72 hours after issuance, but certificates created via the **Diploma toevoegen** flow on the location diplomas page (`/locatie/[location]/diplomas`) had no equivalent — the table's selection menu only offered downloading.

## Solution

Add a "Diploma's verwijderen" bulk action to the diplomas table, mirroring the cohort behavior exactly:

- **`withdrawCertificatesAtLocation`** (`nwd.ts`): guards the caller as `location_admin` at the location, verifies **every selected certificate belongs to that location** (a check the cohort variant lacks) via `Certificate.list({ filter: { id, locationId } })`, then delegates to core `Certificate.withdraw` per certificate. The 72-hour window stays enforced in core — the withdraw query only matches certificates created within the last 72 hours; it soft-deletes the certificate and hard-deletes its `student_completed_competency` rows, freeing those competencies for re-issuance (consistent with the partial-issuance model from #492).
- **New server action** `withdraw-certificates-at-location` (mirrors the cohort withdraw action), revalidating the diplomas page.
- **UI**: `RemoveCertificatesDialog` cloned from the cohort's dialog with identical Dutch copy — the "Tot 72 uur na het uitgeven…" warning, red Verwijderen button, and the same error mapping ("…mogelijk is het diploma meer dan 72 uur geleden uitgegeven. Neem in dat geval contact op met het Secretariaat."). Success shows a toast and clears the selection.
- `locationId` threaded from the page through the table into the actions; the Suspense placeholder passes an empty string, which is unreachable (zero rows → no selection UI).

## Verification

- Biome clean on all touched files; `tsc --noEmit` clean for the changed code.
- Core untouched: the 72-hour rule has a single source of truth in `Certificate.withdraw`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/buchungapp/codesmith/nationaal-watersportdiploma/pr/493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787137385&installation_id=137554715&pr_number=493&repository=buchungapp%2Fnationaal-watersportdiploma&return_to=https%3A%2F%2Fgithub.com%2Fbuchungapp%2Fnationaal-watersportdiploma%2Fpull%2F493&signature=4580b73f5f031421348887db305640c84c9a0c26a6c4afaba4a27710543196e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to remove multiple diplomas from a location, alongside the existing download workflow.
  * Included a confirmation dialog with clear Dutch validation/error messaging, and disabled the remove action while processing.
  * Show success notifications after removal and automatically refresh the diplomas list.
  * Added safeguards to ensure only diplomas belonging to the selected location can be removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->